### PR TITLE
[BAT-367] Refactor MogwaiStruct Storage to BoundedVec

### DIFF
--- a/pallets/battle-mogs/src/mock.rs
+++ b/pallets/battle-mogs/src/mock.rs
@@ -127,6 +127,11 @@ impl ExtBuilder {
 	}
 }
 
+pub fn last_event() -> Event {
+	let mut events = frame_system::Pallet::<Test>::events();
+	events.pop().expect("Event expected").event
+}
+
 /// Run until a particular block.
 pub fn run_to_block(n: u64) {
 	while System::block_number() < n {

--- a/pallets/battle-mogs/src/types.rs
+++ b/pallets/battle-mogs/src/types.rs
@@ -19,7 +19,7 @@ use codec::MaxEncodedLen;
 use frame_support::codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
-#[derive(Encode, Decode, Default, Clone, PartialEq, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode, Debug, Default, Clone, PartialEq, TypeInfo, MaxEncodedLen)]
 pub struct MogwaiStruct<Hash, BlockNumber, Balance, RarityType, PhaseType> {
 	pub id: Hash,
 	pub dna: [[u8; 32]; 2],
@@ -32,7 +32,7 @@ pub struct MogwaiStruct<Hash, BlockNumber, Balance, RarityType, PhaseType> {
 	pub phase: PhaseType,
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, TypeInfo)]
+#[derive(Encode, Decode, Debug, Clone, PartialEq, TypeInfo)]
 pub enum BreedType {
 	DomDom = 0,
 	DomRez = 1,
@@ -40,7 +40,7 @@ pub enum BreedType {
 	RezRez = 3,
 }
 
-#[derive(Encode, Decode, Copy, Clone, PartialEq, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode, Debug, Copy, Clone, PartialEq, TypeInfo, MaxEncodedLen)]
 pub enum RarityType {
 	Common = 0,
 	Uncommon = 1,


### PR DESCRIPTION
## Description

See https://ajunanetwork.atlassian.net/browse/BAT-367 for details. In short: 

* Refactored pallet code to not need the indexed storages previously defined.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
