### PR TITLE
[PLAT-681] Fix premature season ending

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -776,6 +776,10 @@ pub mod pallet {
 		) -> DispatchResult {
 			let GlobalConfig { forge, .. } = Self::global_configs();
 			ensure!(forge.open, Error::<T>::ForgeClosed);
+			ensure!(
+				!Self::current_season_status().prematurely_ended,
+				Error::<T>::PrematureSeasonEnd
+			);
 
 			let season = Self::seasons(season_id).ok_or(Error::<T>::UnknownSeason)?;
 			ensure!(


### PR DESCRIPTION
## Description

Adding the missing early termination on `current_season_status().prematurely_ended` for forging. This prevents an extra forging from taking place even after season prematurely ends.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
