### PR TITLE
Fix CI with tidyups

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,5 +18,5 @@ Please describe your pull request and link relevant issues.
 - [ ] Tests for the changes have been added
 - [ ] Necessary documentation is added (if appropriate)
 - [ ] Formatted with `cargo fmt --all`
-- [ ] Linted with `cargo clippy --all-features -- -D warnings`
-- [ ] Tested with `cargo test --workspace --all-features`
+- [ ] Linted with `cargo clippy --all-features --all-targets`
+- [ ] Tested with `cargo test --workspace --all-features --all-targets`

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CARGO_ARGS: ${{ github.ref == 'refs/heads/main' && '--release --all-targets' || '' }}
+  CARGO_ARGS: ${{ github.ref == 'refs/heads/main' && '--release' || '' }}
 
 jobs:
   fmt:
@@ -56,11 +56,11 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features ${{ env.CARGO_ARGS }} -- -D warnings
+          args: --all-features --all-targets ${{ env.CARGO_ARGS }} -- -D warnings
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all-features ${{ env.CARGO_ARGS }}
+          args: --all-features --all-targets ${{ env.CARGO_ARGS }}
 
   test:
     name: Test
@@ -82,7 +82,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features ${{ env.CARGO_ARGS }} --jobs 1
+          args: --workspace --all-features --all-targets ${{ env.CARGO_ARGS }} --jobs 1
 
   notify:
     name: Notify on Slack

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -146,9 +146,10 @@ pub mod pallet {
 			ensure!(new_season.start < new_season.end, Error::<T>::SeasonStartTooLate);
 
 			let season_id = Self::next_season_id();
+			let prev_season_id = season_id.checked_sub(1).ok_or(ArithmeticError::Overflow)?;
 			let next_season_id = season_id.checked_add(1).ok_or(ArithmeticError::Overflow)?;
 
-			if let Some(prev_season) = Self::seasons(season_id - 1) {
+			if let Some(prev_season) = Self::seasons(prev_season_id) {
 				ensure!(prev_season.end < new_season.early_start, Error::<T>::EarlyStartTooEarly);
 			}
 
@@ -171,11 +172,14 @@ pub mod pallet {
 			ensure!(season.early_start < season.start, Error::<T>::EarlyStartTooLate);
 			ensure!(season.start < season.end, Error::<T>::SeasonStartTooLate);
 
+			let prev_season_id = season_id.checked_sub(1).ok_or(ArithmeticError::Overflow)?;
+			let next_season_id = season_id.checked_add(1).ok_or(ArithmeticError::Overflow)?;
+
 			Seasons::<T>::try_mutate(season_id, |maybe_season| {
-				if let Some(prev_season) = Self::seasons(season_id - 1) {
+				if let Some(prev_season) = Self::seasons(prev_season_id) {
 					ensure!(prev_season.end < season.early_start, Error::<T>::EarlyStartTooEarly);
 				}
-				if let Some(next_season) = Self::seasons(season_id + 1) {
+				if let Some(next_season) = Self::seasons(next_season_id) {
 					ensure!(season.end < next_season.early_start, Error::<T>::SeasonEndTooLate);
 				}
 				let existing_season = maybe_season.as_mut().ok_or(Error::<T>::UnknownSeason)?;

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -146,7 +146,7 @@ pub mod pallet {
 			ensure!(new_season.start < new_season.end, Error::<T>::SeasonStartTooLate);
 
 			let season_id = Self::next_season_id();
-			let prev_season_id = season_id.checked_sub(1).ok_or(ArithmeticError::Overflow)?;
+			let prev_season_id = season_id.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
 			let next_season_id = season_id.checked_add(1).ok_or(ArithmeticError::Overflow)?;
 
 			if let Some(prev_season) = Self::seasons(prev_season_id) {
@@ -172,7 +172,7 @@ pub mod pallet {
 			ensure!(season.early_start < season.start, Error::<T>::EarlyStartTooLate);
 			ensure!(season.start < season.end, Error::<T>::SeasonStartTooLate);
 
-			let prev_season_id = season_id.checked_sub(1).ok_or(ArithmeticError::Overflow)?;
+			let prev_season_id = season_id.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
 			let next_season_id = season_id.checked_add(1).ok_or(ArithmeticError::Overflow)?;
 
 			Seasons::<T>::try_mutate(season_id, |maybe_season| {

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -88,7 +88,3 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 	ext
 }
-
-pub fn last_event() -> Event {
-	frame_system::Pallet::<Test>::events().pop().expect("Event expected").event
-}

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -25,7 +25,7 @@ mod organizer {
 	fn set_organizer_should_work() {
 		new_test_ext().execute_with(|| {
 			assert_ok!(AwesomeAvatars::set_organizer(Origin::root(), HILDA));
-			assert_eq!(Organizer::<Test>::get(), Some(HILDA), "Organizer should be Hilda");
+			assert_eq!(AwesomeAvatars::organizer(), Some(HILDA), "Organizer should be Hilda");
 			System::assert_last_event(mock::Event::AwesomeAvatars(crate::Event::OrganizerSet {
 				organizer: HILDA,
 			}));
@@ -48,7 +48,7 @@ mod organizer {
 			assert_ok!(AwesomeAvatars::set_organizer(Origin::root(), BOB));
 
 			assert_ok!(AwesomeAvatars::set_organizer(Origin::root(), FLORINA));
-			assert_eq!(Organizer::<Test>::get(), Some(FLORINA), "Organizer should be Florina");
+			assert_eq!(AwesomeAvatars::organizer(), Some(FLORINA), "Organizer should be Florina");
 			System::assert_last_event(mock::Event::AwesomeAvatars(crate::Event::OrganizerSet {
 				organizer: FLORINA,
 			}));

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -26,10 +26,9 @@ mod organizer {
 		new_test_ext().execute_with(|| {
 			assert_ok!(AwesomeAvatars::set_organizer(Origin::root(), HILDA));
 			assert_eq!(Organizer::<Test>::get(), Some(HILDA), "Organizer should be Hilda");
-			assert_eq!(
-				last_event(),
-				mock::Event::AwesomeAvatars(crate::Event::OrganizerSet { organizer: HILDA }),
-			);
+			System::assert_last_event(mock::Event::AwesomeAvatars(crate::Event::OrganizerSet {
+				organizer: HILDA,
+			}));
 		});
 	}
 
@@ -50,10 +49,9 @@ mod organizer {
 
 			assert_ok!(AwesomeAvatars::set_organizer(Origin::root(), FLORINA));
 			assert_eq!(Organizer::<Test>::get(), Some(FLORINA), "Organizer should be Florina");
-			assert_eq!(
-				last_event(),
-				mock::Event::AwesomeAvatars(crate::Event::OrganizerSet { organizer: FLORINA }),
-			);
+			System::assert_last_event(mock::Event::AwesomeAvatars(crate::Event::OrganizerSet {
+				organizer: FLORINA,
+			}));
 		});
 	}
 
@@ -120,19 +118,17 @@ mod season {
 			assert_ok!(AwesomeAvatars::set_organizer(Origin::root(), ALICE));
 			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), first_season.clone()));
 			assert_eq!(AwesomeAvatars::seasons(1), Some(first_season.clone()));
-			assert_eq!(
-				last_event(),
-				mock::Event::AwesomeAvatars(crate::Event::NewSeasonCreated(first_season))
-			);
+			System::assert_last_event(mock::Event::AwesomeAvatars(crate::Event::NewSeasonCreated(
+				first_season,
+			)));
 
 			let second_season =
 				Season { early_start: 11, start: 12, end: 13, max_mints: 1, max_mythical_mints: 1 };
 			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), second_season.clone()));
 			assert_eq!(AwesomeAvatars::seasons(2), Some(second_season.clone()));
-			assert_eq!(
-				last_event(),
-				mock::Event::AwesomeAvatars(crate::Event::NewSeasonCreated(second_season))
-			);
+			System::assert_last_event(mock::Event::AwesomeAvatars(crate::Event::NewSeasonCreated(
+				second_season,
+			)));
 		});
 	}
 
@@ -222,10 +218,10 @@ mod season {
 				1,
 				first_season_update.clone()
 			));
-			assert_eq!(
-				last_event(),
-				mock::Event::AwesomeAvatars(crate::Event::SeasonUpdated(first_season_update, 1))
-			);
+			System::assert_last_event(mock::Event::AwesomeAvatars(crate::Event::SeasonUpdated(
+				first_season_update,
+				1,
+			)));
 		});
 	}
 
@@ -362,13 +358,12 @@ mod season {
 				metadata.clone()
 			));
 
-			assert_eq!(
-				last_event(),
-				mock::Event::AwesomeAvatars(crate::Event::UpdatedSeasonMetadata {
+			System::assert_last_event(mock::Event::AwesomeAvatars(
+				crate::Event::UpdatedSeasonMetadata {
 					season_id: SEASON_ID,
-					season_metadata: metadata.clone()
-				}),
-			);
+					season_metadata: metadata.clone(),
+				},
+			));
 
 			assert_eq!(AwesomeAvatars::seasons_metadata(SEASON_ID), Some(metadata));
 		});

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -22,14 +22,9 @@ mod organizer {
 	use super::*;
 
 	#[test]
-	fn set_organizer_should_only_accept_root_caller() {
+	fn set_organizer_should_work() {
 		new_test_ext().execute_with(|| {
-			assert_noop!(
-				AwesomeAvatars::set_organizer(Origin::signed(ALICE), HILDA),
-				DispatchError::BadOrigin
-			);
 			assert_ok!(AwesomeAvatars::set_organizer(Origin::root(), HILDA));
-
 			assert_eq!(Organizer::<Test>::get(), Some(HILDA), "Organizer should be Hilda");
 			assert_eq!(
 				last_event(),
@@ -39,14 +34,19 @@ mod organizer {
 	}
 
 	#[test]
+	fn set_organizer_should_reject_non_root_caller() {
+		new_test_ext().execute_with(|| {
+			assert_noop!(
+				AwesomeAvatars::set_organizer(Origin::signed(ALICE), HILDA),
+				DispatchError::BadOrigin
+			);
+		});
+	}
+
+	#[test]
 	fn set_organizer_should_replace_existing_organizer() {
 		new_test_ext().execute_with(|| {
 			assert_ok!(AwesomeAvatars::set_organizer(Origin::root(), BOB));
-			assert_eq!(Organizer::<Test>::get(), Some(BOB), "Organizer should be Bob");
-			assert_eq!(
-				last_event(),
-				mock::Event::AwesomeAvatars(crate::Event::OrganizerSet { organizer: BOB }),
-			);
 
 			assert_ok!(AwesomeAvatars::set_organizer(Origin::root(), FLORINA));
 			assert_eq!(Organizer::<Test>::get(), Some(FLORINA), "Organizer should be Florina");

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -142,7 +142,7 @@ mod season {
 			let first_season =
 				Season { early_start: 1, start: 5, end: 10, max_mints: 1, max_mythical_mints: 1 };
 			assert_ok!(AwesomeAvatars::set_organizer(Origin::root(), ALICE));
-			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), first_season.clone()));
+			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), first_season));
 
 			let second_season =
 				Season { early_start: 3, start: 7, end: 10, max_mints: 1, max_mythical_mints: 1 };
@@ -210,10 +210,10 @@ mod season {
 			// Create two seasons
 			let first_season =
 				Season { early_start: 1, start: 5, end: 10, max_mints: 1, max_mythical_mints: 1 };
-			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), first_season.clone()));
+			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), first_season));
 			let second_season =
 				Season { early_start: 11, start: 15, end: 20, max_mints: 1, max_mythical_mints: 1 };
-			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), second_season.clone()));
+			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), second_season));
 
 			// Update the first one to end before the second has started
 			let first_season_update =
@@ -258,10 +258,10 @@ mod season {
 			// Create two seasons
 			let first_season =
 				Season { early_start: 1, start: 5, end: 10, max_mints: 1, max_mythical_mints: 1 };
-			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), first_season.clone()));
+			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), first_season));
 			let second_season =
 				Season { early_start: 11, start: 15, end: 20, max_mints: 1, max_mythical_mints: 1 };
-			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), second_season.clone()));
+			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), second_season));
 
 			// Update the first one to end after the second has started
 			let first_season_update =
@@ -280,10 +280,10 @@ mod season {
 			// Create two seasons
 			let first_season =
 				Season { early_start: 1, start: 5, end: 10, max_mints: 1, max_mythical_mints: 1 };
-			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), first_season.clone()));
+			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), first_season));
 			let second_season =
 				Season { early_start: 11, start: 15, end: 20, max_mints: 1, max_mythical_mints: 1 };
-			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), second_season.clone()));
+			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), second_season));
 
 			// Update the second season and set early start before previous season end
 			let second_season_update =
@@ -315,7 +315,7 @@ mod season {
 			let season =
 				Season { early_start: 1, start: 5, end: 10, max_mints: 1, max_mythical_mints: 1 };
 			assert_ok!(AwesomeAvatars::set_organizer(Origin::root(), ALICE));
-			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), season.clone()));
+			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), season));
 
 			let season_update =
 				Season { early_start: 5, start: 1, end: 10, max_mints: 1, max_mythical_mints: 1 };
@@ -341,7 +341,7 @@ mod season {
 			let season =
 				Season { early_start: 1, start: 5, end: 10, max_mints: 1, max_mythical_mints: 1 };
 			assert_ok!(AwesomeAvatars::set_organizer(Origin::root(), ALICE));
-			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), season.clone()));
+			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), season));
 
 			// Update the second season and set early access start before previous season end
 			let season_update =

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -16,7 +16,7 @@
 
 use crate::{mock::*, season::*, *};
 use frame_support::{assert_noop, assert_ok};
-use sp_runtime::DispatchError;
+use sp_runtime::{ArithmeticError, DispatchError};
 
 mod organizer {
 	use super::*;
@@ -360,6 +360,26 @@ mod season {
 			assert_noop!(
 				AwesomeAvatars::update_season(Origin::signed(ALICE), 123, season_update),
 				Error::<Test>::SeasonStartTooLate
+			);
+		});
+	}
+
+	#[test]
+	fn update_season_should_handle_overflow() {
+		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
+			let season_update =
+				Season { early_start: 1, start: 2, end: 3, max_mints: 1, max_mythical_mints: 1 };
+			assert_noop!(
+				AwesomeAvatars::update_season(
+					Origin::signed(ALICE),
+					SeasonId::MIN,
+					season_update.clone()
+				),
+				ArithmeticError::Overflow
+			);
+			assert_noop!(
+				AwesomeAvatars::update_season(Origin::signed(ALICE), SeasonId::MAX, season_update),
+				ArithmeticError::Overflow
 			);
 		});
 	}

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -365,18 +365,22 @@ mod season {
 	}
 
 	#[test]
-	fn update_season_should_handle_overflow() {
+	fn update_season_should_handle_underflow() {
+		let season_update =
+			Season { early_start: 1, start: 2, end: 3, max_mints: 1, max_mythical_mints: 1 };
 		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
-			let season_update =
-				Season { early_start: 1, start: 2, end: 3, max_mints: 1, max_mythical_mints: 1 };
 			assert_noop!(
-				AwesomeAvatars::update_season(
-					Origin::signed(ALICE),
-					SeasonId::MIN,
-					season_update.clone()
-				),
-				ArithmeticError::Overflow
+				AwesomeAvatars::update_season(Origin::signed(ALICE), SeasonId::MIN, season_update),
+				ArithmeticError::Underflow
 			);
+		});
+	}
+
+	#[test]
+	fn update_season_should_handle_overflow() {
+		let season_update =
+			Season { early_start: 1, start: 2, end: 3, max_mints: 1, max_mythical_mints: 1 };
+		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
 			assert_noop!(
 				AwesomeAvatars::update_season(Origin::signed(ALICE), SeasonId::MAX, season_update),
 				ArithmeticError::Overflow


### PR DESCRIPTION
## Description

[Some lints weren't caught in `main`](https://github.com/ajuna-network/Ajuna/runs/7985231256?check_suite_focus=true) due to `clippy` not running for all targets on PR branches.

Changes:
- make clippy, check and test to run for all targets by default
  - update PR template accordingly
- add `ExtBuilder` to allow populating some storage items to avoid reptition

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [x] `ci`: Changes to CI configuration
- [x] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [x] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
