### PR TITLE
Fix tier ordering

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -92,7 +92,7 @@ pub mod pallet {
 		GlobalConfig {
 			max_avatars_per_player: 1_000,
 			mint: MintConfig {
-				open: false,
+				open: true,
 				fees: MintFees {
 					one: (1_000_000_000_000_u64 * 55 / 100).unique_saturated_into(),
 					three: (1_000_000_000_000_u64 * 50 / 100).unique_saturated_into(),
@@ -101,8 +101,8 @@ pub mod pallet {
 				cooldown: 5_u8.into(),
 				free_mint_transfer_fee: 1,
 			},
-			forge: ForgeConfig { open: false, min_sacrifices: 1, max_sacrifices: 4 },
-			trade: TradeConfig { open: false },
+			forge: ForgeConfig { open: true, min_sacrifices: 1, max_sacrifices: 4 },
+			trade: TradeConfig { open: true },
 		}
 	}
 	#[pallet::storage]

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -426,7 +426,7 @@ pub mod pallet {
 		) -> (u8, u8) {
 			let hash = hash.as_ref();
 			let random_tier = {
-				let random_p = hash[index] % MAX_PERCENTAGE;
+				let random_p = (hash[index] % MAX_PERCENTAGE) as u16;
 				let p = if batched_mint { &season.p_batch_mint } else { &season.p_single_mint };
 				let mut cumulative_sum = 0;
 				let mut random_tier = season.tiers[0].clone() as u8;

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -232,12 +232,12 @@ impl Default for Season<MockBlockNumber> {
 			max_variations: 2,
 			max_components: 2,
 			tiers: vec![
-				RarityTier::Mythical,
-				RarityTier::Legendary,
-				RarityTier::Epic,
-				RarityTier::Rare,
-				RarityTier::Uncommon,
 				RarityTier::Common,
+				RarityTier::Uncommon,
+				RarityTier::Rare,
+				RarityTier::Epic,
+				RarityTier::Legendary,
+				RarityTier::Mythical,
 			]
 			.try_into()
 			.unwrap(),

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -87,6 +87,25 @@ mod season {
 	use super::*;
 
 	#[test]
+	fn season_validate_should_mutate_correctly() {
+		let mut season = Season::default()
+			.tiers(vec![RarityTier::Rare, RarityTier::Common, RarityTier::Epic])
+			.p_single_mint(vec![20, 80])
+			.p_batch_mint(vec![60, 40]);
+		assert_ok!(season.validate::<Test>());
+
+		// check for ascending order sort
+		assert_eq!(
+			season.tiers.to_vec(),
+			vec![RarityTier::Common, RarityTier::Rare, RarityTier::Epic]
+		);
+
+		// check for descending order sort
+		assert_eq!(season.p_single_mint.to_vec(), vec![80, 20]);
+		assert_eq!(season.p_batch_mint.to_vec(), vec![60, 40]);
+	}
+
+	#[test]
 	fn upsert_season_should_work() {
 		ExtBuilder::default()
 			.organizer(ALICE)

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -62,7 +62,9 @@ impl<BlockNumber: PartialOrd> Season<BlockNumber> {
 	}
 
 	fn sort(&mut self) {
-		self.tiers.sort_by(|a, b| b.cmp(a));
+		// tiers are sorted in ascending order
+		self.tiers.sort_by(|a, b| a.cmp(b));
+		// probabilities are sorted in descending order
 		self.p_single_mint.sort_by(|a, b| b.cmp(a));
 		self.p_batch_mint.sort_by(|a, b| b.cmp(a));
 	}

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -33,7 +33,7 @@ pub enum RarityTier {
 	Mythical = 5,
 }
 
-pub type RarityPercent = u8;
+pub type RarityPercent = u16;
 pub type MintCount = u16;
 
 #[derive(Encode, Decode, MaxEncodedLen, RuntimeDebug, TypeInfo, Clone, PartialEq)]
@@ -102,8 +102,8 @@ impl<BlockNumber: PartialOrd> Season<BlockNumber> {
 	fn validate_percentages<T: Config>(&self) -> DispatchResult {
 		let p_1 = self.p_single_mint.iter().sum::<RarityPercent>();
 		let p_2 = self.p_batch_mint.iter().sum::<RarityPercent>();
-		ensure!(p_1 == MAX_PERCENTAGE, Error::<T>::IncorrectRarityPercentages);
-		ensure!(p_2 == MAX_PERCENTAGE, Error::<T>::IncorrectRarityPercentages);
+		ensure!(p_1 == MAX_PERCENTAGE as u16, Error::<T>::IncorrectRarityPercentages);
+		ensure!(p_2 == MAX_PERCENTAGE as u16, Error::<T>::IncorrectRarityPercentages);
 		ensure!(self.p_single_mint.len() < self.tiers.len(), Error::<T>::TooManyRarityPercentages);
 		ensure!(self.p_batch_mint.len() < self.tiers.len(), Error::<T>::TooManyRarityPercentages);
 		Ok(())


### PR DESCRIPTION
## Description

Season tiers were sorted in descending order so all minted avatars were of the higher tier.

Changes:
- make tiers sorted in ascending order (probabilities are sorted in descending)
- make all extrinsics available by default
- change `RarityPercent` -> u16 to avoid it being rendered as byte array from Polkadot UI

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
