### PR TITLE
Remove outdated actions

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -32,14 +32,11 @@ jobs:
       SKIP_WASM_BUILD: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
-  check:
+  lint:
     if: ${{ !startsWith(github.head_ref, 'release/') }}
-    name: Clippy and Check
+    name: Clippy
     runs-on: ubuntu-latest
     continue-on-error: false
     env:
@@ -56,14 +53,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all-targets ${{ env.CARGO_ARGS }} -- -D warnings
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features --all-targets ${{ env.CARGO_ARGS }}
+      - run: cargo clippy --all-features --all-targets ${{ env.CARGO_ARGS }} -- -D warnings
 
   test:
     if: ${{ !startsWith(github.head_ref, 'release/') }}
@@ -84,10 +74,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features --all-targets ${{ env.CARGO_ARGS }} --jobs 1
+      - run: cargo test --workspace --all-features --all-targets ${{ env.CARGO_ARGS }} --jobs 1
 
   coverage:
     if: ${{ !startsWith(github.head_ref, 'release/') }}

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -21,6 +21,7 @@ concurrency:
 
 env:
   CARGO_ARGS: ${{ github.ref == 'refs/heads/main' && '--release' || '' }}
+  CARGO_TERM_COLOR: always
 
 jobs:
   fmt:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   release-check:
     if: startsWith(github.ref, 'refs/heads/release')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,10 +71,7 @@ jobs:
           exit 0
       - run: sudo apt-get install -y protobuf-compiler
       - name: Check wasm build
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features --all-targets --release -p ${{ matrix.runtime }}-runtime
+        run: cargo check --all-features --all-targets --release -p ${{ matrix.runtime }}-runtime
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -87,10 +84,7 @@ jobs:
       - run: sudo apt-get install -y protobuf-compiler
       - uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release -p ${{ matrix.runtime }}-runtime --target=${{ matrix.target }}
+        run: cargo build --release -p ${{ matrix.runtime }}-runtime --target=${{ matrix.target }}
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
## Description

It's noted from the [latest release](https://github.com/ajuna-network/Ajuna/actions/runs/3466579147) that the following actions are outdated:
- [actions-rs/cargo@v1](https://github.com/actions-rs/cargo)
  - we don't need this action anyway because GitHub runners come with `cargo` pre-installed

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [x] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
