### PR TITLE
[PLAT-627] Add a job to release on OnF

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,8 @@ jobs:
               build_arg_feature: ajuna,
               build_arg_bin: ajuna-para,
             }
+    outputs:
+      image_tag: ${{ steps.set_image_tag.outputs.image_tag }}
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
@@ -125,7 +127,11 @@ jobs:
         with:
           images: ${{ matrix.image.name }}
       - name: Get image tag from the tag name
-        run: echo "image_tag=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+        id: set_image_tag
+        run: |
+          IMAGE_TAG="${GITHUB_REF#refs/tags/v}"
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_ENV
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
       - uses: docker/build-push-action@v3
         with:
           context: .
@@ -139,3 +145,22 @@ jobs:
             bin=${{ matrix.image.build_arg_bin }}
           cache-from: type=registry,ref=ajuna/${{ matrix.image.name }}:buildcache
           cache-to: type=registry,ref=ajuna/${{ matrix.image.name }}:buildcache,mode=max
+
+  release-onf:
+    needs: release-docker
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        network_keys:
+          - "${{ secrets.ONF_BAJUN_NETWORK_KEY }}"
+          - "${{ secrets.ONF_AJUNA_NETWORK_KEY }}"
+    steps:
+      - uses: OnFinality-io/action-onf-release@v1
+        with:
+          onf-access-key: ${{ secrets.ONF_ACCESS_KEY }}
+          onf-secret-key: ${{ secrets.ONF_SECRET_KEY }}
+          onf-workspace-id: ${{ secrets.ONF_WORKSPACE_ID }}
+          onf-network-key: ${{ matrix.network_keys }}
+          onf-sub-command: image
+          onf-action: add
+          image-version: ${{ needs.release-docker.outputs.image_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        runtime: [bajun]
+        runtime: [bajun, ajuna]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description

Changes:
- add `outputs.image_tag` to propagate image tag other jobs
- add `release-onf` job that:
  - runs after `docker-release`
  - and updates network specs on OnF to reference the newly published images

TODO:
- [x] check if the Bajun network spec has been updated with the new image repo

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [x] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
