### PR TITLE
[PLAT-349] Timeout of a Game

### DIFF
--- a/ajuna-common/src/lib.rs
+++ b/ajuna-common/src/lib.rs
@@ -142,6 +142,9 @@ pub trait TurnBasedGame {
 	/// Play a turn with player on the current state returning the new state
 	fn play_turn(player: Self::Player, state: Self::State, turn: Self::Turn)
 		-> Option<Self::State>;
+	/// Forces the termination of a game with a designated winner, useful when games
+	/// get stalled for some reason.
+	fn abort(state: Self::State, winner: Self::Player) -> Self::State;
 	/// Check if the game has finished with winner
 	fn is_finished(state: &Self::State) -> Finished<Self::Player>;
 	/// Get seed if any

--- a/ajuna-common/src/lib.rs
+++ b/ajuna-common/src/lib.rs
@@ -137,6 +137,8 @@ pub trait TurnBasedGame {
 	type State: Codec;
 	/// Initialise turn based game with players returning the initial state
 	fn init(players: &[Self::Player], seed: Option<u32>) -> Option<Self::State>;
+	/// Get the player that should play its turn next
+	fn get_next_player(state: &Self::State) -> Self::Player;
 	/// Play a turn with player on the current state returning the new state
 	fn play_turn(player: Self::Player, state: Self::State, turn: Self::Turn)
 		-> Option<Self::State>;

--- a/pallets/ajuna-board/src/dot4gravity.rs
+++ b/pallets/ajuna-board/src/dot4gravity.rs
@@ -59,6 +59,12 @@ where
 		.ok()
 	}
 
+	fn abort(state: Self::State, winner: Self::Player) -> Self::State {
+		let mut state = state;
+		state.winner = Some(winner);
+		state
+	}
+
 	fn is_finished(state: &Self::State) -> Finished<Self::Player> {
 		match state.winner.clone() {
 			Some(winner) => Finished::Winner(winner),

--- a/pallets/ajuna-board/src/dot4gravity.rs
+++ b/pallets/ajuna-board/src/dot4gravity.rs
@@ -43,6 +43,10 @@ where
 		}
 	}
 
+	fn get_next_player(state: &Self::State) -> Self::Player {
+		state.next_player.clone()
+	}
+
 	fn play_turn(
 		player: Self::Player,
 		state: Self::State,
@@ -135,6 +139,8 @@ mod tests {
 		type GameState = crate::dot4gravity::GameState<MockAccountId>;
 		type Game = crate::dot4gravity::Game<MockAccountId>;
 		type MaxNumberOfPlayers = frame_support::traits::ConstU32<2>;
+		type MaxNumberOfIdleBlocks = frame_support::traits::ConstU32<10>;
+		type MaxNumberOfGamesToExpire = frame_support::traits::ConstU32<5>;
 	}
 
 	#[test]

--- a/pallets/ajuna-board/src/guessing.rs
+++ b/pallets/ajuna-board/src/guessing.rs
@@ -74,6 +74,12 @@ where
 		Some(state)
 	}
 
+	fn abort(state: Self::State, winner: Self::Player) -> Self::State {
+		let mut state = state;
+		state.winner = Some(winner);
+		state
+	}
+
 	fn is_finished(state: &Self::State) -> pallet_ajuna_board::Finished<Self::Player> {
 		let winner = &state.winner;
 		match winner.clone() {

--- a/pallets/ajuna-board/src/guessing.rs
+++ b/pallets/ajuna-board/src/guessing.rs
@@ -43,6 +43,10 @@ where
 		}
 	}
 
+	fn get_next_player(state: &Self::State) -> Self::Player {
+		state.players[state.next_player as usize].clone()
+	}
+
 	fn play_turn(
 		player: Self::Player,
 		state: Self::State,

--- a/pallets/ajuna-board/src/lib.rs
+++ b/pallets/ajuna-board/src/lib.rs
@@ -78,12 +78,12 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxNumberOfPlayers: Get<u32>;
 
-		#[pallet::constant]
 		/// Maximum number of successive blocks with no player activity
+		#[pallet::constant]
 		type MaxNumberOfIdleBlocks: Get<u32>;
 
-		#[pallet::constant]
 		/// Maximum number of games to be expired in a single run
+		#[pallet::constant]
 		type MaxNumberOfGamesToExpire: Get<u32>;
 	}
 
@@ -222,7 +222,7 @@ pub mod pallet {
 
 			BoardStates::<T>::insert(board_id, board_game);
 
-			Self::set_or_update_expiry(board_id);
+			Self::upsert_expiry(board_id);
 
 			Self::deposit_event(Event::GameCreated { board_id, players: players.into_inner() });
 
@@ -247,7 +247,7 @@ pub mod pallet {
 					{
 						Self::declare_winner(&board_id, &winner, &board_game.state);
 					} else {
-						Self::set_or_update_expiry(board_id);
+						Self::upsert_expiry(board_id);
 					}
 
 					Ok(())
@@ -300,18 +300,12 @@ impl<T: Config> Pallet<T> {
 		Self::deposit_event(Event::GameFinished { board_id: *board_id, winner: winner.clone() });
 	}
 
-	fn set_or_update_expiry(board_id: T::BoardId) {
+	fn upsert_expiry(board_id: T::BoardId) {
 		let current_block_number = <frame_system::Pallet<T>>::block_number();
 		let expiry_block_count = T::MaxNumberOfIdleBlocks::get();
 
 		let block_of_expiry = current_block_number + expiry_block_count.into();
 
-		if BoardExpiries::<T>::contains_key(board_id) {
-			BoardExpiries::<T>::mutate(board_id, |entry| {
-				*entry = block_of_expiry;
-			});
-		} else {
-			BoardExpiries::<T>::insert(board_id, block_of_expiry);
-		}
+		BoardExpiries::<T>::insert(board_id, block_of_expiry);
 	}
 }

--- a/pallets/ajuna-board/src/lib.rs
+++ b/pallets/ajuna-board/src/lib.rs
@@ -171,8 +171,8 @@ pub mod pallet {
 
 			// For now 'iter' is going to be considered the same as doing 1 read
 			let total_reads: Weight = 1_u64;
-			// We do 2 writes for each entry we expire
-			let total_writes: Weight = expired_board_ids.len() as u64 * 2_u64;
+			// We do 3 writes for each entry we expire
+			let total_writes: Weight = expired_board_ids.len() as u64 * 3_u64;
 			T::DbWeight::get().reads_writes(total_reads, total_writes)
 		}
 	}

--- a/pallets/ajuna-board/src/lib.rs
+++ b/pallets/ajuna-board/src/lib.rs
@@ -160,10 +160,13 @@ pub mod pallet {
 				.collect::<Vec<T::BoardId>>();
 
 			expired_board_ids.iter().for_each(|expired_board_id| {
-				if let Some(board) = BoardStates::<T>::get(expired_board_id) {
-					let winner = T::Game::get_next_player(&board.state);
-					Self::declare_winner(expired_board_id, &winner, &board.state);
-				}
+				BoardStates::<T>::mutate(expired_board_id, |maybe_board_game| {
+					if let Some(board_game) = maybe_board_game {
+						let winner = T::Game::get_next_player(&board_game.state);
+						Self::declare_winner(expired_board_id, &winner, &board_game.state);
+						board_game.state = T::Game::abort(board_game.state.clone(), winner);
+					}
+				});
 			});
 
 			// For now 'iter' is going to be considered the same as doing 1 read

--- a/pallets/ajuna-board/src/mock.rs
+++ b/pallets/ajuna-board/src/mock.rs
@@ -72,6 +72,8 @@ impl frame_system::Config for Test {
 
 parameter_types! {
 	pub const MaxNumberOfPlayers: u8 = 2;
+	pub const MaxNumberOfIdleBlocks: u32 = 10;
+	pub const MaxNumberOfGamesToExpire: u32 = 2;
 }
 
 use crate::guessing::MockGame;
@@ -83,6 +85,8 @@ impl pallet_ajuna_board::Config for Test {
 	type GameState = crate::guessing::GameState<MockAccountId>;
 	type Game = MockGame<MockAccountId>;
 	type MaxNumberOfPlayers = MaxNumberOfPlayers;
+	type MaxNumberOfIdleBlocks = MaxNumberOfIdleBlocks;
+	type MaxNumberOfGamesToExpire = MaxNumberOfGamesToExpire;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/ajuna-board/src/mock.rs
+++ b/pallets/ajuna-board/src/mock.rs
@@ -72,7 +72,9 @@ impl frame_system::Config for Test {
 
 parameter_types! {
 	pub const MaxNumberOfPlayers: u8 = 2;
+	// Used as assumption in tests beware if changed
 	pub const MaxNumberOfIdleBlocks: u32 = 10;
+	// Used as assumption in tests beware if changed
 	pub const MaxNumberOfGamesToExpire: u32 = 2;
 }
 
@@ -104,4 +106,9 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 pub fn last_event() -> Event {
 	frame_system::Pallet::<Test>::events().pop().expect("Event expected").event
+}
+
+pub fn last_two_events() -> (Event, Event) {
+	let mut events = frame_system::Pallet::<Test>::events();
+	(events.pop().expect("Event expected").event, events.pop().expect("Event expected").event)
 }

--- a/pallets/ajuna-board/src/tests.rs
+++ b/pallets/ajuna-board/src/tests.rs
@@ -251,7 +251,6 @@ fn game_expiry_should_properly_extend_after_play() {
 		assert_ok!(AjunaBoard::play_turn(Origin::signed(BOB), 1_u32));
 
 		// We run on_idle with the remaining weight
-
 		AjunaBoard::on_idle(mock::System::block_number(), 10_000);
 
 		// The latest event is still the game creation


### PR DESCRIPTION
## Description

This PR aims to tackle the problem described in https://ajunanetwork.atlassian.net/browse/PLAT-349 in order to do the following changes have been implemented:

* Added `on_idle` hook to the `pallet_ajuna_board` Pallet which checks periodically for stale Games to clean
* Added the `get_next_player` method to the `TurnBasedGame` trait
* Added the `abort` method to the `TurnBasedGame` trait

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features -- -D warnings`
- [ ] Tested with `cargo test --workspace --all-features`
