### PR TITLE
Move constants into storage

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -53,7 +53,6 @@ pub mod pallet {
 		GlobalConfig<BalanceOf<T>, <T as frame_system::Config>::BlockNumber>;
 
 	pub(crate) const MAX_PERCENTAGE: u8 = 100;
-	pub(crate) const FREE_MINT_TRANSFER_FEE: MintCount = 1;
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
@@ -100,6 +99,7 @@ pub mod pallet {
 					six: (1_000_000_000_000_u64 * 45 / 100).unique_saturated_into(),
 				},
 				cooldown: 5_u8.into(),
+				free_mint_transfer_fee: 1,
 			},
 			forge: ForgeConfig { open: false, min_sacrifices: 1, max_sacrifices: 4 },
 			trade: TradeConfig { open: false },
@@ -257,11 +257,11 @@ pub mod pallet {
 			how_many: MintCount,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
-
+			let GlobalConfig { mint, .. } = Self::global_configs();
 			let sender_free_mints = FreeMints::<T>::get(&sender)
 				.checked_sub(
 					how_many
-						.checked_add(FREE_MINT_TRANSFER_FEE)
+						.checked_add(mint.free_mint_transfer_fee)
 						.ok_or(ArithmeticError::Overflow)?,
 				)
 				.ok_or(Error::<T>::InsufficientFreeMints)?;

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -101,6 +101,7 @@ impl pallet_ajuna_awesome_avatars::Config for Test {
 pub struct ExtBuilder {
 	organizer: Option<MockAccountId>,
 	seasons: Vec<(SeasonId, Season<MockBlockNumber>)>,
+	max_avatars_per_player: Option<u32>,
 	mint_open: bool,
 	mint_cooldown: Option<MockBlockNumber>,
 	mint_fees: Option<MintFees<MockBalance>>,
@@ -119,6 +120,10 @@ impl ExtBuilder {
 	}
 	pub fn seasons(mut self, seasons: Vec<(SeasonId, Season<MockBlockNumber>)>) -> Self {
 		self.seasons = seasons;
+		self
+	}
+	pub fn max_avatars_per_player(mut self, max_avatars_per_player: u32) -> Self {
+		self.max_avatars_per_player = Some(max_avatars_per_player);
 		self
 	}
 	pub fn mint_open(mut self, mint_open: bool) -> Self {
@@ -175,28 +180,24 @@ impl ExtBuilder {
 				Seasons::<Test>::insert(season_id, season);
 			}
 
-			GlobalConfigs::<Test>::mutate(|config| config.mint.open = self.mint_open);
-			if let Some(mint_cooldown) = self.mint_cooldown {
-				GlobalConfigs::<Test>::mutate(|config| {
-					config.mint.cooldown = mint_cooldown;
-				});
+			if let Some(x) = self.max_avatars_per_player {
+				GlobalConfigs::<Test>::mutate(|config| config.max_avatars_per_player = x);
 			}
-			if let Some(mint_fees) = self.mint_fees {
-				GlobalConfigs::<Test>::mutate(|config| {
-					config.mint.fees = mint_fees;
-				});
+
+			GlobalConfigs::<Test>::mutate(|config| config.mint.open = self.mint_open);
+			if let Some(x) = self.mint_cooldown {
+				GlobalConfigs::<Test>::mutate(|config| config.mint.cooldown = x);
+			}
+			if let Some(x) = self.mint_fees {
+				GlobalConfigs::<Test>::mutate(|config| config.mint.fees = x);
 			}
 
 			GlobalConfigs::<Test>::mutate(|config| config.forge.open = self.forge_open);
-			if let Some(forge_min_sacrifices) = self.forge_min_sacrifices {
-				GlobalConfigs::<Test>::mutate(|config| {
-					config.forge.min_sacrifices = forge_min_sacrifices;
-				});
+			if let Some(x) = self.forge_min_sacrifices {
+				GlobalConfigs::<Test>::mutate(|config| config.forge.min_sacrifices = x);
 			}
-			if let Some(forge_max_sacrifices) = self.forge_max_sacrifices {
-				GlobalConfigs::<Test>::mutate(|config| {
-					config.forge.max_sacrifices = forge_max_sacrifices;
-				});
+			if let Some(x) = self.forge_max_sacrifices {
+				GlobalConfigs::<Test>::mutate(|config| config.forge.max_sacrifices = x);
 			}
 
 			GlobalConfigs::<Test>::mutate(|config| config.trade.open = self.trade_open);

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -510,16 +510,18 @@ mod minting {
 
 	#[test]
 	fn mint_should_reject_when_max_ownership_has_reached() {
+		let max_avatars_per_player = 7;
 		let avatar_ids = BoundedAvatarIdsOf::<Test>::try_from(
-			(0..MAX_AVATARS_PER_PLAYER)
+			(0..max_avatars_per_player)
 				.map(|_| sp_core::H256::default())
 				.collect::<Vec<_>>(),
 		)
 		.unwrap();
-		assert!(avatar_ids.is_full());
+		assert_eq!(avatar_ids.len(), max_avatars_per_player);
 
 		ExtBuilder::default()
 			.seasons(vec![(SeasonId::default(), Season::default())])
+			.max_avatars_per_player(max_avatars_per_player as u32)
 			.mint_open(true)
 			.balances(vec![(ALICE, 1_234_567_890_123_456)])
 			.free_mints(vec![(ALICE, 10)])

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -233,6 +233,7 @@ pub struct TradeConfig {
 
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
 pub struct GlobalConfig<Balance, BlockNumber> {
+	pub max_avatars_per_player: u32,
 	pub mint: MintConfig<Balance, BlockNumber>,
 	pub forge: ForgeConfig,
 	pub trade: TradeConfig,

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -217,6 +217,7 @@ pub struct MintConfig<Balance, BlockNumber> {
 	pub open: bool,
 	pub fees: MintFees<Balance>,
 	pub cooldown: BlockNumber,
+	pub free_mint_transfer_fee: MintCount,
 }
 
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]


### PR DESCRIPTION
## Description

Moving a couple of constants into `GlobalConfigs` storage so the organizer can update them without runtime upgrade.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
