### PR TITLE
[PLAT-174] Refactor game_registry identifiers

### DIFF
--- a/pallets/ajuna-gameregistry/src/lib.rs
+++ b/pallets/ajuna-gameregistry/src/lib.rs
@@ -31,7 +31,9 @@ mod tests;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use ajuna_common::{GetIdentifier, MatchMaker, Runner, RunnerState, DEFAULT_PLAYERS};
+	use ajuna_common::{
+		GetIdentifier, Identifier, MatchMaker, Runner, RunnerState, DEFAULT_PLAYERS,
+	};
 	use frame_support::{
 		dispatch::DispatchResult,
 		pallet_prelude::{Member, *},
@@ -67,13 +69,13 @@ pub mod pallet {
 		type MatchMaker: MatchMaker<Player = Self::AccountId>;
 
 		/// An identifier for a game, we use the runner identifier
-		type GameId: Member + Parameter;
+		type GameId: Identifier;
 
 		/// Generate identifiers for games
 		type GetIdentifier: GetIdentifier<Self::GameId>;
 
 		/// The Runners
-		type Runner: Runner<Identifier = Self::GameId>;
+		type Runner: Runner<RunnerId = Self::GameId>;
 
 		/// Authenticated TEE's
 		type Observers: Contains<Self::AccountId>;


### PR DESCRIPTION
* Applied trait to Runner and GameRegistry

## Description

This PR aims to unify the diferent types used as identifiers into a singular type that can be reused in the overall codebase.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features -- -D warnings`
- [ ] Tested with `cargo test --workspace --all-features`
