### PR TITLE
Refactor Hooks

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -305,7 +305,7 @@ pub mod pallet {
 				ensure!(season.end < next_season.early_start, Error::<T>::SeasonEndTooLate);
 			}
 
-			Self::validate_rarity_tiers(&mut season.rarity_tiers)?;
+			Self::validate_rarity_tiers(&mut season.rarity_tiers_single_mint)?;
 			Self::validate_rarity_tiers(&mut season.rarity_tiers_batch_mint)?;
 
 			Ok(season)
@@ -352,7 +352,7 @@ pub mod pallet {
 				let rarity_tiers = if batched_mint {
 					&season.rarity_tiers_batch_mint
 				} else {
-					&season.rarity_tiers
+					&season.rarity_tiers_single_mint
 				};
 				let mut cumulative_sum = 0;
 				let mut random_tier = rarity_tiers[0].0.clone() as u8;

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -213,7 +213,7 @@ impl Default for Season<MockBlockNumber> {
 			start: 2,
 			end: 3,
 			max_rare_mints: 1,
-			rarity_tiers: tiers.clone(),
+			rarity_tiers_single_mint: tiers.clone(),
 			rarity_tiers_batch_mint: tiers,
 			max_variations: 1,
 			max_components: 1,
@@ -238,8 +238,8 @@ impl Season<MockBlockNumber> {
 		self.max_rare_mints = max_rare_mints;
 		self
 	}
-	pub fn rarity_tiers(mut self, rarity_tiers: RarityTiers) -> Self {
-		self.rarity_tiers = rarity_tiers;
+	pub fn rarity_tiers_single_mint(mut self, rarity_tiers: RarityTiers) -> Self {
+		self.rarity_tiers_single_mint = rarity_tiers;
 		self
 	}
 	pub fn rarity_tiers_batch_mint(mut self, rarity_tiers: RarityTiers) -> Self {

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -101,7 +101,7 @@ impl pallet_ajuna_awesome_avatars::Config for Test {
 #[derive(Default)]
 pub struct ExtBuilder {
 	organizer: Option<MockAccountId>,
-	seasons: Vec<Season<MockBlockNumber>>,
+	seasons: Vec<(SeasonId, Season<MockBlockNumber>)>,
 	mint_availability: bool,
 	mint_cooldown: Option<MockBlockNumber>,
 	mint_fees: Option<MintFees<MockBalance>>,
@@ -114,7 +114,7 @@ impl ExtBuilder {
 		self.organizer = Some(organizer);
 		self
 	}
-	pub fn seasons(mut self, seasons: Vec<Season<MockBlockNumber>>) -> Self {
+	pub fn seasons(mut self, seasons: Vec<(SeasonId, Season<MockBlockNumber>)>) -> Self {
 		self.seasons = seasons;
 		self
 	}
@@ -151,10 +151,8 @@ impl ExtBuilder {
 				Organizer::<Test>::put(organizer);
 			}
 
-			for season in self.seasons {
-				let season_id = AwesomeAvatars::next_season_id();
+			for (season_id, season) in self.seasons {
 				Seasons::<Test>::insert(season_id, season);
-				NextSeasonId::<Test>::put(season_id + 1);
 			}
 
 			GlobalConfigs::<Test>::mutate(|configs| {

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -183,14 +183,15 @@ mod season {
 					(RarityTier::Legendary, 80),
 				]),
 			] {
-				assert_noop!(
-					AwesomeAvatars::upsert_season(
-						Origin::signed(ALICE),
-						1,
-						Season::default().rarity_tiers(duplicated_rarity_tiers)
-					),
-					Error::<Test>::DuplicatedRarityTier
-				);
+				for season in [
+					Season::default().rarity_tiers_single_mint(duplicated_rarity_tiers.clone()),
+					Season::default().rarity_tiers_batch_mint(duplicated_rarity_tiers),
+				] {
+					assert_noop!(
+						AwesomeAvatars::upsert_season(Origin::signed(ALICE), 1, season),
+						Error::<Test>::DuplicatedRarityTier
+					);
+				}
 			}
 		});
 	}
@@ -213,14 +214,15 @@ mod season {
 					(RarityTier::Mythical, 11),
 				]),
 			] {
-				assert_noop!(
-					AwesomeAvatars::upsert_season(
-						Origin::signed(ALICE),
-						1,
-						Season::default().rarity_tiers(incorrect_rarity_tiers)
-					),
-					Error::<Test>::IncorrectRarityPercentages
-				);
+				for season in [
+					Season::default().rarity_tiers_single_mint(incorrect_rarity_tiers.clone()),
+					Season::default().rarity_tiers_batch_mint(incorrect_rarity_tiers),
+				] {
+					assert_noop!(
+						AwesomeAvatars::upsert_season(Origin::signed(ALICE), 1, season,),
+						Error::<Test>::IncorrectRarityPercentages
+					);
+				}
 			}
 		});
 	}
@@ -704,7 +706,7 @@ mod minting {
 		let season = Season::default()
 			.start(1)
 			.end(20)
-			.rarity_tiers(test_rarity_tiers(vec![(RarityTier::Mythical, 100)]));
+			.rarity_tiers_single_mint(test_rarity_tiers(vec![(RarityTier::Mythical, 100)]));
 
 		ExtBuilder::default()
 			.organizer(ALICE)

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -42,10 +42,10 @@ pub struct Season<BlockNumber> {
 	pub start: BlockNumber,
 	pub end: BlockNumber,
 	pub max_rare_mints: MintCount,
-	pub rarity_tiers: RarityTiers,
-	pub rarity_tiers_batch_mint: RarityTiers,
 	pub max_variations: u8,
 	pub max_components: u8,
+	pub rarity_tiers_single_mint: RarityTiers,
+	pub rarity_tiers_batch_mint: RarityTiers,
 }
 
 pub type SeasonId = u16;


### PR DESCRIPTION
## Description

Removing `Hooks` based on offline discussion. Trade-off is that the `mint` and `forge` extrinsics will have small overhead of (de)activating active season.

Changes:
- combine `new_season` and `update_season` into `upsert_season`
- remove Hooks impl block
  - add lazy `toggle_season()` on every mint
- remove duplicated tests for minting
- rename `rarity_tiers` -> `rarity_tiers_single_mint`

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
