### PR TITLE
ci: use literal values for network_keys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,9 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        network_keys:
-          - "${{ secrets.ONF_BAJUN_NETWORK_KEY }}"
-          - "${{ secrets.ONF_AJUNA_NETWORK_KEY }}"
+        network_keys: [bajun, ajuna]
     steps:
       - uses: OnFinality-io/action-onf-release@v1
         with:


### PR DESCRIPTION
## Description

Using literal values (as the CI doesn't know how to interpolate the secret values and inject them into the `matrix`).

TODO:
- [ ] check if network spec keys are updated on OnF

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [x] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
