### PR TITLE
Fix docker caching

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,22 +1,18 @@
+FROM alpine as scratchpad
+COPY . /ajuna
+RUN rm -rf /ajuna/resources
+
+# Builder
 FROM docker.io/library/rust:1.59-bullseye as builder
 
 ARG features
 ARG bin
 
-# NOTE: can't use glob and preserve directory structure yet See: https://github.com/moby/moby/issues/15858
-COPY ajuna-common                /ajuna/ajuna-common
-COPY node                        /ajuna/node
-COPY pallets                     /ajuna/pallets
-COPY primitives                  /ajuna/primitives
-COPY rpc                         /ajuna/rpc
-COPY runtime                     /ajuna/runtime
-COPY Cargo.* rust-toolchain.toml /ajuna/
+COPY --from=scratchpad /ajuna /ajuna
 WORKDIR /ajuna
 
 RUN apt update && apt install -y git clang curl libssl-dev llvm libudev-dev
 RUN cargo build --locked --release --no-default-features --features ${features} --bin ${bin}
-
-COPY resources /ajuna/resources
 
 # Runner
 FROM docker.io/library/ubuntu:20.04
@@ -24,7 +20,7 @@ FROM docker.io/library/ubuntu:20.04
 ARG bin
 
 COPY --from=builder /ajuna/target/release/${bin} /usr/local/bin/ajuna
-COPY --from=builder /ajuna/resources/ /
+COPY resources /
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /ajuna ajuna && \
   mkdir -p /data /ajuna/.local/share && \


### PR DESCRIPTION
## Description

Adding the new crate, `ajuna-test`, broke CI on the latest `main`.

Fixing this by adding the `scratchpad` stage where all directories are copied except `resources/` and copying `resources/` at the last stage (because adding another `COPY ajuna-test /ajuna/ajuna-test` isn't a good solution).

(We had this workaround originally so that changing genesis spec files doesn't trigger building new images)

## Type of changes

- [x] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
