### PR TITLE
[BAT-385] Ensure no actions, when price set

### DIFF
--- a/pallets/battle-mogs/src/mock.rs
+++ b/pallets/battle-mogs/src/mock.rs
@@ -31,6 +31,7 @@ pub type MockAccountId = u32;
 pub type MockBlockNumber = u64;
 pub type MockBalance = u64;
 pub type MockIndex = u64;
+pub type MockMogwaiId = <Test as frame_system::Config>::Hash;
 
 use frame_support_test::TestRandomness;
 


### PR DESCRIPTION
## Description

See https://ajunanetwork.atlassian.net/browse/BAT-385 for details. In short:

* Added additional checks to restrict actions performable on a mogwai on sale
* Added new error variant to reflect invalid state for a mogwai on sale


## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
