### PR TITLE
Remove redundant clones and improve test

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -161,7 +161,7 @@ pub mod pallet {
 		pub fn set_organizer(origin: OriginFor<T>, organizer: T::AccountId) -> DispatchResult {
 			ensure_root(origin)?;
 
-			Organizer::<T>::put(organizer.clone());
+			Organizer::<T>::put(&organizer);
 			Self::deposit_event(Event::OrganizerSet { organizer });
 
 			Ok(())
@@ -180,7 +180,7 @@ pub mod pallet {
 				ensure!(prev_season.end < new_season.early_start, Error::<T>::EarlyStartTooEarly);
 			}
 
-			Seasons::<T>::insert(season_id, new_season.clone());
+			Seasons::<T>::insert(season_id, &new_season);
 			NextSeasonId::<T>::put(next_season_id);
 
 			Self::deposit_event(Event::NewSeasonCreated(new_season));
@@ -223,7 +223,7 @@ pub mod pallet {
 
 			ensure!(Self::seasons(season_id).is_some(), Error::<T>::UnknownSeason);
 
-			SeasonsMetadata::<T>::insert(season_id, metadata.clone());
+			SeasonsMetadata::<T>::insert(season_id, &metadata);
 
 			Self::deposit_event(Event::UpdatedSeasonMetadata {
 				season_id,

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{self as pallet_ajuna_awesome_avatars, types::*};
+use crate::{self as pallet_ajuna_awesome_avatars, types::*, *};
 use frame_support::traits::{ConstU16, ConstU64, Hooks};
 use frame_system::mocking::{MockBlock, MockUncheckedExtrinsic};
 use sp_core::H256;
@@ -114,12 +114,13 @@ impl ExtBuilder {
 		ext.execute_with(|| System::set_block_number(1));
 		ext.execute_with(|| {
 			if let Some(organizer) = self.organizer {
-				let _ = AwesomeAvatars::set_organizer(Origin::root(), organizer);
+				Organizer::<Test>::put(organizer);
 			}
 
-			for season in self.seasons.into_iter() {
-				let organizer = AwesomeAvatars::organizer().unwrap();
-				let _ = AwesomeAvatars::new_season(Origin::signed(organizer), season);
+			for season in self.seasons {
+				let season_id = AwesomeAvatars::next_season_id();
+				Seasons::<Test>::insert(season_id, season);
+				NextSeasonId::<Test>::put(season_id + 1);
 			}
 		});
 		ext

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -183,6 +183,7 @@ mod season {
 	fn new_season_should_return_error_when_sum_of_rarity_chance_is_incorrect() {
 		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
 			for incorrect_rarity_tiers in [
+				test_rarity_tiers(vec![]),
 				test_rarity_tiers(vec![(RarityTier::Common, 10), (RarityTier::Common, 10)]),
 				test_rarity_tiers(vec![(RarityTier::Common, 100), (RarityTier::Common, 100)]),
 				test_rarity_tiers(vec![


### PR DESCRIPTION
## Description

Just noticed some clones we don't need along with a missing test. Also persisting mock data directly into storage (rather than going through extrinsics which are unit tested).

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [x] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
