### PR TITLE
DOT4-GRAVITY - Logic adjustment

### DIFF
--- a/pallets/ajuna-board/src/tests.rs
+++ b/pallets/ajuna-board/src/tests.rs
@@ -116,6 +116,11 @@ fn play_works() {
 		assert_ne!(Seed::<Test>::get(), Some(TEST_SEED));
 		assert!(PlayerBoards::<Test>::get(ALICE).is_none());
 		assert!(PlayerBoards::<Test>::get(BOB).is_none());
+		assert!(BoardGames::<Test>::get(BOARD_ID).is_some());
+
+		// We clear the board
+		assert_ok!(AjunaBoard::clear_board(RuntimeOrigin::root(), BOARD_ID));
+
 		assert!(BoardGames::<Test>::get(BOARD_ID).is_none());
 	})
 }


### PR DESCRIPTION
## Description

Changed the end game logic in `ajuna-board` pallet, now when a game finishes the board is not removed from storage, only the player references to it. 

A new extrinsic `clear_board` has been added to remove the boards. The change comes from the need of being able to check previously completed games.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [x] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
