### PR TITLE
Remove rare avatar minting with refactored mint probability

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -212,7 +212,6 @@ impl Default for Season<MockBlockNumber> {
 			early_start: 1,
 			start: 2,
 			end: 3,
-			max_rare_mints: 1,
 			rarity_tiers_single_mint: tiers.clone(),
 			rarity_tiers_batch_mint: tiers,
 			max_variations: 1,
@@ -232,10 +231,6 @@ impl Season<MockBlockNumber> {
 	}
 	pub fn end(mut self, end: MockBlockNumber) -> Self {
 		self.end = end;
-		self
-	}
-	pub fn max_rare_mints(mut self, max_rare_mints: MintCount) -> Self {
-		self.max_rare_mints = max_rare_mints;
 		self
 	}
 	pub fn rarity_tiers_single_mint(mut self, rarity_tiers: RarityTiers) -> Self {

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -191,31 +191,28 @@ pub fn run_to_block(n: u64) {
 	}
 }
 
-pub fn test_rarity_tiers(rarity_tiers: Vec<(RarityTier, RarityPercent)>) -> RarityTiers {
-	rarity_tiers.try_into().unwrap()
-}
-
 impl Default for Season<MockBlockNumber> {
 	fn default() -> Self {
-		let tiers = test_rarity_tiers(vec![
-			(RarityTier::Common, 50),
-			(RarityTier::Uncommon, 30),
-			(RarityTier::Rare, 12),
-			(RarityTier::Epic, 5),
-			(RarityTier::Legendary, 2),
-			(RarityTier::Mythical, 1),
-		]);
-
 		Self {
 			name: b"cool season".to_vec().try_into().unwrap(),
 			description: b"this is a really cool season".to_vec().try_into().unwrap(),
 			early_start: 1,
 			start: 2,
 			end: 3,
-			rarity_tiers_single_mint: tiers.clone(),
-			rarity_tiers_batch_mint: tiers,
 			max_variations: 1,
 			max_components: 1,
+			tiers: vec![
+				RarityTier::Mythical,
+				RarityTier::Legendary,
+				RarityTier::Epic,
+				RarityTier::Rare,
+				RarityTier::Uncommon,
+				RarityTier::Common,
+			]
+			.try_into()
+			.unwrap(),
+			p_single_mint: vec![50, 30, 15, 4, 1].try_into().unwrap(),
+			p_batch_mint: vec![50, 30, 15, 4, 1].try_into().unwrap(),
 		}
 	}
 }
@@ -233,16 +230,20 @@ impl Season<MockBlockNumber> {
 		self.end = end;
 		self
 	}
-	pub fn rarity_tiers_single_mint(mut self, rarity_tiers: RarityTiers) -> Self {
-		self.rarity_tiers_single_mint = rarity_tiers;
-		self
-	}
-	pub fn rarity_tiers_batch_mint(mut self, rarity_tiers: RarityTiers) -> Self {
-		self.rarity_tiers_batch_mint = rarity_tiers;
-		self
-	}
 	pub fn max_components(mut self, max_components: u8) -> Self {
 		self.max_components = max_components;
+		self
+	}
+	pub fn tiers(mut self, tiers: Vec<RarityTier>) -> Self {
+		self.tiers = tiers.try_into().unwrap();
+		self
+	}
+	pub fn p_single_mint(mut self, percentages: Vec<RarityPercent>) -> Self {
+		self.p_single_mint = percentages.try_into().unwrap();
+		self
+	}
+	pub fn p_batch_mint(mut self, percentages: Vec<RarityPercent>) -> Self {
+		self.p_batch_mint = percentages.try_into().unwrap();
 		self
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -41,7 +41,6 @@ pub struct Season<BlockNumber> {
 	pub early_start: BlockNumber,
 	pub start: BlockNumber,
 	pub end: BlockNumber,
-	pub max_rare_mints: MintCount,
 	pub max_variations: u8,
 	pub max_components: u8,
 	pub rarity_tiers_single_mint: RarityTiers,


### PR DESCRIPTION
## Description

We got the rare avatar minting requirements wrong:
- Rare avatars should only be obtainable through forging (in an upcoming PR)
- An avatar is considered rare when all of its components are of the highest tier

Also the highest tier shouldn't be mint-able so the current mint prob implementation needs refactoring.

Changes:
- removed rare avatar logic (will be re-implemented in a follow up PR in regards to forging)
- refactored `Season` struct
  - moved a few `ensure!`s as methods
- removed soul points calculation logic because we just want to get a random number between 1 and 100
  - (so a low tier avatar can have amazing soul points and vice versa)

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
