### PR TITLE
Enrich `AccountInfo` with last minted block number

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/benchmarking.rs
+++ b/pallets/ajuna-awesome-avatars/src/benchmarking.rs
@@ -24,7 +24,7 @@ use crate::{
 use frame_benchmarking::{benchmarks, vec};
 use frame_support::traits::{Currency, Get};
 use frame_system::RawOrigin;
-use sp_runtime::traits::UniqueSaturatedFrom;
+use sp_runtime::traits::{UniqueSaturatedFrom, Zero};
 
 fn account<T: Config>(name: &'static str) -> T::AccountId {
 	let index = 0;
@@ -82,7 +82,7 @@ fn create_avatars<T: Config>(name: &'static str, n: u32) -> Result<(), &'static 
 			&MintOption { mint_type: MintType::Free, count: MintPackSize::One },
 			season_id,
 		)?;
-		LastMintedBlockNumbers::<T>::remove(&player);
+		Accounts::<T>::mutate(&player, |account| account.stats.mint.last = Zero::zero());
 	}
 	Ok(())
 }

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -708,9 +708,11 @@ pub mod pallet {
 			Owners::<T>::insert(player, remaining_avatar_ids);
 
 			Accounts::<T>::mutate(&player, |AccountInfo { stats, .. }| {
+				let current_block = <frame_system::Pallet<T>>::block_number();
 				if stats.forge.first.is_zero() {
-					stats.forge.first = <frame_system::Pallet<T>>::block_number();
+					stats.forge.first = current_block;
 				}
+				stats.forge.last = current_block;
 
 				stats.forge.total.saturating_inc();
 				stats.forge.current_season.saturating_inc();

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -390,8 +390,8 @@ pub mod pallet {
 			});
 			Trade::<T>::remove(&avatar_id);
 
-			Accounts::<T>::mutate(&buyer, |account| account.stats.bought.saturating_inc());
-			Accounts::<T>::mutate(&seller, |account| account.stats.sold.saturating_inc());
+			Accounts::<T>::mutate(&buyer, |account| account.stats.trade.bought.saturating_inc());
+			Accounts::<T>::mutate(&seller, |account| account.stats.trade.sold.saturating_inc());
 
 			Self::deposit_event(Event::AvatarTraded { avatar_id, from: seller, to: buyer });
 			Ok(())
@@ -607,13 +607,13 @@ pub mod pallet {
 
 			LastMintedBlockNumbers::<T>::insert(&player, current_block);
 			Accounts::<T>::mutate(&player, |AccountInfo { stats, .. }| {
-				if stats.first_minted.is_zero() {
-					stats.first_minted = current_block;
+				if stats.mint.first.is_zero() {
+					stats.mint.first = current_block;
 				}
 
 				let count = mint_option.count as Stat;
-				stats.minted = stats.minted.saturating_add(count);
-				stats.current_season_minted = stats.current_season_minted.saturating_add(count);
+				stats.mint.total = stats.mint.total.saturating_add(count);
+				stats.mint.current_season = stats.mint.current_season.saturating_add(count);
 			});
 
 			Self::deposit_event(Event::AvatarsMinted { avatar_ids: generated_avatar_ids });
@@ -712,12 +712,12 @@ pub mod pallet {
 			Owners::<T>::insert(player, remaining_avatar_ids);
 
 			Accounts::<T>::mutate(&player, |AccountInfo { stats, .. }| {
-				if stats.first_forged.is_zero() {
-					stats.first_forged = <frame_system::Pallet<T>>::block_number();
+				if stats.forge.first.is_zero() {
+					stats.forge.first = <frame_system::Pallet<T>>::block_number();
 				}
 
-				stats.forged.saturating_inc();
-				stats.current_season_forged.saturating_inc();
+				stats.forge.total.saturating_inc();
+				stats.forge.current_season.saturating_inc();
 			});
 
 			Self::deposit_event(Event::AvatarForged { avatar_id: *leader_id, upgraded_components });
@@ -809,8 +809,8 @@ pub mod pallet {
 
 		fn reset_seasonal_stats(who: &T::AccountId) {
 			Accounts::<T>::mutate(who, |account| {
-				account.stats.current_season_minted = Zero::zero();
-				account.stats.current_season_forged = Zero::zero();
+				account.stats.mint.current_season = Zero::zero();
+				account.stats.forge.current_season = Zero::zero();
 			});
 		}
 	}

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -444,13 +444,13 @@ mod minting {
 					current_season_minted_count += 1;
 					assert_eq!(System::account_nonce(ALICE), expected_nonce);
 					assert_eq!(AAvatars::owners(ALICE).len(), owned_avatar_count);
-					assert_eq!(AAvatars::accounts(ALICE).stats.minted, minted_count);
+					assert_eq!(AAvatars::accounts(ALICE).stats.mint.total, minted_count);
 					assert_eq!(
-						AAvatars::accounts(ALICE).stats.current_season_minted,
+						AAvatars::accounts(ALICE).stats.mint.current_season,
 						current_season_minted_count
 					);
 					assert!(AAvatars::current_season_status().active);
-					assert_eq!(AAvatars::accounts(ALICE).stats.first_minted, season_1.start);
+					assert_eq!(AAvatars::accounts(ALICE).stats.mint.first, season_1.start);
 					System::assert_has_event(mock::Event::AAvatars(crate::Event::SeasonStarted(1)));
 					System::assert_last_event(mock::Event::AAvatars(crate::Event::AvatarsMinted {
 						avatar_ids: vec![AAvatars::owners(ALICE)[0]],
@@ -481,9 +481,9 @@ mod minting {
 					current_season_minted_count += 3;
 					assert_eq!(System::account_nonce(ALICE), expected_nonce);
 					assert_eq!(AAvatars::owners(ALICE).len(), owned_avatar_count);
-					assert_eq!(AAvatars::accounts(ALICE).stats.minted, minted_count);
+					assert_eq!(AAvatars::accounts(ALICE).stats.mint.total, minted_count);
 					assert_eq!(
-						AAvatars::accounts(ALICE).stats.current_season_minted,
+						AAvatars::accounts(ALICE).stats.mint.current_season,
 						current_season_minted_count
 					);
 					assert!(AAvatars::current_season_status().active);
@@ -517,9 +517,9 @@ mod minting {
 					current_season_minted_count += 6;
 					assert_eq!(System::account_nonce(ALICE), expected_nonce);
 					assert_eq!(AAvatars::owners(ALICE).len(), owned_avatar_count);
-					assert_eq!(AAvatars::accounts(ALICE).stats.minted, minted_count);
+					assert_eq!(AAvatars::accounts(ALICE).stats.mint.total, minted_count);
 					assert_eq!(
-						AAvatars::accounts(ALICE).stats.current_season_minted,
+						AAvatars::accounts(ALICE).stats.mint.current_season,
 						current_season_minted_count
 					);
 					assert!(AAvatars::current_season_status().active);
@@ -533,16 +533,16 @@ mod minting {
 						Origin::signed(ALICE),
 						MintOption { count: MintPackSize::One, mint_type: mint_type.clone() }
 					));
-					assert_eq!(AAvatars::accounts(ALICE).stats.first_minted, season_1.start);
+					assert_eq!(AAvatars::accounts(ALICE).stats.mint.first, season_1.start);
 
 					// total minted count updates
 					minted_count += 1;
-					assert_eq!(AAvatars::accounts(ALICE).stats.minted, minted_count);
+					assert_eq!(AAvatars::accounts(ALICE).stats.mint.total, minted_count);
 
 					// current season minted count resets
 					current_season_minted_count = 1;
 					assert_eq!(
-						AAvatars::accounts(ALICE).stats.current_season_minted,
+						AAvatars::accounts(ALICE).stats.mint.current_season,
 						current_season_minted_count
 					);
 
@@ -892,9 +892,9 @@ mod forging {
 				assert_eq!(AAvatars::avatars(leader_id).unwrap().1.dna.to_vec(), expected_dna);
 
 				forged_count += 1;
-				assert_eq!(AAvatars::accounts(BOB).stats.forged, forged_count);
-				assert_eq!(AAvatars::accounts(BOB).stats.current_season_forged, forged_count);
-				assert_eq!(AAvatars::accounts(BOB).stats.first_forged, season.start);
+				assert_eq!(AAvatars::accounts(BOB).stats.forge.total, forged_count);
+				assert_eq!(AAvatars::accounts(BOB).stats.forge.current_season, forged_count);
+				assert_eq!(AAvatars::accounts(BOB).stats.forge.first, season.start);
 			};
 
 		ExtBuilder::default()
@@ -964,9 +964,9 @@ mod forging {
 				));
 				assert_eq!(AAvatars::current_season_max_tier_avatars(), 0);
 				assert!(!AAvatars::current_season_status().prematurely_ended);
-				assert_eq!(AAvatars::accounts(BOB).stats.forged, 8);
-				assert_eq!(AAvatars::accounts(BOB).stats.current_season_forged, 0);
-				assert_eq!(AAvatars::accounts(BOB).stats.current_season_minted, 1);
+				assert_eq!(AAvatars::accounts(BOB).stats.forge.total, 8);
+				assert_eq!(AAvatars::accounts(BOB).stats.forge.current_season, 0);
+				assert_eq!(AAvatars::accounts(BOB).stats.mint.current_season, 1);
 			});
 	}
 
@@ -1668,8 +1668,8 @@ mod trading {
 				assert_eq!(AAvatars::trade(avatar_for_sale), None);
 
 				// check for account stats
-				assert_eq!(AAvatars::accounts(ALICE).stats.bought, 1);
-				assert_eq!(AAvatars::accounts(BOB).stats.sold, 1);
+				assert_eq!(AAvatars::accounts(ALICE).stats.trade.bought, 1);
+				assert_eq!(AAvatars::accounts(BOB).stats.trade.sold, 1);
 
 				// check events
 				System::assert_last_event(mock::Event::AAvatars(crate::Event::AvatarTraded {
@@ -1682,8 +1682,8 @@ mod trading {
 				let avatar_for_sale = AAvatars::owners(BOB)[0];
 				assert_ok!(AAvatars::set_price(Origin::signed(BOB), avatar_for_sale, 1357));
 				assert_ok!(AAvatars::buy(Origin::signed(CHARLIE), avatar_for_sale));
-				assert_eq!(AAvatars::accounts(CHARLIE).stats.bought, 1);
-				assert_eq!(AAvatars::accounts(BOB).stats.sold, 2);
+				assert_eq!(AAvatars::accounts(CHARLIE).stats.trade.bought, 1);
+				assert_eq!(AAvatars::accounts(BOB).stats.trade.sold, 2);
 			});
 	}
 

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -578,7 +578,7 @@ mod minting {
 
 					// reset for next iteration
 					System::set_block_number(0);
-					LastMintedBlockNumbers::<Test>::remove(ALICE);
+					Accounts::<Test>::mutate(ALICE, |account| account.stats.mint.last = 0);
 					Owners::<Test>::remove(ALICE);
 					CurrentSeasonStatus::<Test>::mutate(|status| status.active = false);
 					CurrentSeasonId::<Test>::set(1);
@@ -739,7 +739,7 @@ mod minting {
 
 					// reset for next iteration
 					System::set_block_number(0);
-					LastMintedBlockNumbers::<Test>::remove(ALICE);
+					Accounts::<Test>::mutate(ALICE, |account| account.stats.mint.last = 0);
 				}
 			});
 	}

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -895,6 +895,7 @@ mod forging {
 				assert_eq!(AAvatars::accounts(BOB).stats.forge.total, forged_count);
 				assert_eq!(AAvatars::accounts(BOB).stats.forge.current_season, forged_count);
 				assert_eq!(AAvatars::accounts(BOB).stats.forge.first, season.start);
+				assert_eq!(AAvatars::accounts(BOB).stats.forge.last, System::block_number());
 			};
 
 		ExtBuilder::default()

--- a/pallets/ajuna-awesome-avatars/src/types/account.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/account.rs
@@ -55,15 +55,23 @@ impl StorageTier {
 pub type Stat = u32;
 
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Default)]
-pub struct Stats<BlockNumber> {
-	pub first_minted: BlockNumber,
-	pub first_forged: BlockNumber,
-	pub current_season_minted: Stat,
-	pub current_season_forged: Stat,
-	pub minted: Stat,
-	pub forged: Stat,
+pub struct PlayStats<BlockNumber> {
+	pub total: Stat,
+	pub current_season: Stat,
+	pub first: BlockNumber,
+}
+
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Default)]
+pub struct TradeStats {
 	pub bought: Stat,
 	pub sold: Stat,
+}
+
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Default)]
+pub struct Stats<BlockNumber> {
+	pub mint: PlayStats<BlockNumber>,
+	pub forge: PlayStats<BlockNumber>,
+	pub trade: TradeStats,
 }
 
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Default)]

--- a/pallets/ajuna-awesome-avatars/src/types/account.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/account.rs
@@ -59,6 +59,7 @@ pub struct PlayStats<BlockNumber> {
 	pub total: Stat,
 	pub current_season: Stat,
 	pub first: BlockNumber,
+	pub last: BlockNumber,
 }
 
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Default)]


### PR DESCRIPTION
## Description

Changes:
- refactor `AccountInfo.stats` with categorised nesting
- remove `LastMintedBlockNumbers` and add `PlayStats.last` as replacement

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
