### PR TITLE
[PLAT-434] Seeds are generated post winning condition only

### DIFF
--- a/node/cli/src/benchmarking.rs
+++ b/node/cli/src/benchmarking.rs
@@ -62,7 +62,7 @@ impl frame_benchmarking_cli::ExtrinsicBuilder for RemarkBuilder {
 			SystemCall::remark { remark: vec![] }.into(),
 			nonce,
 		)
-			.into();
+		.into();
 
 		Ok(extrinsic)
 	}
@@ -102,7 +102,7 @@ impl frame_benchmarking_cli::ExtrinsicBuilder for TransferKeepAliveBuilder {
 				dest: self.dest.clone().into(),
 				value: self.value.into(),
 			}
-				.into(),
+			.into(),
 			nonce,
 		)
 		.into();

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -79,27 +79,27 @@ pub enum Subcommand {
 	#[cfg(feature = "solo")]
 	PurgeChainSolo(sc_cli::PurgeChainCmd),
 
-    /// Remove the whole parachain chain data.
-    #[cfg(any(feature = "bajun", feature = "ajuna"))]
-    PurgeChainPara(cumulus_client_cli::PurgeChainCmd),
+	/// Remove the whole parachain chain data.
+	#[cfg(any(feature = "bajun", feature = "ajuna"))]
+	PurgeChainPara(cumulus_client_cli::PurgeChainCmd),
 
-    /// Revert the chain to a previous state.
-    Revert(sc_cli::RevertCmd),
+	/// Revert the chain to a previous state.
+	Revert(sc_cli::RevertCmd),
 
-    /// Sub-commands concerned with benchmarking.
-    #[clap(subcommand)]
-    Benchmark(frame_benchmarking_cli::BenchmarkCmd),
+	/// Sub-commands concerned with benchmarking.
+	#[clap(subcommand)]
+	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 
-    /// Try some command against runtime state.
-    #[cfg(feature = "try-runtime")]
-    TryRuntime(try_runtime_cli::TryRuntimeCmd),
+	/// Try some command against runtime state.
+	#[cfg(feature = "try-runtime")]
+	TryRuntime(try_runtime_cli::TryRuntimeCmd),
 
-    /// Try some command against runtime state. Note: `try-runtime` feature must be enabled.
-    #[cfg(not(feature = "try-runtime"))]
-    TryRuntime,
+	/// Try some command against runtime state. Note: `try-runtime` feature must be enabled.
+	#[cfg(not(feature = "try-runtime"))]
+	TryRuntime,
 
-    /// Db meta columns information.
-    ChainInfo(sc_cli::ChainInfoCmd),
+	/// Db meta columns information.
+	ChainInfo(sc_cli::ChainInfoCmd),
 }
 
 // Command for exporting the genesis state of the parachain

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -22,16 +22,16 @@ use ajuna_service::{
 };
 #[cfg(feature = "bajun")]
 use ajuna_service::{
-    bajun,
-    bajun::BajunRuntimeExecutor,
-    bajun_runtime::{Block as ParaBajunBlock, RuntimeApi as BajunRuntimeApi},
+	bajun,
+	bajun::BajunRuntimeExecutor,
+	bajun_runtime::{Block as ParaBajunBlock, RuntimeApi as BajunRuntimeApi},
 };
 #[cfg(any(feature = "bajun", feature = "ajuna"))]
 use {
-    crate::cli::RelayChainCli, codec::Encode,
-    cumulus_client_service::genesis::generate_genesis_block, cumulus_primitives_core::ParaId,
-    log::info, polkadot_parachain::primitives::AccountIdConversion, sc_cli::Result,
-    sp_core::hexdisplay::HexDisplay, sp_runtime::traits::Block as BlockT, std::io::Write,
+	crate::cli::RelayChainCli, codec::Encode,
+	cumulus_client_service::genesis::generate_genesis_block, cumulus_primitives_core::ParaId,
+	log::info, polkadot_parachain::primitives::AccountIdConversion, sc_cli::Result,
+	sp_core::hexdisplay::HexDisplay, sp_runtime::traits::Block as BlockT, std::io::Write,
 };
 
 use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};
@@ -41,16 +41,16 @@ use sp_keyring::Sr25519Keyring;
 use std::{path::PathBuf, sync::Arc};
 #[cfg(feature = "solo")]
 use {
-    crate::{
-        benchmarking::{inherent_benchmark_data, RemarkBuilder, TransferKeepAliveBuilder},
-        cli::{Cli, Subcommand},
-    },
-    ajuna_service::{
-        ajuna_solo_runtime::Block as SoloBlock,
-        ajuna_solo_runtime::ExistentialDeposit,
-        chain_spec,
-        solo::{self, new_full, new_partial, ExecutorDispatch},
-    },
+	crate::{
+		benchmarking::{inherent_benchmark_data, RemarkBuilder, TransferKeepAliveBuilder},
+		cli::{Cli, Subcommand},
+	},
+	ajuna_service::{
+		ajuna_solo_runtime::Block as SoloBlock,
+		ajuna_solo_runtime::ExistentialDeposit,
+		chain_spec,
+		solo::{self, new_full, new_partial, ExecutorDispatch},
+	},
 };
 
 fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
@@ -533,44 +533,44 @@ macro_rules! construct_sync_run {
 // }
 /// Parse and run command line arguments
 pub fn run() -> sc_cli::Result<()> {
-    let cli = Cli::from_args();
+	let cli = Cli::from_args();
 
-    match &cli.subcommand {
-        Some(Subcommand::Key(cmd)) => cmd.run(&cli),
-        Some(Subcommand::BuildSpec(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
-        },
-        Some(Subcommand::CheckBlock(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.async_run(|config| {
-                let PartialComponents { client, task_manager, import_queue, .. } =
-                    new_partial(&config)?;
-                Ok((cmd.run(client, import_queue), task_manager))
-            })
-        },
+	match &cli.subcommand {
+		Some(Subcommand::Key(cmd)) => cmd.run(&cli),
+		Some(Subcommand::BuildSpec(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
+		},
+		Some(Subcommand::CheckBlock(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|config| {
+				let PartialComponents { client, task_manager, import_queue, .. } =
+					new_partial(&config)?;
+				Ok((cmd.run(client, import_queue), task_manager))
+			})
+		},
 		Some(Subcommand::ExportBlocks(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.async_run(|config| {
-                let PartialComponents { client, task_manager, .. } = new_partial(&config)?;
-                Ok((cmd.run(client, config.database), task_manager))
-            })
-        },
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|config| {
+				let PartialComponents { client, task_manager, .. } = new_partial(&config)?;
+				Ok((cmd.run(client, config.database), task_manager))
+			})
+		},
 		Some(Subcommand::ExportState(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.async_run(|config| {
-                let PartialComponents { client, task_manager, .. } = new_partial(&config)?;
-                Ok((cmd.run(client, config.chain_spec), task_manager))
-            })
-        },
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|config| {
+				let PartialComponents { client, task_manager, .. } = new_partial(&config)?;
+				Ok((cmd.run(client, config.chain_spec), task_manager))
+			})
+		},
 		Some(Subcommand::ImportBlocks(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.async_run(|config| {
-                let PartialComponents { client, task_manager, import_queue, .. } =
-                    new_partial(&config)?;
-                Ok((cmd.run(client, import_queue), task_manager))
-            })
-        },
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|config| {
+				let PartialComponents { client, task_manager, import_queue, .. } =
+					new_partial(&config)?;
+				Ok((cmd.run(client, import_queue), task_manager))
+			})
+		},
 		#[cfg(feature = "solo")]
 		Some(Subcommand::PurgeChainSolo(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
@@ -586,12 +586,12 @@ pub fn run() -> sc_cli::Result<()> {
 					[RelayChainCli::executable_name()].iter().chain(cli.relay_chain_args.iter()),
 				);
 
-                let polkadot_config = SubstrateCli::create_configuration(
-                    &polkadot_cli,
-                    &polkadot_cli,
-                    config.tokio_handle.clone(),
-                )
-                    .map_err(|err| format!("Relay chain argument error: {:?}", err))?;
+				let polkadot_config = SubstrateCli::create_configuration(
+					&polkadot_cli,
+					&polkadot_cli,
+					config.tokio_handle.clone(),
+				)
+				.map_err(|err| format!("Relay chain argument error: {:?}", err))?;
 
 				cmd.run(config, polkadot_config)
 			})
@@ -608,89 +608,89 @@ pub fn run() -> sc_cli::Result<()> {
 			})
 		},
 		Some(Subcommand::Benchmark(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
+			let runner = cli.create_runner(cmd)?;
 
-            runner.sync_run(|config| {
-                // This switch needs to be in the client, since the client decides
-                // which sub-commands it wants to support.
-                match cmd {
-                    BenchmarkCmd::Pallet(cmd) => {
-                        if !cfg!(feature = "runtime-benchmarks") {
-                            return Err(
-                                "Runtime benchmarking wasn't enabled when building the node. \
+			runner.sync_run(|config| {
+				// This switch needs to be in the client, since the client decides
+				// which sub-commands it wants to support.
+				match cmd {
+					BenchmarkCmd::Pallet(cmd) => {
+						if !cfg!(feature = "runtime-benchmarks") {
+							return Err(
+								"Runtime benchmarking wasn't enabled when building the node. \
 							You can enable it with `--features runtime-benchmarks`."
-                                    .into(),
-                            )
-                        }
+									.into(),
+							)
+						}
 
-                        cmd.run::<SoloBlock, ExecutorDispatch>(config)
-                    },
-                    BenchmarkCmd::Block(cmd) => {
-                        let PartialComponents { client, .. } = new_partial(&config)?;
-                        cmd.run(client)
-                    },
-                    BenchmarkCmd::Storage(cmd) => {
-                        let PartialComponents { client, backend, .. } = new_partial(&config)?;
-                        let db = backend.expose_db();
-                        let storage = backend.expose_storage();
+						cmd.run::<SoloBlock, ExecutorDispatch>(config)
+					},
+					BenchmarkCmd::Block(cmd) => {
+						let PartialComponents { client, .. } = new_partial(&config)?;
+						cmd.run(client)
+					},
+					BenchmarkCmd::Storage(cmd) => {
+						let PartialComponents { client, backend, .. } = new_partial(&config)?;
+						let db = backend.expose_db();
+						let storage = backend.expose_storage();
 
-                        cmd.run(config, client, db, storage)
-                    },
-                    BenchmarkCmd::Overhead(cmd) => {
-                        let PartialComponents { client, .. } = new_partial(&config)?;
-                        let ext_builder = RemarkBuilder::new(client.clone());
+						cmd.run(config, client, db, storage)
+					},
+					BenchmarkCmd::Overhead(cmd) => {
+						let PartialComponents { client, .. } = new_partial(&config)?;
+						let ext_builder = RemarkBuilder::new(client.clone());
 
-                        cmd.run(config, client, inherent_benchmark_data()?, &ext_builder)
-                    },
-                    BenchmarkCmd::Extrinsic(cmd) => {
-                        let PartialComponents { client, .. } = new_partial(&config)?;
-                        // Register the *Remark* and *TKA* builders.
-                        let ext_factory = ExtrinsicFactory(vec![
-                            Box::new(RemarkBuilder::new(client.clone())),
-                            Box::new(TransferKeepAliveBuilder::new(
-                                client.clone(),
-                                Sr25519Keyring::Alice.to_account_id(),
-                                ExistentialDeposit::get(),
-                            )),
-                        ]);
+						cmd.run(config, client, inherent_benchmark_data()?, &ext_builder)
+					},
+					BenchmarkCmd::Extrinsic(cmd) => {
+						let PartialComponents { client, .. } = new_partial(&config)?;
+						// Register the *Remark* and *TKA* builders.
+						let ext_factory = ExtrinsicFactory(vec![
+							Box::new(RemarkBuilder::new(client.clone())),
+							Box::new(TransferKeepAliveBuilder::new(
+								client.clone(),
+								Sr25519Keyring::Alice.to_account_id(),
+								ExistentialDeposit::get(),
+							)),
+						]);
 
-                        cmd.run(client, inherent_benchmark_data()?, &ext_factory)
-                    },
-                    BenchmarkCmd::Machine(cmd) =>
-                        cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()),
-                }
-            })
-        },
-        #[cfg(feature = "try-runtime")]
-        Some(Subcommand::TryRuntime(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.async_run(|config| {
-                // we don't need any of the components of new_partial, just a runtime, or a task
-                // manager to do `async_run`.
-                let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
-                let task_manager =
-                    sc_service::TaskManager::new(config.tokio_handle.clone(), registry)
-                        .map_err(|e| sc_cli::Error::Service(sc_service::Error::Prometheus(e)))?;
-                Ok((cmd.run::<SoloBlock, ExecutorDispatch>(config), task_manager))
-            })
-        },
-        #[cfg(not(feature = "try-runtime"))]
-        Some(Subcommand::TryRuntime) => Err("TryRuntime wasn't enabled when building the node. \
+						cmd.run(client, inherent_benchmark_data()?, &ext_factory)
+					},
+					BenchmarkCmd::Machine(cmd) =>
+						cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()),
+				}
+			})
+		},
+		#[cfg(feature = "try-runtime")]
+		Some(Subcommand::TryRuntime(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|config| {
+				// we don't need any of the components of new_partial, just a runtime, or a task
+				// manager to do `async_run`.
+				let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
+				let task_manager =
+					sc_service::TaskManager::new(config.tokio_handle.clone(), registry)
+						.map_err(|e| sc_cli::Error::Service(sc_service::Error::Prometheus(e)))?;
+				Ok((cmd.run::<SoloBlock, ExecutorDispatch>(config), task_manager))
+			})
+		},
+		#[cfg(not(feature = "try-runtime"))]
+		Some(Subcommand::TryRuntime) => Err("TryRuntime wasn't enabled when building the node. \
 				You can enable it with `--features try-runtime`."
-            .into()),
-        Some(Subcommand::ChainInfo(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.sync_run(|config| cmd.run::<SoloBlock>(&config))
-        },
-        None => {
-            #[cfg(feature = "bajun")]
-            if cfg!(feature = "bajun") {
-                let runner = cli.create_runner(&cli.run_para.normalize())?;
-                let collator_options = cli.run_para.collator_options();
+			.into()),
+		Some(Subcommand::ChainInfo(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.sync_run(|config| cmd.run::<SoloBlock>(&config))
+		},
+		None => {
+			#[cfg(feature = "bajun")]
+			if cfg!(feature = "bajun") {
+				let runner = cli.create_runner(&cli.run_para.normalize())?;
+				let collator_options = cli.run_para.collator_options();
 
-                return runner.run_node_until_exit(|config| async move {
-                    let para_id = chain_spec::Extensions::try_get(&*config.chain_spec)
-                        .map(|e| e.para_id)
+				return runner.run_node_until_exit(|config| async move {
+					let para_id = chain_spec::Extensions::try_get(&*config.chain_spec)
+						.map(|e| e.para_id)
 						.ok_or("Could not find parachain ID in chain-spec.")?;
 
 					let polkadot_cli = RelayChainCli::new(
@@ -768,13 +768,13 @@ pub fn run() -> sc_cli::Result<()> {
 					let genesis_state =
 						format!("0x{:?}", HexDisplay::from(&block.header().encode()));
 
-                    let tokio_handle = config.tokio_handle.clone();
-                    let polkadot_config = SubstrateCli::create_configuration(
-                        &polkadot_cli,
-                        &polkadot_cli,
-                        tokio_handle,
-                    )
-                        .map_err(|err| format!("Relay chain argument error: {:?}", err))?;
+					let tokio_handle = config.tokio_handle.clone();
+					let polkadot_config = SubstrateCli::create_configuration(
+						&polkadot_cli,
+						&polkadot_cli,
+						tokio_handle,
+					)
+					.map_err(|err| format!("Relay chain argument error: {:?}", err))?;
 
 					info!("Parachain id: {:?}", id);
 					info!("Parachain Account: {}", parachain_account);

--- a/node/service/src/solo.rs
+++ b/node/service/src/solo.rs
@@ -251,17 +251,17 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 	};
 
 	let _rpc_handlers = sc_service::spawn_tasks(sc_service::SpawnTasksParams {
-        network: network.clone(),
-        client: client.clone(),
-        keystore: keystore_container.sync_keystore(),
-        task_manager: &mut task_manager,
-        transaction_pool: transaction_pool.clone(),
-        rpc_builder: rpc_extensions_builder,
-        backend,
-        system_rpc_tx,
-        config,
-        telemetry: telemetry.as_mut(),
-    })?;
+		network: network.clone(),
+		client: client.clone(),
+		keystore: keystore_container.sync_keystore(),
+		task_manager: &mut task_manager,
+		transaction_pool: transaction_pool.clone(),
+		rpc_builder: rpc_extensions_builder,
+		backend,
+		system_rpc_tx,
+		config,
+		telemetry: telemetry.as_mut(),
+	})?;
 
 	if role.is_authority() {
 		let proposer_factory = sc_basic_authorship::ProposerFactory::new(

--- a/pallets/ajuna-board/src/tests.rs
+++ b/pallets/ajuna-board/src/tests.rs
@@ -119,7 +119,7 @@ fn should_create_new_game() {
 			players: vec![BOB, CHARLIE],
 		}));
 		assert!(BoardStates::<Test>::contains_key(BOARD_ID));
-		assert!(Seed::<Test>::get().is_none());
+		assert!(Seed::<Test>::get().is_some());
 
 		let tests_for_errors = vec![
 			(BTreeSet::from([BOB, CHARLIE]), BOARD_ID, Error::<Test>::BoardExists),

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -27,7 +27,7 @@ pub use sc_rpc_api::DenyUnsafe;
 
 /// Full client dependencies.
 pub struct FullDeps<C, P> {
-    /// The client instance to use.
+	/// The client instance to use.
 	pub client: Arc<C>,
 	/// Transaction pool instance.
 	pub pool: Arc<P>,
@@ -37,30 +37,30 @@ pub struct FullDeps<C, P> {
 
 /// Instantiate all full RPC extensions.
 pub fn create_full<C, P>(
-    deps: FullDeps<C, P>,
+	deps: FullDeps<C, P>,
 ) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
-    where
-        C: ProvideRuntimeApi<Block>,
-        C: HeaderBackend<Block> + HeaderMetadata<Block, Error=BlockChainError> + 'static,
-        C: Send + Sync + 'static,
-        C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
-        C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
-        C::Api: BlockBuilder<Block>,
-        P: TransactionPool + 'static,
+where
+	C: ProvideRuntimeApi<Block>,
+	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + 'static,
+	C: Send + Sync + 'static,
+	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
+	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
+	C::Api: BlockBuilder<Block>,
+	P: TransactionPool + 'static,
 {
-    use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
-    use substrate_frame_rpc_system::{System, SystemApiServer};
+	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
+	use substrate_frame_rpc_system::{System, SystemApiServer};
 
-    let mut module = RpcModule::new(());
-    let FullDeps { client, pool, deny_unsafe } = deps;
+	let mut module = RpcModule::new(());
+	let FullDeps { client, pool, deny_unsafe } = deps;
 
-    module.merge(System::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
-    module.merge(TransactionPayment::new(client).into_rpc())?;
+	module.merge(System::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
+	module.merge(TransactionPayment::new(client).into_rpc())?;
 
-    // Extend this RPC with a custom API by using the following syntax.
-    // `YourRpcStruct` should have a reference to a client, which is needed
-    // to call into the runtime.
-    // `module.merge(YourRpcTrait::into_rpc(YourRpcStruct::new(ReferenceToClient, ...)))?;`
+	// Extend this RPC with a custom API by using the following syntax.
+	// `YourRpcStruct` should have a reference to a client, which is needed
+	// to call into the runtime.
+	// `module.merge(YourRpcTrait::into_rpc(YourRpcStruct::new(ReferenceToClient, ...)))?;`
 
-    Ok(module)
+	Ok(module)
 }

--- a/runtime/ajuna/src/lib.rs
+++ b/runtime/ajuna/src/lib.rs
@@ -41,13 +41,13 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 use frame_support::{
-    construct_runtime, parameter_types,
-    traits::{Contains, Currency, EitherOfDiverse, EnsureOrigin, Imbalance, OnUnbalanced},
-    weights::{
-        constants::WEIGHT_PER_SECOND, ConstantMultiplier, DispatchClass, Weight,
-        WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
-    },
-    PalletId,
+	construct_runtime, parameter_types,
+	traits::{Contains, Currency, EitherOfDiverse, EnsureOrigin, Imbalance, OnUnbalanced},
+	weights::{
+		constants::WEIGHT_PER_SECOND, ConstantMultiplier, DispatchClass, Weight,
+		WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
+	},
+	PalletId,
 };
 use frame_system::{
 	limits::{BlockLength, BlockWeights},
@@ -377,8 +377,8 @@ parameter_types! {
 }
 
 impl pallet_transaction_payment::Config for Runtime {
-    type Event = Event;
-    type OnChargeTransaction = CurrencyAdapter<Balances, NegativeImbalanceToTreasury>;
+	type Event = Event;
+	type OnChargeTransaction = CurrencyAdapter<Balances, NegativeImbalanceToTreasury>;
 	type WeightToFee = WeightToFee;
 	type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
 	type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
@@ -410,55 +410,55 @@ impl pallet_collective::Config<CouncilCollective> for Runtime {
 }
 
 type EnsureRootOrMoreThanHalfCouncil = EitherOfDiverse<
-    EnsureRoot<AccountId>,
-    EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
+	EnsureRoot<AccountId>,
+	EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
 >;
 type EnsureRootOrAtLeastTwoThirdsCouncil = EitherOfDiverse<
-    EnsureRoot<AccountId>,
-    EnsureProportionAtLeast<AccountId, CouncilCollective, 2, 3>,
+	EnsureRoot<AccountId>,
+	EnsureProportionAtLeast<AccountId, CouncilCollective, 2, 3>,
 >;
 
 impl pallet_membership::Config<pallet_membership::Instance2> for Runtime {
 	type Event = Event;
-    type AddOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type RemoveOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type SwapOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type ResetOrigin = EnsureRootOrAtLeastTwoThirdsCouncil;
-    type PrimeOrigin = EnsureRootOrAtLeastTwoThirdsCouncil;
-    type MembershipInitialized = Council;
-    type MembershipChanged = Council;
-    type MaxMembers = CouncilMaxMembers;
-    type WeightInfo = weights::pallet_membership::WeightInfo<Runtime>;
+	type AddOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type RemoveOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type SwapOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type ResetOrigin = EnsureRootOrAtLeastTwoThirdsCouncil;
+	type PrimeOrigin = EnsureRootOrAtLeastTwoThirdsCouncil;
+	type MembershipInitialized = Council;
+	type MembershipChanged = Council;
+	type MaxMembers = CouncilMaxMembers;
+	type WeightInfo = weights::pallet_membership::WeightInfo<Runtime>;
 }
 
 pub struct RootMaxSpendOrigin;
 
 impl EnsureOrigin<Origin> for RootMaxSpendOrigin {
-    type Success = Balance;
+	type Success = Balance;
 
-    fn try_origin(o: Origin) -> Result<Self::Success, Origin> {
-        Result::<frame_system::RawOrigin<_>, Origin>::from(o).and_then(|o| match o {
-            frame_system::RawOrigin::Root => Ok(Balance::MAX),
-            r => Err(Origin::from(r)),
-        })
-    }
+	fn try_origin(o: Origin) -> Result<Self::Success, Origin> {
+		Result::<frame_system::RawOrigin<_>, Origin>::from(o).and_then(|o| match o {
+			frame_system::RawOrigin::Root => Ok(Balance::MAX),
+			r => Err(Origin::from(r)),
+		})
+	}
 
-    #[cfg(feature = "runtime-benchmarks")]
-    fn try_successful_origin() -> Result<Origin, ()> {
-        Ok(Origin::root())
-    }
+	#[cfg(feature = "runtime-benchmarks")]
+	fn try_successful_origin() -> Result<Origin, ()> {
+		Ok(Origin::root())
+	}
 }
 
 impl pallet_treasury::Config for Runtime {
-    type PalletId = TreasuryPalletId;
-    type Event = Event;
-    type Currency = Balances;
-    type MaxApprovals = frame_support::traits::ConstU32<100>;
-    type ApproveOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type RejectOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type SpendOrigin = RootMaxSpendOrigin;
-    type OnSlash = ();
-    type ProposalBond = FivePercent;
+	type PalletId = TreasuryPalletId;
+	type Event = Event;
+	type Currency = Balances;
+	type MaxApprovals = frame_support::traits::ConstU32<100>;
+	type ApproveOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type RejectOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type SpendOrigin = RootMaxSpendOrigin;
+	type OnSlash = ();
+	type ProposalBond = FivePercent;
 	type ProposalBondMinimum = MinimumProposalBond;
 	type ProposalBondMaximum = ();
 	type SpendPeriod = Weekly;
@@ -495,8 +495,8 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type OutboundXcmpMessageSource = XcmpQueue;
 	type XcmpMessageHandler = XcmpQueue;
-    type ReservedXcmpWeight = ReservedXcmpWeight;
-    type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+	type ReservedXcmpWeight = ReservedXcmpWeight;
+	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 }
 
 impl parachain_info::Config for Runtime {}

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -41,13 +41,13 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 use frame_support::{
-    construct_runtime, parameter_types,
-    traits::{Contains, Currency, EitherOfDiverse, Imbalance, OnUnbalanced},
-    weights::{
-        constants::WEIGHT_PER_SECOND, ConstantMultiplier, DispatchClass, Weight,
-        WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
-    },
-    PalletId,
+	construct_runtime, parameter_types,
+	traits::{Contains, Currency, EitherOfDiverse, Imbalance, OnUnbalanced},
+	weights::{
+		constants::WEIGHT_PER_SECOND, ConstantMultiplier, DispatchClass, Weight,
+		WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
+	},
+	PalletId,
 };
 use frame_system::{
 	limits::{BlockLength, BlockWeights},
@@ -377,8 +377,8 @@ parameter_types! {
 }
 
 impl pallet_transaction_payment::Config for Runtime {
-    type Event = Event;
-    type OnChargeTransaction = CurrencyAdapter<Balances, NegativeImbalanceToTreasury>;
+	type Event = Event;
+	type OnChargeTransaction = CurrencyAdapter<Balances, NegativeImbalanceToTreasury>;
 	type WeightToFee = WeightToFee;
 	type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
 	type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
@@ -410,25 +410,25 @@ impl pallet_collective::Config<CouncilCollective> for Runtime {
 }
 
 type EnsureRootOrMoreThanHalfCouncil = EitherOfDiverse<
-    EnsureRoot<AccountId>,
-    EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
+	EnsureRoot<AccountId>,
+	EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
 >;
 type EnsureRootOrAtLeastTwoThirdsCouncil = EitherOfDiverse<
-    EnsureRoot<AccountId>,
-    EnsureProportionAtLeast<AccountId, CouncilCollective, 2, 3>,
+	EnsureRoot<AccountId>,
+	EnsureProportionAtLeast<AccountId, CouncilCollective, 2, 3>,
 >;
 
 impl pallet_membership::Config<pallet_membership::Instance2> for Runtime {
 	type Event = Event;
-    type AddOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type RemoveOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type SwapOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type ResetOrigin = EnsureRootOrAtLeastTwoThirdsCouncil;
-    type PrimeOrigin = EnsureRootOrAtLeastTwoThirdsCouncil;
-    type MembershipInitialized = Council;
-    type MembershipChanged = Council;
-    type MaxMembers = CouncilMaxMembers;
-    type WeightInfo = weights::pallet_membership::WeightInfo<Runtime>;
+	type AddOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type RemoveOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type SwapOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type ResetOrigin = EnsureRootOrAtLeastTwoThirdsCouncil;
+	type PrimeOrigin = EnsureRootOrAtLeastTwoThirdsCouncil;
+	type MembershipInitialized = Council;
+	type MembershipChanged = Council;
+	type MaxMembers = CouncilMaxMembers;
+	type WeightInfo = weights::pallet_membership::WeightInfo<Runtime>;
 }
 
 use frame_support::pallet_prelude::EnsureOrigin;
@@ -436,38 +436,38 @@ use frame_support::pallet_prelude::EnsureOrigin;
 pub struct RootMaxSpendOrigin;
 
 impl EnsureOrigin<Origin> for RootMaxSpendOrigin {
-    type Success = Balance;
+	type Success = Balance;
 
-    fn try_origin(o: Origin) -> Result<Self::Success, Origin> {
-        Result::<frame_system::RawOrigin<_>, Origin>::from(o).and_then(|o| match o {
-            frame_system::RawOrigin::Root => Ok(Balance::MAX),
-            r => Err(Origin::from(r)),
-        })
-    }
+	fn try_origin(o: Origin) -> Result<Self::Success, Origin> {
+		Result::<frame_system::RawOrigin<_>, Origin>::from(o).and_then(|o| match o {
+			frame_system::RawOrigin::Root => Ok(Balance::MAX),
+			r => Err(Origin::from(r)),
+		})
+	}
 
-    #[cfg(feature = "runtime-benchmarks")]
-    fn try_successful_origin() -> Result<Origin, ()> {
-        Ok(Origin::root())
-    }
+	#[cfg(feature = "runtime-benchmarks")]
+	fn try_successful_origin() -> Result<Origin, ()> {
+		Ok(Origin::root())
+	}
 }
 
 impl pallet_treasury::Config for Runtime {
-    type PalletId = TreasuryPalletId;
-    type Event = Event;
-    type Currency = Balances;
-    type MaxApprovals = frame_support::traits::ConstU32<100>;
-    type ApproveOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type RejectOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type OnSlash = ();
-    type ProposalBond = FivePercent;
-    type ProposalBondMinimum = MinimumProposalBond;
+	type PalletId = TreasuryPalletId;
+	type Event = Event;
+	type Currency = Balances;
+	type MaxApprovals = frame_support::traits::ConstU32<100>;
+	type ApproveOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type RejectOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type OnSlash = ();
+	type ProposalBond = FivePercent;
+	type ProposalBondMinimum = MinimumProposalBond;
 	type ProposalBondMaximum = ();
 	type SpendPeriod = Weekly;
 	type SpendFunds = ();
 	type Burn = ZeroPercent;
 	type BurnDestination = ();
-    type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
-    type SpendOrigin = RootMaxSpendOrigin;
+	type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
+	type SpendOrigin = RootMaxSpendOrigin;
 }
 
 parameter_types! {
@@ -497,8 +497,8 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type OutboundXcmpMessageSource = XcmpQueue;
 	type XcmpMessageHandler = XcmpQueue;
-    type ReservedXcmpWeight = ReservedXcmpWeight;
-    type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+	type ReservedXcmpWeight = ReservedXcmpWeight;
+	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 }
 
 impl parachain_info::Config for Runtime {}

--- a/runtime/solo/src/lib.rs
+++ b/runtime/solo/src/lib.rs
@@ -69,9 +69,9 @@ use impls::{CreditToTreasury, NegativeImbalanceToTreasury, OneToOneConversion};
 use types::governance::*;
 
 // Some public reexports..
+pub use frame_system::Call as SystemCall;
 pub use pallet_ajuna_gameregistry;
 pub use pallet_ajuna_matchmaker;
-pub use frame_system::Call as SystemCall;
 pub use pallet_balances::Call as BalancesCall;
 pub use pallet_sidechain;
 pub use pallet_teerex;
@@ -187,7 +187,7 @@ impl pallet_grandpa::Config for Runtime {
 	type KeyOwnerProofSystem = ();
 
 	type KeyOwnerProof =
-	<Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(KeyTypeId, GrandpaId)>>::Proof;
+		<Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(KeyTypeId, GrandpaId)>>::Proof;
 
 	type KeyOwnerIdentification = <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(
 		KeyTypeId,
@@ -402,8 +402,8 @@ impl pallet_democracy::Config for Runtime {
 }
 
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Runtime
-	where
-		Call: From<LocalCall>,
+where
+	Call: From<LocalCall>,
 {
 	fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
 		call: Call,
@@ -449,8 +449,8 @@ impl frame_system::offchain::SigningTypes for Runtime {
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
-	where
-		Call: From<C>,
+where
+	Call: From<C>,
 {
 	type OverarchingCall = Call;
 	type Extrinsic = UncheckedExtrinsic;

--- a/runtime/solo/src/types.rs
+++ b/runtime/solo/src/types.rs
@@ -17,18 +17,18 @@
 pub mod governance {
 	use crate::CouncilCollective;
 	use ajuna_primitives::AccountId;
-    use frame_support::traits::EitherOfDiverse;
-    use frame_system::EnsureRoot;
+	use frame_support::traits::EitherOfDiverse;
+	use frame_system::EnsureRoot;
 	use pallet_collective::{EnsureProportionAtLeast, EnsureProportionMoreThan};
 
-    pub(crate) type EnsureRootOrMoreThanHalfCouncil = EitherOfDiverse<
-        EnsureRoot<AccountId>,
-        EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
-    >;
-    pub(crate) type EnsureRootOrAtLeastTwoThirdsCouncil = EitherOfDiverse<
-        EnsureRoot<AccountId>,
-        EnsureProportionAtLeast<AccountId, CouncilCollective, 2, 3>,
-    >;
+	pub(crate) type EnsureRootOrMoreThanHalfCouncil = EitherOfDiverse<
+		EnsureRoot<AccountId>,
+		EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
+	>;
+	pub(crate) type EnsureRootOrAtLeastTwoThirdsCouncil = EitherOfDiverse<
+		EnsureRoot<AccountId>,
+		EnsureProportionAtLeast<AccountId, CouncilCollective, 2, 3>,
+	>;
 
 	pub(crate) type EnsureAtLeastHalfCouncil =
 		EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 2>;


### PR DESCRIPTION
## Description

See https://ajunanetwork.atlassian.net/browse/PLAT-434 for details. In short:

* Moved seed generation to just after a game is initialized instead of when a winner is declared.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
