### PR TITLE
[PLAT-392] AAA pallet - Organizer storage and logic

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -50,8 +50,6 @@ pub mod pallet {
 
 	#[pallet::error]
 	pub enum Error<T> {
-		/// The specified account is not an organizer
-		AccountIsNotOrganizer,
 		/// There is no account set as the organizer
 		OrganizerNotSet,
 	}
@@ -71,15 +69,16 @@ pub mod pallet {
 
 			Ok(())
 		}
+	}
 
-		#[pallet::weight(10_000)]
-		pub fn ensure_organizer(origin: OriginFor<T>) -> DispatchResult {
+	impl<T: Config> Pallet<T> {
+		pub(crate) fn ensure_organizer(origin: OriginFor<T>) -> DispatchResult {
 			let maybe_organizer = ensure_signed(origin)?;
 			let existing_organizer = Organizer::<T>::get().ok_or(Error::<T>::OrganizerNotSet)?;
 
 			match maybe_organizer == existing_organizer {
 				true => Ok(()),
-				false => Err(Error::<T>::AccountIsNotOrganizer.into()),
+				false => Err(DispatchError::BadOrigin),
 			}
 		}
 	}

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -72,6 +72,7 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
+		#[allow(dead_code)]
 		pub(crate) fn ensure_organizer(origin: OriginFor<T>) -> DispatchResult {
 			let maybe_organizer = ensure_signed(origin)?;
 			let existing_organizer = Organizer::<T>::get().ok_or(Error::<T>::OrganizerNotSet)?;

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -68,7 +68,7 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		#[pallet::weight(10_000)]
 		pub fn set_organizer(origin: OriginFor<T>, organizer: T::AccountId) -> DispatchResult {
-			if let Err(_) = ensure_root(origin) {
+			if ensure_root(origin).is_err() {
 				return Err(Error::<T>::InsufficientPrivileges.into())
 			}
 
@@ -78,7 +78,7 @@ pub mod pallet {
 				Event::OrganizerSet { organizer: organizer.clone() }
 			};
 
-			Organizer::<T>::put(organizer.clone());
+			Organizer::<T>::put(organizer);
 
 			Self::deposit_event(event);
 

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -33,8 +33,8 @@ frame_support::construct_runtime!(
 		NodeBlock = MockBlock<Test>,
 		UncheckedExtrinsic = MockUncheckedExtrinsic<Test>,
 	{
-		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-		AjunaAwesomeAvatars: pallet_ajuna_awesome_avatars::{Pallet, Call, Storage, Event<T>},
+		System: frame_system,
+		AjunaAwesomeAvatars: pallet_ajuna_awesome_avatars,
 	}
 );
 
@@ -83,9 +83,4 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 pub fn last_event() -> Event {
 	frame_system::Pallet::<Test>::events().pop().expect("Event expected").event
-}
-
-pub fn _last_two_events() -> (Event, Event) {
-	let mut events = frame_system::Pallet::<Test>::events();
-	(events.pop().expect("Event expected").event, events.pop().expect("Event expected").event)
 }

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -14,11 +14,105 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::mock::*;
+use crate::{mock::*, *};
+use frame_support::{assert_noop, assert_ok};
 
-#[test]
-fn always_good_to_test() {
-	new_test_ext().execute_with(|| {
-		assert_eq!(1 + 1, 2);
-	});
+#[cfg(test)]
+mod organizer {
+	use super::*;
+
+	const ALICE: u32 = 1;
+	const BOB: u32 = 2;
+	const CHARLIE: u32 = 3;
+	const DELTHEA: u32 = 4;
+	const ERIN: u32 = 5;
+	const FLORINA: u32 = 6;
+	const HILDA: u32 = 7;
+
+	#[test]
+	fn only_root_should_set_organizer() {
+		new_test_ext().execute_with(|| {
+			let root_origin = Origin::root();
+			let non_root_origin = Origin::signed(ALICE);
+
+			assert_noop!(
+				AjunaAwesomeAvatars::set_organizer(non_root_origin, HILDA),
+				Error::<Test>::InsufficientPrivileges
+			);
+
+			assert_ok!(AjunaAwesomeAvatars::set_organizer(root_origin, HILDA));
+
+			assert_eq!(Organizer::<Test>::get(), Some(HILDA), "Organizer should be Hilda");
+
+			assert_eq!(
+				last_event(),
+				mock::Event::AjunaAwesomeAvatars(crate::Event::OrganizerSet { organizer: HILDA }),
+			);
+		});
+	}
+
+	#[test]
+	fn set_organizer_should_replace_previous_organizer() {
+		new_test_ext().execute_with(|| {
+			let root_origin = Origin::root();
+
+			assert_ok!(AjunaAwesomeAvatars::set_organizer(root_origin.clone(), BOB));
+
+			assert_eq!(Organizer::<Test>::get(), Some(BOB), "Organizer should be Bob");
+
+			assert_eq!(
+				last_event(),
+				mock::Event::AjunaAwesomeAvatars(crate::Event::OrganizerSet { organizer: BOB }),
+			);
+
+			assert_ok!(AjunaAwesomeAvatars::set_organizer(root_origin, FLORINA));
+
+			assert_eq!(Organizer::<Test>::get(), Some(FLORINA), "Organizer should be Florina");
+
+			assert_eq!(
+				last_event(),
+				mock::Event::AjunaAwesomeAvatars(crate::Event::OrganizerReplaced {
+					prev_organizer: BOB,
+					new_organizer: FLORINA
+				}),
+			);
+		});
+	}
+
+	#[test]
+	fn ensure_organizer_should_fail_if_no_organizer_set() {
+		new_test_ext().execute_with(|| {
+			let organizer = Origin::signed(DELTHEA);
+
+			assert_noop!(
+				AjunaAwesomeAvatars::ensure_organizer(organizer),
+				Error::<Test>::OrganizerNotSet
+			);
+		});
+	}
+
+	#[test]
+	fn ensure_organizer_should_fail_if_account_is_no_organizer() {
+		new_test_ext().execute_with(|| {
+			let organizer = Origin::signed(DELTHEA);
+			let root_origin = Origin::root();
+
+			assert_ok!(AjunaAwesomeAvatars::set_organizer(root_origin.clone(), ERIN));
+			assert_noop!(
+				AjunaAwesomeAvatars::ensure_organizer(organizer),
+				Error::<Test>::AccountIsNotOrganizer
+			);
+		});
+	}
+
+	#[test]
+	fn ensure_organizer_should_validate_newly_set_organizer() {
+		new_test_ext().execute_with(|| {
+			let organizer = Origin::signed(CHARLIE);
+			let root_origin = Origin::root();
+
+			assert_ok!(AjunaAwesomeAvatars::set_organizer(root_origin.clone(), CHARLIE));
+			assert_ok!(AjunaAwesomeAvatars::ensure_organizer(organizer));
+		});
+	}
 }

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -31,7 +31,7 @@ mod organizer {
 	const HILDA: u32 = 7;
 
 	#[test]
-	fn only_root_should_set_organizer() {
+	fn set_organizer_should_only_accept_root_caller() {
 		new_test_ext().execute_with(|| {
 			assert_noop!(
 				AjunaAwesomeAvatars::set_organizer(Origin::signed(ALICE), HILDA),
@@ -48,7 +48,7 @@ mod organizer {
 	}
 
 	#[test]
-	fn set_organizer_should_replace_previous_organizer() {
+	fn set_organizer_should_replace_existing_organizer() {
 		new_test_ext().execute_with(|| {
 			let root_origin = Origin::root();
 
@@ -79,12 +79,12 @@ mod organizer {
 	}
 
 	#[test]
-	fn ensure_organizer_should_fail_if_account_is_no_organizer() {
+	fn ensure_organizer_should_fail_if_caller_is_not_organizer() {
 		new_test_ext().execute_with(|| {
 			assert_ok!(AjunaAwesomeAvatars::set_organizer(Origin::root(), ERIN));
 			assert_noop!(
 				AjunaAwesomeAvatars::ensure_organizer(Origin::signed(DELTHEA)),
-				Error::<Test>::AccountIsNotOrganizer
+				DispatchError::BadOrigin
 			);
 		});
 	}

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -50,16 +50,14 @@ mod organizer {
 	#[test]
 	fn set_organizer_should_replace_existing_organizer() {
 		new_test_ext().execute_with(|| {
-			let root_origin = Origin::root();
-
-			assert_ok!(AjunaAwesomeAvatars::set_organizer(root_origin.clone(), BOB));
+			assert_ok!(AjunaAwesomeAvatars::set_organizer(Origin::root(), BOB));
 			assert_eq!(Organizer::<Test>::get(), Some(BOB), "Organizer should be Bob");
 			assert_eq!(
 				last_event(),
 				mock::Event::AjunaAwesomeAvatars(crate::Event::OrganizerSet { organizer: BOB }),
 			);
 
-			assert_ok!(AjunaAwesomeAvatars::set_organizer(root_origin, FLORINA));
+			assert_ok!(AjunaAwesomeAvatars::set_organizer(Origin::root(), FLORINA));
 			assert_eq!(Organizer::<Test>::get(), Some(FLORINA), "Organizer should be Florina");
 			assert_eq!(
 				last_event(),


### PR DESCRIPTION
## Description

See https://ajunanetwork.atlassian.net/browse/PLAT-392 for details, in short:

* Adds Organizer storage to track season organizer account
* Adds extrinsics to set the Organizer and verify that a given Account is the current organizer

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features -- -D warnings`
- [x] Tested with `cargo test --workspace --all-features`
