### PR TITLE
[AAATAR-303] Premature season ending

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -87,6 +87,10 @@ pub mod pallet {
 	#[pallet::getter(fn seasons)]
 	pub type Seasons<T: Config> = StorageMap<_, Identity, SeasonId, SeasonOf<T>, OptionQuery>;
 
+	#[pallet::storage]
+	#[pallet::getter(fn season_max_tier_forges)]
+	pub type SeasonMaxTierForges<T: Config> = StorageValue<_, u32, ValueQuery>;
+
 	#[pallet::type_value]
 	pub fn DefaultGlobalConfig<T: Config>() -> GlobalConfigOf<T> {
 		GlobalConfig {
@@ -602,6 +606,10 @@ pub mod pallet {
 						}
 					}
 				}
+			}
+
+			if leader.min_tier::<T>()? == max_tier {
+				SeasonMaxTierForges::<T>::mutate(|x| x.saturating_inc());
 			}
 
 			Avatars::<T>::insert(leader_id, (player, leader));

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -279,6 +279,10 @@ impl Season<MockBlockNumber> {
 		self.end = end;
 		self
 	}
+	pub fn max_tier_forges(mut self, max_tier_forges: u32) -> Self {
+		self.max_tier_forges = max_tier_forges;
+		self
+	}
 	pub fn max_components(mut self, max_components: u8) -> Self {
 		self.max_components = max_components;
 		self

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -247,6 +247,7 @@ impl Default for Season<MockBlockNumber> {
 			early_start: 1,
 			start: 2,
 			end: 3,
+			max_tier_forges: 10,
 			max_variations: 2,
 			max_components: 2,
 			tiers: vec![

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -43,6 +43,7 @@ pub struct Season<BlockNumber> {
 	pub early_start: BlockNumber,
 	pub start: BlockNumber,
 	pub end: BlockNumber,
+	pub max_tier_forges: u32,
 	pub max_variations: u8,
 	pub max_components: u8,
 	pub tiers: BoundedVec<RarityTier, ConstU32<6>>,

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -152,7 +152,7 @@ impl Avatar {
 	}
 
 	pub(crate) fn upgradable_indexes<T: Config>(&self) -> Result<Vec<usize>, DispatchError> {
-		let min_tier = self.dna.iter().map(|x| *x >> 4).min().ok_or(Error::<T>::IncorrectDna)?;
+		let min_tier = self.min_tier::<T>()?;
 		Ok(self
 			.dna
 			.iter()
@@ -160,6 +160,14 @@ impl Avatar {
 			.filter(|(_, x)| (*x >> 4) == min_tier)
 			.map(|(i, _)| i)
 			.collect::<Vec<usize>>())
+	}
+
+	fn min_tier<T: Config>(&self) -> Result<u8, DispatchError> {
+		self.dna
+			.iter()
+			.map(|x| *x >> 4)
+			.min()
+			.ok_or_else(|| Error::<T>::IncorrectDna.into())
 	}
 
 	pub(crate) fn compare(

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -162,7 +162,7 @@ impl Avatar {
 			.collect::<Vec<usize>>())
 	}
 
-	fn min_tier<T: Config>(&self) -> Result<u8, DispatchError> {
+	pub(crate) fn min_tier<T: Config>(&self) -> Result<u8, DispatchError> {
 		self.dna
 			.iter()
 			.map(|x| *x >> 4)


### PR DESCRIPTION
## Description

Re: [AAATAR-303](https://ajunanetwork.atlassian.net/browse/AAATAR-303)

Changes:
- added `SeasonMaxTierForges` storage to keep track of seasonal highest tier forges
- added `IsSeasonPrematurelyEnded` storage which gets updated when `max_tier_forges` has reached

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
