### PR TITLE
[PLAT-276] Reinstate CheckNonZeroSender and asset payment for SignedExtra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
  "frame-benchmarking-cli",
  "frame-system",
  "log",
- "pallet-transaction-payment",
+ "pallet-asset-tx-payment",
  "parity-scale-codec",
  "polkadot-cli",
  "polkadot-parachain",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -20,18 +20,18 @@ ajuna-primitives = { path = "../../primitives" }
 ajuna-service    = { path = "../service", optional = true }
 
 # Substrate
-frame-benchmarking-cli     = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
-frame-system               = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
-sc-cli                     = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20", features = [ "wasmtime" ] }
-sc-client-api              = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
-sc-finality-grandpa        = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
-sc-service                 = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20", features = [ "wasmtime" ] }
-sp-core                    = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
-sp-inherents               = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
-sp-keyring                 = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
-sp-runtime                 = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
-sp-timestamp               = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
+frame-benchmarking-cli  = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
+frame-system            = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
+pallet-asset-tx-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
+sc-cli                  = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20", features = [ "wasmtime" ] }
+sc-client-api           = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
+sc-finality-grandpa     = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
+sc-service              = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20", features = [ "wasmtime" ] }
+sp-core                 = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
+sp-inherents            = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
+sp-keyring              = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
+sp-runtime              = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
+sp-timestamp            = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
 
 sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20", optional = true }
 sc-tracing   = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20", optional = true }

--- a/node/cli/src/command_helper.rs
+++ b/node/cli/src/command_helper.rs
@@ -83,8 +83,7 @@ pub fn create_benchmark_extrinsic(
 		)),
 		frame_system::CheckNonce::<runtime::Runtime>::from(nonce),
 		frame_system::CheckWeight::<runtime::Runtime>::new(),
-		// TODO PLAT-276: reinstate ChargeTransactionPayment once worker supports it
-		pallet_transaction_payment::ChargeTransactionPayment::<runtime::Runtime>::from(0),
+		pallet_asset_tx_payment::ChargeAssetTxPayment::<runtime::Runtime>::from(0, None),
 	);
 
 	let raw_payload = runtime::SignedPayload::from_raw(

--- a/node/cli/src/command_helper.rs
+++ b/node/cli/src/command_helper.rs
@@ -73,8 +73,7 @@ pub fn create_benchmark_extrinsic(
 		.map(|c| c / 2)
 		.unwrap_or(2) as u64;
 	let extra: runtime::SignedExtra = (
-		// TODO: Integrate upstream-changes after scs/substrate-api-client#211 has been solved.
-		// frame_system::CheckNonZeroSender::<runtime::Runtime>::new(),
+		frame_system::CheckNonZeroSender::<runtime::Runtime>::new(),
 		frame_system::CheckSpecVersion::<runtime::Runtime>::new(),
 		frame_system::CheckTxVersion::<runtime::Runtime>::new(),
 		frame_system::CheckGenesis::<runtime::Runtime>::new(),
@@ -92,8 +91,7 @@ pub fn create_benchmark_extrinsic(
 		call.clone(),
 		extra.clone(),
 		(
-			// TODO: Integrate upstream-changes after scs/substrate-api-client#211 has been solved.
-			// (),
+			(),
 			runtime::VERSION.spec_version,
 			runtime::VERSION.transaction_version,
 			genesis_hash,

--- a/runtime/solo/src/lib.rs
+++ b/runtime/solo/src/lib.rs
@@ -399,8 +399,7 @@ where
 			.saturating_sub(1);
 		let era = sp_runtime::generic::Era::mortal(period, current_block);
 		let extra: SignedExtra = (
-			// TODO: Integrate upstream-changes after scs/substrate-api-client#211 has been solved.
-			// frame_system::CheckNonZeroSender::<Runtime>::new(),
+			frame_system::CheckNonZeroSender::<Runtime>::new(),
 			frame_system::CheckSpecVersion::<Runtime>::new(),
 			frame_system::CheckTxVersion::<Runtime>::new(),
 			frame_system::CheckGenesis::<Runtime>::new(),
@@ -569,8 +568,7 @@ pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
-	// TODO: Integrate upstream-changes after scs/substrate-api-client#211 has been solved.
-	// frame_system::CheckNonZeroSender<Runtime>,
+	frame_system::CheckNonZeroSender<Runtime>,
 	frame_system::CheckSpecVersion<Runtime>,
 	frame_system::CheckTxVersion<Runtime>,
 	frame_system::CheckGenesis<Runtime>,

--- a/runtime/solo/src/lib.rs
+++ b/runtime/solo/src/lib.rs
@@ -406,8 +406,7 @@ where
 			frame_system::CheckEra::<Runtime>::from(era),
 			frame_system::CheckNonce::<Runtime>::from(nonce),
 			frame_system::CheckWeight::<Runtime>::new(),
-			// TODO PLAT-276: reinstate ChargeTransactionPayment once worker supports it
-			pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
+			pallet_asset_tx_payment::ChargeAssetTxPayment::<Runtime>::from(tip, None),
 		);
 		let raw_payload = SignedPayload::new(call, extra)
 			.map_err(|e| {
@@ -543,6 +542,7 @@ construct_runtime!(
 		Grandpa: pallet_grandpa = 3,
 		Balances: pallet_balances = 4,
 		TransactionPayment: pallet_transaction_payment = 5,
+		AssetTxPayment: pallet_asset_tx_payment = 6,
 		Assets: pallet_assets = 7,
 		Vesting: orml_vesting = 8,
 		Council: pallet_collective::<Instance2> = 9,
@@ -575,7 +575,7 @@ pub type SignedExtra = (
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
-	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	pallet_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.


### PR DESCRIPTION
## Description

Adding back `CheckNonZeroSender` and `pallet-asset-tx-payment` as part of [PLAT-276](https://ajunanetwork.atlassian.net/browse/PLAT-276).

The changes are essentially reverting these two commits:
- https://github.com/ajuna-network/Ajuna/pull/15/commits/85869dc99e12165e618bb66bc176a8aa74597ff9
- https://github.com/ajuna-network/Ajuna/pull/15/commits/2f7b8fe805ead4cb4cfa14f0fb2a38ee15c69bbc

## Type of changes

- [x] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features -- -D warnings`
- [x] Tested with `cargo test --workspace --all-features`
