### PR TITLE
Consolidate SeasonMetadata into Season

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -213,7 +213,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		#[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
+		#[pallet::weight(10_000)]
 		pub fn new_season(origin: OriginFor<T>, new_season: SeasonOf<T>) -> DispatchResult {
 			Self::ensure_organizer(origin)?;
 			let new_season = Self::ensure_season(new_season)?;
@@ -233,7 +233,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		#[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
+		#[pallet::weight(10_000)]
 		pub fn update_season(
 			origin: OriginFor<T>,
 			season_id: SeasonId,

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -145,7 +145,7 @@ pub mod pallet {
 		/// A new organizer has been set.
 		OrganizerSet { organizer: T::AccountId },
 		/// A new season has been created.
-		NewSeasonCreated(SeasonOf<T>),
+		CreatedSeason(SeasonOf<T>),
 		/// The season configuration for {season_id} has been updated.
 		UpdatedSeason { season_id: SeasonId, season: SeasonOf<T> },
 		/// Global configuration updated.
@@ -229,7 +229,7 @@ pub mod pallet {
 			Seasons::<T>::insert(season_id, &new_season);
 			NextSeasonId::<T>::put(next_season_id);
 
-			Self::deposit_event(Event::NewSeasonCreated(new_season));
+			Self::deposit_event(Event::CreatedSeason(new_season));
 			Ok(())
 		}
 

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -209,6 +209,8 @@ impl Default for Season<MockBlockNumber> {
 		]);
 
 		Self {
+			name: b"cool season".to_vec().try_into().unwrap(),
+			description: b"this is a really cool season".to_vec().try_into().unwrap(),
 			early_start: 1,
 			start: 2,
 			end: 3,

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -102,14 +102,14 @@ mod season {
 			let first_season = Season::default().early_start(1).start(5).end(10);
 			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), first_season.clone()));
 			assert_eq!(AwesomeAvatars::seasons(1), Some(first_season.clone()));
-			System::assert_last_event(mock::Event::AwesomeAvatars(crate::Event::NewSeasonCreated(
+			System::assert_last_event(mock::Event::AwesomeAvatars(crate::Event::CreatedSeason(
 				first_season,
 			)));
 
 			let second_season = Season::default().early_start(11).start(12).end(13);
 			assert_ok!(AwesomeAvatars::new_season(Origin::signed(ALICE), second_season.clone()));
 			assert_eq!(AwesomeAvatars::seasons(2), Some(second_season.clone()));
-			System::assert_last_event(mock::Event::AwesomeAvatars(crate::Event::NewSeasonCreated(
+			System::assert_last_event(mock::Event::AwesomeAvatars(crate::Event::CreatedSeason(
 				second_season,
 			)));
 		});

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -86,8 +86,6 @@ mod organizer {
 mod season {
 	use super::*;
 
-	const SEASON_ID: SeasonId = 1;
-
 	#[test]
 	fn new_season_should_reject_non_organizer_as_caller() {
 		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
@@ -236,7 +234,7 @@ mod season {
 					first_season_update.clone()
 				));
 				System::assert_last_event(mock::Event::AwesomeAvatars(
-					crate::Event::SeasonUpdated(first_season_update, 1),
+					crate::Event::UpdatedSeason { season_id: 1, season: first_season_update },
 				));
 			});
 	}
@@ -362,60 +360,6 @@ mod season {
 					Season::default()
 				),
 				ArithmeticError::Overflow
-			);
-		});
-	}
-
-	#[test]
-	fn update_season_metadata_should_work() {
-		ExtBuilder::default()
-			.organizer(ALICE)
-			.seasons(vec![Season::default()])
-			.build()
-			.execute_with(|| {
-				let metadata = SeasonMetadata::default();
-
-				assert_ok!(AwesomeAvatars::update_season_metadata(
-					Origin::signed(ALICE),
-					SEASON_ID,
-					metadata.clone()
-				));
-
-				System::assert_last_event(mock::Event::AwesomeAvatars(
-					crate::Event::UpdatedSeasonMetadata {
-						season_id: SEASON_ID,
-						season_metadata: metadata.clone(),
-					},
-				));
-
-				assert_eq!(AwesomeAvatars::seasons_metadata(SEASON_ID), Some(metadata));
-			});
-	}
-
-	#[test]
-	fn update_season_metadata_should_fail_if_caller_is_not_organizer() {
-		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
-			assert_noop!(
-				AwesomeAvatars::update_season_metadata(
-					Origin::signed(BOB),
-					SEASON_ID,
-					SeasonMetadata::default()
-				),
-				DispatchError::BadOrigin
-			);
-		});
-	}
-
-	#[test]
-	fn update_season_metadata_should_fail_with_invalid_season_id() {
-		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
-			assert_noop!(
-				AwesomeAvatars::update_season_metadata(
-					Origin::signed(ALICE),
-					SEASON_ID + 10,
-					SeasonMetadata::default()
-				),
-				Error::<Test>::UnknownSeason
 			);
 		});
 	}

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -36,6 +36,8 @@ pub type MintCount = u16;
 
 #[derive(Encode, Decode, MaxEncodedLen, RuntimeDebug, TypeInfo, Clone, PartialEq)]
 pub struct Season<BlockNumber> {
+	pub name: BoundedVec<u8, ConstU32<100>>,
+	pub description: BoundedVec<u8, ConstU32<1_000>>,
 	pub early_start: BlockNumber,
 	pub start: BlockNumber,
 	pub end: BlockNumber,
@@ -44,12 +46,6 @@ pub struct Season<BlockNumber> {
 	pub rarity_tiers_batch_mint: RarityTiers,
 	pub max_variations: u8,
 	pub max_components: u8,
-}
-
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, Eq, PartialEq)]
-pub struct SeasonMetadata {
-	pub name: BoundedVec<u8, ConstU32<100>>,
-	pub description: BoundedVec<u8, ConstU32<1000>>,
 }
 
 pub type SeasonId = u16;


### PR DESCRIPTION
## Description

Combining `SeasonMetadata` into `Season` as I don't see any benefit from the normalisation.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
