### PR TITLE
[AAATAR-305] Early season access

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -651,15 +651,12 @@ pub mod pallet {
 				// deactivate season (and active if condition met)
 				if now > season.end {
 					Self::deactivate_season(current_season_id);
+					season_deactivated = true;
 					let next_season_id = current_season_id.saturating_add(1);
-					match Self::seasons(next_season_id) {
-						Some(next_season) =>
-							if next_season.is_active(now) {
-								Self::activate_season(next_season_id);
-							},
-						None => {
-							season_deactivated = true;
-						},
+					if let Some(next_season) = Self::seasons(next_season_id) {
+						if next_season.is_active(now) {
+							Self::activate_season(next_season_id);
+						}
 					}
 				}
 			}

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -351,7 +351,7 @@ mod minting {
 		let expected_nonce_increment = 1 as MockIndex;
 		let mut expected_nonce = 0;
 		let mut initial_balance = 1_234_567_890_123_456;
-		let mut initial_free_mints = 11;
+		let mut initial_free_mints = 12;
 		let mut owned_avatar_count = 0;
 		let fees = MintFees { one: 12, three: 34, six: 56 };
 		let mint_cooldown = 1;
@@ -376,7 +376,7 @@ mod minting {
 					assert!(!AAvatars::current_season_status().active);
 
 					// single mint
-					run_to_block(season_1.early_start + 1);
+					run_to_block(season_1.start);
 					assert_ok!(AAvatars::mint(
 						Origin::signed(ALICE),
 						MintOption { count: MintPackSize::One, mint_type: mint_type.clone() }
@@ -498,7 +498,7 @@ mod minting {
 			.mint_open(false)
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				for count in [MintPackSize::One, MintPackSize::Three, MintPackSize::Six] {
 					for mint_type in [MintType::Normal, MintType::Free] {
 						assert_noop!(
@@ -561,7 +561,7 @@ mod minting {
 			.free_mints(vec![(ALICE, 10)])
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				Owners::<Test>::insert(ALICE, avatar_ids);
 				for count in [MintPackSize::One, MintPackSize::Three, MintPackSize::Six] {
 					for mint_type in [MintType::Normal, MintType::Free] {
@@ -623,10 +623,14 @@ mod minting {
 
 	#[test]
 	fn mint_should_reject_when_balance_is_insufficient() {
+		let season = Season::default();
+
 		ExtBuilder::default()
-			.seasons(vec![(1, Season::default())])
+			.seasons(vec![(1, season.clone())])
 			.build()
 			.execute_with(|| {
+				run_to_block(season.start);
+
 				for mint_count in [MintPackSize::One, MintPackSize::Three, MintPackSize::Six] {
 					assert_noop!(
 						AAvatars::mint(
@@ -780,7 +784,7 @@ mod forging {
 			.forge_max_sacrifices(4)
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					Origin::signed(BOB),
 					MintOption { count: MintPackSize::One, mint_type: MintType::Free }
@@ -867,7 +871,7 @@ mod forging {
 			.build()
 			.execute_with(|| {
 				// prepare avatars to forge
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					Origin::signed(BOB),
 					MintOption { count: MintPackSize::Six, mint_type: MintType::Free }
@@ -963,7 +967,7 @@ mod forging {
 			.build()
 			.execute_with(|| {
 				// prepare avatars to forge
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					Origin::signed(BOB),
 					MintOption { count: MintPackSize::Six, mint_type: MintType::Free }
@@ -1015,7 +1019,7 @@ mod forging {
 			.forge_open(false)
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				assert_noop!(
 					AAvatars::forge(Origin::signed(ALICE), H256::default(), Vec::new()),
 					Error::<Test>::ForgeClosed,
@@ -1045,7 +1049,7 @@ mod forging {
 			.forge_max_sacrifices(max_sacrifices)
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 
 				for i in 0..min_sacrifices {
 					assert_noop!(
@@ -1115,7 +1119,7 @@ mod forging {
 			.forge_max_sacrifices(max_sacrifices)
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				for _ in 0..max_sacrifices {
 					assert_ok!(AAvatars::mint(
 						Origin::signed(ALICE),
@@ -1152,7 +1156,7 @@ mod forging {
 			.forge_max_sacrifices(max_sacrifices)
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				for player in [ALICE, BOB] {
 					for _ in 0..max_sacrifices {
 						assert_ok!(AAvatars::mint(
@@ -1190,7 +1194,7 @@ mod forging {
 			.forge_max_sacrifices(max_sacrifices)
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				for _ in 0..max_sacrifices {
 					assert_ok!(AAvatars::mint(
 						Origin::signed(ALICE),
@@ -1222,7 +1226,7 @@ mod forging {
 			.mint_fees(MintFees { one: 1, three: 1, six: 1 })
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					Origin::signed(ALICE),
 					MintOption { count: MintPackSize::Six, mint_type: MintType::Normal }
@@ -1269,7 +1273,7 @@ mod trading {
 			.mint_fees(MintFees { one: 1, three: 1, six: 1 })
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					Origin::signed(BOB),
 					MintOption { count: MintPackSize::One, mint_type: MintType::Normal }
@@ -1318,7 +1322,7 @@ mod trading {
 			.mint_fees(MintFees { one: 1, three: 1, six: 1 })
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					Origin::signed(BOB),
 					MintOption { count: MintPackSize::One, mint_type: MintType::Normal }
@@ -1341,7 +1345,7 @@ mod trading {
 			.mint_fees(MintFees { one: 1, three: 1, six: 1 })
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					Origin::signed(BOB),
 					MintOption { count: MintPackSize::One, mint_type: MintType::Normal }
@@ -1390,7 +1394,7 @@ mod trading {
 			.mint_fees(MintFees { one: 1, three: 1, six: 1 })
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					Origin::signed(BOB),
 					MintOption { count: MintPackSize::One, mint_type: MintType::Normal }
@@ -1430,7 +1434,7 @@ mod trading {
 			.mint_fees(mint_fees)
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					Origin::signed(BOB),
 					MintOption { count: MintPackSize::One, mint_type: MintType::Normal }
@@ -1507,7 +1511,7 @@ mod trading {
 			.mint_fees(MintFees { one: 1, three: 1, six: 1 })
 			.build()
 			.execute_with(|| {
-				run_to_block(season.early_start + 1);
+				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					Origin::signed(BOB),
 					MintOption { count: MintPackSize::One, mint_type: MintType::Normal }

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -623,18 +623,23 @@ mod minting {
 			.build()
 			.execute_with(|| {
 				for mint_count in [MintPackSize::One, MintPackSize::Three, MintPackSize::Six] {
-					for (mint_type, error) in [
-						(MintType::Normal, Error::<Test>::InsufficientFunds),
-						(MintType::Free, Error::<Test>::InsufficientFreeMints),
-					] {
-						assert_noop!(
-							AAvatars::mint(
-								Origin::signed(ALICE),
-								MintOption { count: mint_count, mint_type }
-							),
-							error,
-						);
-					}
+					assert_noop!(
+						AAvatars::mint(
+							Origin::signed(ALICE),
+							MintOption { count: mint_count, mint_type: MintType::Normal }
+						),
+						pallet_balances::Error::<Test>::InsufficientBalance
+					);
+				}
+
+				for mint_count in [MintPackSize::One, MintPackSize::Three, MintPackSize::Six] {
+					assert_noop!(
+						AAvatars::mint(
+							Origin::signed(ALICE),
+							MintOption { count: mint_count, mint_type: MintType::Free }
+						),
+						Error::<Test>::InsufficientFreeMints
+					);
 				}
 			});
 	}
@@ -1507,7 +1512,7 @@ mod trading {
 				assert_ok!(AAvatars::set_price(Origin::signed(BOB), avatar_for_sale, price));
 				assert_noop!(
 					AAvatars::buy(Origin::signed(ALICE), avatar_for_sale),
-					Error::<Test>::InsufficientFunds
+					pallet_balances::Error::<Test>::InsufficientBalance
 				);
 			});
 	}

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -452,8 +452,13 @@ mod minting {
 						avatar_ids: AAvatars::owners(ALICE)[4..=9].to_vec(),
 					}));
 
-					// check for season ending
+					// check for season ending (we allow one extra mint before closing season)
 					run_to_block(season_1.end + 1);
+					assert_ok!(AAvatars::mint(
+						Origin::signed(ALICE),
+						MintOption { count: MintPackSize::One, mint_type: mint_type.clone() }
+					));
+					expected_nonce += 1;
 					assert_noop!(
 						AAvatars::mint(
 							Origin::signed(ALICE),

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -36,6 +36,12 @@ pub enum RarityTier {
 pub type RarityPercent = u16;
 pub type MintCount = u16;
 
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Default)]
+pub struct SeasonStatus {
+	pub active: bool,
+	pub prematurely_ended: bool,
+}
+
 #[derive(Encode, Decode, MaxEncodedLen, RuntimeDebug, TypeInfo, Clone, PartialEq)]
 pub struct Season<BlockNumber> {
 	pub name: BoundedVec<u8, ConstU32<100>>,

--- a/pallets/ajuna-awesome-avatars/src/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types.rs
@@ -39,6 +39,7 @@ pub type MintCount = u16;
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Default)]
 pub struct SeasonStatus {
 	pub active: bool,
+	pub early: bool,
 	pub prematurely_ended: bool,
 }
 
@@ -59,7 +60,11 @@ pub struct Season<BlockNumber> {
 
 impl<BlockNumber: PartialOrd> Season<BlockNumber> {
 	pub(crate) fn is_active(&self, now: BlockNumber) -> bool {
-		now >= self.early_start && now <= self.end
+		now >= self.start && now <= self.end
+	}
+
+	pub(crate) fn is_early(&self, now: BlockNumber) -> bool {
+		now >= self.early_start && now < self.start
 	}
 
 	pub(crate) fn validate<T: Config>(&mut self) -> DispatchResult {


### PR DESCRIPTION
## Description

Re: [AAATAR-305](https://ajunanetwork.atlassian.net/browse/AAATAR-305)

Changes:
- consolidate all boolean `StorageValue` into `CurrentSeasonStatus`
- remove obsolete balance checks (since extrinsics are atomic now)
  - also bubble up pallet_balance errors
- fix a mistake in season ending logic
- add `SeasonStatus.early` to handle early season access

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
