### PR TITLE
store u8 against player

### DIFF
--- a/pallets/ajuna-matchmaker/src/lib.rs
+++ b/pallets/ajuna-matchmaker/src/lib.rs
@@ -68,7 +68,7 @@ pub mod pallet {
 	/// A map tracking which accounts are queued
 	#[pallet::storage]
 	pub type PlayerQueue<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::AccountId, (), OptionQuery>;
+		StorageMap<_, Blake2_128Concat, T::AccountId, u8, OptionQuery>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
@@ -93,7 +93,7 @@ impl<T: Config> MatchMaker for MatchMaking<T> {
 		Brackets::<T>::mutate(bracket, |range| {
 			Players::<T>::insert(bracket, range.end, account_id.clone());
 			range.end += 1;
-			PlayerQueue::<T>::insert(account_id.clone(), ());
+			PlayerQueue::<T>::insert(account_id.clone(), 1);
 
 			Pallet::<T>::deposit_event(Event::Queued(account_id));
 			true


### PR DESCRIPTION
## Description

Stores a u8 against player key to workaround limitation in dotnet client for existence of key in map

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features -- -D warnings`
- [ ] Tested with `cargo test --workspace --all-features`
