### PR TITLE
[PLAT-416] implement xt

### DIFF
--- a/pallets/ajuna-board/README.md
+++ b/pallets/ajuna-board/README.md
@@ -41,7 +41,8 @@ impl pallet_ajuna_board::Config for Test {
 	type BoardId = u32;
 	type PlayersTurn = u32;
 	type GameState = GameState;
-	type Game = Game;
+    type Game = Game;
+    type IdleBoardTimeout = IdleBoardTimeout;
 }
 ```
 

--- a/pallets/ajuna-board/src/lib.rs
+++ b/pallets/ajuna-board/src/lib.rs
@@ -38,26 +38,31 @@ pub mod weights;
 
 /// The state of the board game
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, MaxEncodedLen)]
-pub struct BoardGame<BoardId, State, Players> {
+pub struct BoardGame<BoardId, State, Players, Start> {
 	board_id: BoardId,
 	/// Players in the game
 	players: Players,
 	/// The current state of the game
 	pub state: State,
+	/// When the game started
+	pub started: Start,
 }
 
-impl<BoardId, State, Players> BoardGame<BoardId, State, Players> {
+impl<BoardId, State, Players, Start> BoardGame<BoardId, State, Players, Start> {
 	/// Create a BoardGame
-	fn new(board_id: BoardId, players: Players, state: State) -> Self {
-		Self { board_id, players, state }
+	fn new(board_id: BoardId, players: Players, state: State, started: Start) -> Self {
+		Self { board_id, players, state, started }
 	}
 }
 
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_system::{ensure_signed, pallet_prelude::OriginFor};
-	use sp_runtime::traits::AtLeast32BitUnsigned;
+	use frame_system::{
+		ensure_signed,
+		pallet_prelude::{BlockNumberFor, OriginFor},
+	};
+	use sp_runtime::traits::{AtLeast32BitUnsigned, BlockNumberProvider, Saturating};
 	use sp_std::vec::Vec;
 
 	#[pallet::config]
@@ -71,14 +76,18 @@ pub mod pallet {
 		type GameState: Codec + TypeInfo + MaxEncodedLen + Clone;
 		/// A turn based game
 		type Game: TurnBasedGame<
-			Player = Self::AccountId,
-			Turn = Self::PlayersTurn,
-			State = Self::GameState,
+			Player=Self::AccountId,
+			Turn=Self::PlayersTurn,
+			State=Self::GameState,
 		>;
 		// TODO: consider adding MinNumberOfPlayers to return before Game::init fails
 		/// Maximum number of players
 		#[pallet::constant]
 		type MaxNumberOfPlayers: Get<u32>;
+
+		/// Timeout in blocks we allow a game to be idle
+		#[pallet::constant]
+		type IdleBoardTimeout: Get<BlockNumberFor<Self>>;
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
@@ -117,13 +126,19 @@ pub mod pallet {
 		PlayerAlreadyInGame,
 		/// Board already exists
 		BoardExists,
+		/// A dispute failed
+		DisputeFailed,
 	}
 
 	type BoundedPlayersOf<T> =
-		BoundedVec<<T as frame_system::Config>::AccountId, <T as Config>::MaxNumberOfPlayers>;
+	BoundedVec<<T as frame_system::Config>::AccountId, <T as Config>::MaxNumberOfPlayers>;
 
-	pub(crate) type BoardGameOf<T> =
-		BoardGame<<T as Config>::BoardId, <T as Config>::GameState, BoundedPlayersOf<T>>;
+	pub(crate) type BoardGameOf<T> = BoardGame<
+		<T as Config>::BoardId,
+		<T as Config>::GameState,
+		BoundedPlayersOf<T>,
+		BlockNumberFor<T>,
+	>;
 
 	type PlayersOf<T> = BTreeSet<<T as frame_system::Config>::AccountId>;
 
@@ -184,7 +199,12 @@ pub mod pallet {
 				PlayerBoards::<T>::insert(player, board_id);
 			});
 
-			let board_game = BoardGameOf::<T>::new(board_id, players.clone(), state);
+			let board_game = BoardGameOf::<T>::new(
+				board_id,
+				players.clone(),
+				state,
+				frame_system::Pallet::<T>::current_block_number(),
+			);
 
 			BoardStates::<T>::insert(board_id, board_game);
 
@@ -237,6 +257,24 @@ pub mod pallet {
 			BoardStates::<T>::remove(board_id);
 			// Clear winner
 			BoardWinners::<T>::remove(board_id);
+			Ok(())
+		}
+
+		/// Dispute a board a prevent players leaving stale boards. After the `IdleBoardTimeout` a
+		/// board maybe disputed and then awarded to the player awaiting their turn
+		#[pallet::weight(10_000)]
+		pub fn dispute_game(origin: OriginFor<T>, board_id: T::BoardId) -> DispatchResult {
+			let _ = ensure_signed(origin)?;
+			let board = BoardStates::<T>::get(board_id).ok_or(Error::<T>::InvalidBoard)?;
+			ensure!(
+				board.started.saturating_add(T::IdleBoardTimeout::get()) <
+					frame_system::Pallet::<T>::current_block_number(),
+				Error::<T>::DisputeFailed
+			);
+
+			let winner = T::Game::get_next_player(&board.state);
+			Self::declare_winner(&board_id, &winner, &board.state);
+
 			Ok(())
 		}
 	}

--- a/pallets/ajuna-board/src/lib.rs
+++ b/pallets/ajuna-board/src/lib.rs
@@ -266,11 +266,9 @@ pub mod pallet {
 		pub fn dispute_game(origin: OriginFor<T>, board_id: T::BoardId) -> DispatchResult {
 			let _ = ensure_signed(origin)?;
 			let board = BoardStates::<T>::get(board_id).ok_or(Error::<T>::InvalidBoard)?;
-			ensure!(
-				board.started.saturating_add(T::IdleBoardTimeout::get()) <
-					frame_system::Pallet::<T>::current_block_number(),
-				Error::<T>::DisputeFailed
-			);
+			let timeout_block_number = board.started.saturating_add(T::IdleBoardTimeout::get());
+			let current_block_number = frame_system::Pallet::<T>::current_block_number();
+			ensure!(timeout_block_number <= current_block_number, Error::<T>::DisputeFailed);
 
 			let winner = T::Game::get_next_player(&board.state);
 			Self::declare_winner(&board_id, &winner, &board.state);

--- a/pallets/ajuna-board/src/lib.rs
+++ b/pallets/ajuna-board/src/lib.rs
@@ -76,9 +76,9 @@ pub mod pallet {
 		type GameState: Codec + TypeInfo + MaxEncodedLen + Clone;
 		/// A turn based game
 		type Game: TurnBasedGame<
-			Player=Self::AccountId,
-			Turn=Self::PlayersTurn,
-			State=Self::GameState,
+			Player = Self::AccountId,
+			Turn = Self::PlayersTurn,
+			State = Self::GameState,
 		>;
 		// TODO: consider adding MinNumberOfPlayers to return before Game::init fails
 		/// Maximum number of players
@@ -131,7 +131,7 @@ pub mod pallet {
 	}
 
 	type BoundedPlayersOf<T> =
-	BoundedVec<<T as frame_system::Config>::AccountId, <T as Config>::MaxNumberOfPlayers>;
+		BoundedVec<<T as frame_system::Config>::AccountId, <T as Config>::MaxNumberOfPlayers>;
 
 	pub(crate) type BoardGameOf<T> = BoardGame<
 		<T as Config>::BoardId,

--- a/pallets/ajuna-board/src/lib.rs
+++ b/pallets/ajuna-board/src/lib.rs
@@ -270,7 +270,7 @@ pub mod pallet {
 			let current_block_number = frame_system::Pallet::<T>::current_block_number();
 			ensure!(timeout_block_number <= current_block_number, Error::<T>::DisputeFailed);
 
-			let winner = T::Game::get_next_player(&board.state);
+			let winner = T::Game::get_last_player(&board.state);
 			Self::declare_winner(&board_id, &winner, &board.state);
 
 			Ok(())

--- a/pallets/ajuna-board/src/mock.rs
+++ b/pallets/ajuna-board/src/mock.rs
@@ -72,10 +72,6 @@ impl frame_system::Config for Test {
 
 parameter_types! {
 	pub const MaxNumberOfPlayers: u8 = 2;
-	// Used as assumption in tests beware if changed
-	pub const MaxNumberOfIdleBlocks: u32 = 10;
-	// Used as assumption in tests beware if changed
-	pub const MaxNumberOfGamesToExpire: u32 = 2;
 }
 
 impl pallet_ajuna_board::Config for Test {

--- a/pallets/ajuna-board/src/mock.rs
+++ b/pallets/ajuna-board/src/mock.rs
@@ -72,6 +72,7 @@ impl frame_system::Config for Test {
 
 parameter_types! {
 	pub const MaxNumberOfPlayers: u8 = 2;
+	pub const IdleBoardTimeout: u64 = 10;
 }
 
 impl pallet_ajuna_board::Config for Test {
@@ -81,6 +82,7 @@ impl pallet_ajuna_board::Config for Test {
 	type GameState = crate::dot4gravity::GameState<MockAccountId>;
 	type Game = crate::dot4gravity::Game<MockAccountId>;
 	type MaxNumberOfPlayers = MaxNumberOfPlayers;
+	type IdleBoardTimeout = IdleBoardTimeout;
 	type WeightInfo = ();
 }
 

--- a/runtime/solo/src/lib.rs
+++ b/runtime/solo/src/lib.rs
@@ -469,6 +469,8 @@ impl pallet_ajuna_board::Config for Runtime {
 	type GameState = pallet_ajuna_board::dot4gravity::GameState<AccountId>;
 	type Game = pallet_ajuna_board::dot4gravity::Game<AccountId>;
 	type MaxNumberOfPlayers = frame_support::traits::ConstU32<2>;
+	// Based on 600ms blocks this would be 10 minutesc
+	type IdleBoardTimeout = frame_support::traits::ConstU32<1000>;
 	type WeightInfo = pallet_ajuna_board::weights::AjunaWeight<Runtime>;
 }
 

--- a/runtime/solo/src/lib.rs
+++ b/runtime/solo/src/lib.rs
@@ -462,6 +462,10 @@ impl pallet_scheduler::Config for Runtime {
 	type NoPreimagePostponement = NoPreimagePostponement;
 }
 
+parameter_types! {
+	pub const TenMinutes: BlockNumber = 10 * MINUTES;
+}
+
 impl pallet_ajuna_board::Config for Runtime {
 	type Event = Event;
 	type BoardId = u32;
@@ -469,8 +473,7 @@ impl pallet_ajuna_board::Config for Runtime {
 	type GameState = pallet_ajuna_board::dot4gravity::GameState<AccountId>;
 	type Game = pallet_ajuna_board::dot4gravity::Game<AccountId>;
 	type MaxNumberOfPlayers = frame_support::traits::ConstU32<2>;
-	// Based on 600ms blocks this would be 10 minutesc
-	type IdleBoardTimeout = frame_support::traits::ConstU32<1000>;
+	type IdleBoardTimeout = TenMinutes;
 	type WeightInfo = pallet_ajuna_board::weights::AjunaWeight<Runtime>;
 }
 


### PR DESCRIPTION
## Description

In order to dispute a stale board any signing transaction can be used to challenge the stale board.  If the board is stale then the game is awarded to the next player to play.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features -- -D warnings`
- [x] Tested with `cargo test --workspace --all-features`
