### PR TITLE
Track game id for player

### DIFF
--- a/pallets/ajuna-gameregistry/src/lib.rs
+++ b/pallets/ajuna-gameregistry/src/lib.rs
@@ -131,7 +131,7 @@ pub mod pallet {
 		#[pallet::weight(10_000)]
 		pub fn queue(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			ensure!(Players::<T>::contains_key(who.clone()) == false, Error::<T>::AlreadyPlaying);
+			ensure!(!Players::<T>::contains_key(who.clone()), Error::<T>::AlreadyPlaying);
 			// Queue sender as player
 			ensure!(T::MatchMaker::enqueue(who, DEFAULT_BRACKET), Error::<T>::AlreadyQueued);
 			// Let's process a match, *may* not include this player based on the queue but we

--- a/pallets/ajuna-gameregistry/src/lib.rs
+++ b/pallets/ajuna-gameregistry/src/lib.rs
@@ -143,7 +143,7 @@ pub mod pallet {
 				let identifier = T::Runner::create::<T::GetIdentifier>(
 					Game::new(players.clone()).encode().into(),
 				)
-					.ok_or(Error::<T>::FailedToQueue)?;
+				.ok_or(Error::<T>::FailedToQueue)?;
 
 				// Players need to know which game they are in
 				players.iter().for_each(|player| {

--- a/pallets/ajuna-gameregistry/src/tests.rs
+++ b/pallets/ajuna-gameregistry/src/tests.rs
@@ -38,7 +38,10 @@ fn should_create_game() {
 		assert_eq!(Registry::queued(), None);
 		assert_ok!(Registry::queue(Origin::signed(BOB)));
 		assert_eq!(Registry::queued(), Some(vec![GLOBAL_IDENTIFIER]));
+		assert_noop!(Registry::queue(Origin::signed(ALICE)), Error::<Test>::AlreadyPlaying);
 		assert!(MockRunner::get_state(GLOBAL_IDENTIFIER).is_some());
+		assert_eq!(Registry::players(ALICE), Some(GLOBAL_IDENTIFIER));
+		assert_eq!(Registry::players(BOB), Some(GLOBAL_IDENTIFIER));
 	});
 }
 
@@ -97,5 +100,7 @@ fn should_finish_game() {
 			Some(RunnerState::Finished(game.encode().into())),
 			MockRunner::get_state(GLOBAL_IDENTIFIER)
 		);
+		assert_eq!(Registry::players(ALICE), None);
+		assert_eq!(Registry::players(BOB), None);
 	});
 }


### PR DESCRIPTION
## Description

In order for a player to know the game they are in we store a map of the player against the game id created

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features -- -D warnings`
- [x] Tested with `cargo test --workspace --all-features`
