### PR TITLE
[PLAT-447] Early season ending

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -388,6 +388,13 @@ pub mod pallet {
 			(random_tier, random_variation)
 		}
 
+		fn finish_season(season_id: SeasonId) {
+			ActiveSeasonId::<T>::kill();
+			ActiveSeasonLegendaryOrMythicalMintCount::<T>::kill();
+
+			Self::deposit_event(Event::SeasonEnded { season_id });
+		}
+
 		pub(crate) fn random_dna(
 			who: &T::AccountId,
 			season: &SeasonOf<T>,
@@ -478,9 +485,7 @@ pub mod pallet {
 					if active_season.max_high_tier_mints >=
 						ActiveSeasonLegendaryOrMythicalMintCount::<T>::get()
 					{
-						ActiveSeasonId::<T>::kill();
-
-						Self::deposit_event(Event::SeasonEnded { season_id });
+						Self::finish_season(season_id);
 
 						db_weight += T::DbWeight::get().reads_writes(2, 1);
 					}
@@ -500,9 +505,7 @@ pub mod pallet {
 
 						db_weight += T::DbWeight::get().writes(2);
 					} else {
-						ActiveSeasonId::<T>::kill();
-
-						Self::deposit_event(Event::SeasonEnded { season_id });
+						Self::finish_season(season_id);
 
 						db_weight += T::DbWeight::get().writes(1);
 					}

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -456,7 +456,7 @@ pub mod pallet {
 			let generated_avatars = (0..how_many)
 				.map(|_| {
 					let (dna, minted_mythical, minted_legendary) =
-						Self::random_dna(&player, &active_season)?;
+						Self::random_dna(player, &active_season)?;
 					let avatar = Avatar { season: active_season_id, dna };
 					let avatar_id = T::Hashing::hash_of(&avatar);
 
@@ -496,18 +496,18 @@ pub mod pallet {
 					.filter_map(|(avatar_id, _, legendary)| legendary.then(|| avatar_id))
 					.collect::<Vec<_>>();
 
-				if mythical_avatars.len() > 0 || legendary_avatars.len() > 0 {
+				if !mythical_avatars.is_empty() || !legendary_avatars.is_empty() {
 					ActiveSeasonLegendaryOrMythicalMintCount::<T>::mutate(|value| {
 						*value += (mythical_avatars.len() + legendary_avatars.len()) as u16
 					});
 
-					if mythical_avatars.len() > 0 {
+					if !mythical_avatars.is_empty() {
 						Self::deposit_event(Event::MythicalAvatarMinted {
 							avatar_ids: mythical_avatars,
 						});
 					}
 
-					if legendary_avatars.len() > 0 {
+					if !legendary_avatars.is_empty() {
 						Self::deposit_event(Event::LegendaryAvatarMinted {
 							avatar_ids: legendary_avatars,
 						});

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -166,8 +166,7 @@ impl Default for Season<MockBlockNumber> {
 			early_start: 1,
 			start: 2,
 			end: 3,
-			max_mints: 1,
-			max_mythical_mints: 1,
+			max_high_tier_mints: 1,
 			rarity_tiers: test_rarity_tiers(vec![
 				(RarityTier::Common, 50),
 				(RarityTier::Uncommon, 30),

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -670,9 +670,11 @@ mod minting {
 		.unwrap();
 		assert!(avatar_ids.is_full());
 
+		let rarity_tiers = test_rarity_tiers(vec![(RarityTier::Common, 100)]);
+
 		ExtBuilder::default()
 			.organizer(ALICE)
-			.seasons(vec![Season::default()])
+			.seasons(vec![Season::default().rarity_tiers(rarity_tiers)])
 			.mint_availability(true)
 			.build()
 			.execute_with(|| {
@@ -757,7 +759,8 @@ mod minting {
 
 	#[test]
 	fn mint_should_wait_for_cooldown() {
-		let season = Season::default().early_start(1).start(3).end(20);
+		let rarity_tiers = test_rarity_tiers(vec![(RarityTier::Common, 100)]);
+		let season = Season::default().early_start(1).start(3).end(20).rarity_tiers(rarity_tiers);
 		let mint_cooldown = 7;
 
 		ExtBuilder::default()

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -33,13 +33,15 @@ pub enum RarityTier {
 pub type RarityPercent = u8;
 pub type RarityTiers = BoundedVec<(RarityTier, RarityPercent), ConstU32<6>>;
 
+pub type MaximumHighTierMints = u16;
+
 #[derive(Encode, Decode, MaxEncodedLen, RuntimeDebug, TypeInfo, Clone, PartialEq)]
 pub struct Season<BlockNumber> {
 	pub early_start: BlockNumber,
 	pub start: BlockNumber,
 	pub end: BlockNumber,
-	pub max_mints: u16,
-	pub max_mythical_mints: u16,
+	/// Maximum amount of Legendary and Mythical mints that can be minted in the Season
+	pub max_high_tier_mints: MaximumHighTierMints,
 	pub rarity_tiers: RarityTiers,
 	pub max_variations: u8,
 	pub max_components: u8,


### PR DESCRIPTION
## Description

See https://ajunanetwork.atlassian.net/browse/PLAT-447 for details. In short:

* Added new event types for Legendary and Mythical minting
* Added storage to track amount of Mythical/Legendary mintings in season
* Modified logic in `on_initialize` to make a season end early if the rare minting quota is reached

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] ~Tests for the changes have been added~
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
