### PR TITLE
Refactor into non-scaling soul points

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -445,7 +445,7 @@ pub mod pallet {
 					let avatar_id = Self::random_hash(b"create_avatar", player);
 					let (dna, is_rare) = Self::random_dna(&avatar_id, &season, how_many > 1)?;
 					let soul_points = Self::calculate_soul_points_from_dna(&dna, &season);
-					let avatar = Avatar { season: season_id, dna, souls: soul_points };
+					let avatar = Avatar { season_id, dna, souls: soul_points };
 					Ok((avatar_id, avatar, is_rare))
 				})
 				.collect::<Result<Vec<(AvatarIdOf<T>, Avatar, bool)>, DispatchError>>()?;

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -56,6 +56,7 @@ pub mod pallet {
 	pub(crate) const MAX_AVATARS_PER_PLAYER: u32 = 1_000;
 	pub(crate) const MAX_PERCENTAGE: u8 = 100;
 	pub(crate) const MAX_RANDOM_BYTES: u8 = 32;
+	pub(crate) const FREE_MINT_TRANSFER_FEE: MintCount = 1;
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
@@ -230,7 +231,11 @@ pub mod pallet {
 			let sender = ensure_signed(origin)?;
 
 			let sender_free_mints = FreeMints::<T>::get(&sender)
-				.checked_sub(how_many.checked_add(1).ok_or(ArithmeticError::Overflow)?)
+				.checked_sub(
+					how_many
+						.checked_add(FREE_MINT_TRANSFER_FEE)
+						.ok_or(ArithmeticError::Overflow)?,
+				)
 				.ok_or(Error::<T>::InsufficientFreeMints)?;
 			let dest_free_mints = FreeMints::<T>::get(&dest)
 				.checked_add(how_many)

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -202,27 +202,6 @@ pub mod pallet {
 		}
 
 		#[pallet::weight(10_000)]
-		pub fn set_organizer(origin: OriginFor<T>, organizer: T::AccountId) -> DispatchResult {
-			ensure_root(origin)?;
-			Organizer::<T>::put(&organizer);
-			Self::deposit_event(Event::OrganizerSet { organizer });
-			Ok(())
-		}
-
-		#[pallet::weight(10_000)]
-		pub fn upsert_season(
-			origin: OriginFor<T>,
-			season_id: SeasonId,
-			season: SeasonOf<T>,
-		) -> DispatchResult {
-			Self::ensure_organizer(origin)?;
-			let season = Self::ensure_season(&season_id, season)?;
-			Seasons::<T>::insert(season_id, &season);
-			Self::deposit_event(Event::UpdatedSeason { season_id, season });
-			Ok(())
-		}
-
-		#[pallet::weight(10_000)]
 		pub fn transfer_free_mints(
 			origin: OriginFor<T>,
 			dest: T::AccountId,
@@ -249,17 +228,23 @@ pub mod pallet {
 		}
 
 		#[pallet::weight(10_000)]
-		pub fn issue_free_mints(
+		pub fn set_organizer(origin: OriginFor<T>, organizer: T::AccountId) -> DispatchResult {
+			ensure_root(origin)?;
+			Organizer::<T>::put(&organizer);
+			Self::deposit_event(Event::OrganizerSet { organizer });
+			Ok(())
+		}
+
+		#[pallet::weight(10_000)]
+		pub fn upsert_season(
 			origin: OriginFor<T>,
-			dest: T::AccountId,
-			how_many: MintCount,
+			season_id: SeasonId,
+			season: SeasonOf<T>,
 		) -> DispatchResult {
 			Self::ensure_organizer(origin)?;
-			let dest_free_mints = FreeMints::<T>::get(&dest)
-				.checked_add(how_many)
-				.ok_or(ArithmeticError::Overflow)?;
-			FreeMints::<T>::insert(&dest, dest_free_mints);
-			Self::deposit_event(Event::FreeMintsIssued { to: dest, how_many });
+			let season = Self::ensure_season(&season_id, season)?;
+			Seasons::<T>::insert(season_id, &season);
+			Self::deposit_event(Event::UpdatedSeason { season_id, season });
 			Ok(())
 		}
 
@@ -271,6 +256,21 @@ pub mod pallet {
 			Self::ensure_organizer(origin)?;
 			GlobalConfigs::<T>::put(&new_global_config);
 			Self::deposit_event(Event::UpdatedGlobalConfig(new_global_config));
+			Ok(())
+		}
+
+		#[pallet::weight(10_000)]
+		pub fn issue_free_mints(
+			origin: OriginFor<T>,
+			dest: T::AccountId,
+			how_many: MintCount,
+		) -> DispatchResult {
+			Self::ensure_organizer(origin)?;
+			let dest_free_mints = FreeMints::<T>::get(&dest)
+				.checked_add(how_many)
+				.ok_or(ArithmeticError::Overflow)?;
+			FreeMints::<T>::insert(&dest, dest_free_mints);
+			Self::deposit_event(Event::FreeMintsIssued { to: dest, how_many });
 			Ok(())
 		}
 	}

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -487,7 +487,7 @@ mod minting {
 						.into_iter()
 						.map(|avatar_id| {
 							let (_player, avatar) = AwesomeAvatars::avatars(avatar_id).unwrap();
-							if avatar.season == season_id &&
+							if avatar.season_id == season_id &&
 								avatar
 									.dna
 									.into_iter()

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -50,13 +50,13 @@ pub struct Season<BlockNumber> {
 
 pub type SeasonId = u16;
 pub type Dna = BoundedVec<u8, ConstU32<100>>;
-pub type SoulPoints = u32;
+pub type SoulCount = u32;
 
 #[derive(Encode, Decode, Clone, Default, TypeInfo, MaxEncodedLen)]
 pub struct Avatar {
 	pub season_id: SeasonId,
 	pub dna: Dna,
-	pub souls: SoulPoints,
+	pub souls: SoulCount,
 }
 
 /// Number of avatars to be minted.

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -54,7 +54,7 @@ pub type SoulPoints = u32;
 
 #[derive(Encode, Decode, Clone, Default, TypeInfo, MaxEncodedLen)]
 pub struct Avatar {
-	pub season: SeasonId,
+	pub season_id: SeasonId,
 	pub dna: Dna,
 	pub souls: SoulPoints,
 }


### PR DESCRIPTION
## Description

Based on offline discussion with @darkfriend77, we don't need to scale soul points based on rarity and variation.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
