### PR TITLE
[BAT-357] Overflow tests on the intrinsics and balance changes

### DIFF
--- a/pallets/battle-mogs/src/mock.rs
+++ b/pallets/battle-mogs/src/mock.rs
@@ -90,7 +90,7 @@ impl pallet_balances::Config for Test {
 	type MaxLocks = ();
 	type MaxReserves = ();
 	type ReserveIdentifier = [u8; 8];
-	type Balance = u64;
+	type Balance = MockBalance;
 	type Event = Event;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
@@ -109,14 +109,16 @@ pub struct ExtBuilder;
 
 impl ExtBuilder {
 	pub fn build(self) -> sp_io::TestExternalities {
-		let balance = 1_000_000_000_000_000_000_u64;
-		let config = GenesisConfig {
-			system: Default::default(),
-			balances: BalancesConfig {
-				balances: [(ALICE, balance), (BOB, balance), (CHARLIE, balance)].to_vec(),
-			},
-			//battleMogs: Default::default(),
-		};
+		let balance = 1_000_000_000_000_000_000;
+		self.build_with_balances([(ALICE, balance), (BOB, balance), (CHARLIE, balance)].to_vec())
+	}
+
+	pub fn build_with_balances(
+		self,
+		balances: Vec<(MockAccountId, MockBalance)>,
+	) -> sp_io::TestExternalities {
+		let config =
+			GenesisConfig { system: Default::default(), balances: BalancesConfig { balances } };
 
 		let mut ext: sp_io::TestExternalities = config.build_storage().unwrap().into();
 		ext.execute_with(|| System::set_block_number(1));


### PR DESCRIPTION
## Description

See https://ajunanetwork.atlassian.net/browse/BAT-357 for details. In short:

* `BattleMogs::sacrifice`: Added balance check which limits the amount of currency the account that sacrificed the mogwai receives from it, so that it never exceeds the maximum balance.
* `BattleMogs::sacrifice_into`: Replace simple `AddAssign` with `saturating_add` to avoid overflowing when adding mogwai intrinsics.
* `BattleMogs::morph_mogwai`: Updated `tip_mogwai` to use `saturating_add` insead of `AddAssign`
* `BattleMogs::breed_mogwai`: Updated `tip_mogwai` to use `saturating_add` insead of `AddAssign`

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [x] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
