### PR TITLE
[PLAT-382] Make last player winner on idle

### DIFF
--- a/ajuna-common/src/lib.rs
+++ b/ajuna-common/src/lib.rs
@@ -137,6 +137,8 @@ pub trait TurnBasedGame {
 	type State: Codec;
 	/// Initialise turn based game with players returning the initial state
 	fn init(players: &[Self::Player], seed: Option<u32>) -> Option<Self::State>;
+	/// Get the player that played its turn last
+	fn get_last_player(state: &Self::State) -> Self::Player;
 	/// Get the player that should play its turn next
 	fn get_next_player(state: &Self::State) -> Self::Player;
 	/// Play a turn with player on the current state returning the new state

--- a/pallets/ajuna-board/src/dot4gravity.rs
+++ b/pallets/ajuna-board/src/dot4gravity.rs
@@ -43,6 +43,14 @@ where
 		}
 	}
 
+	fn get_last_player(state: &Self::State) -> Self::Player {
+		state
+			.last_move
+			.clone()
+			.map(|last_move_of| last_move_of.player)
+			.unwrap_or_else(|| state.next_player.clone())
+	}
+
 	fn get_next_player(state: &Self::State) -> Self::Player {
 		state.next_player.clone()
 	}

--- a/pallets/ajuna-board/src/guessing.rs
+++ b/pallets/ajuna-board/src/guessing.rs
@@ -43,8 +43,9 @@ where
 		}
 	}
 
-	fn get_last_player(_state: &Self::State) -> Self::Player {
-		unimplemented!()
+	fn get_last_player(state: &Self::State) -> Self::Player {
+		let next_player_index = (state.next_player as usize + 1) % state.players.len();
+		state.players[next_player_index].clone()
 	}
 
 	fn get_next_player(state: &Self::State) -> Self::Player {

--- a/pallets/ajuna-board/src/guessing.rs
+++ b/pallets/ajuna-board/src/guessing.rs
@@ -43,6 +43,10 @@ where
 		}
 	}
 
+	fn get_last_player(_state: &Self::State) -> Self::Player {
+		unimplemented!()
+	}
+
 	fn get_next_player(state: &Self::State) -> Self::Player {
 		state.players[state.next_player as usize].clone()
 	}


### PR DESCRIPTION
## Description

As identified by @andyjsbell, a player can win by not playing. The fix is to make the last player winner (instead of next player).

Changes:
- add and implement `get_last_player` method on `TurnBasedGame` trait

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [x] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [x] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features -- -D warnings`
- [ ] Tested with `cargo test --workspace --all-features`
