### PR TITLE
ci: remove slack notify

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -102,18 +102,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-
-  notify:
-    if: ${{ !startsWith(github.head_ref, 'release/') }}
-    name: Notify on Slack
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - uses: 8398a7/action-slack@v3
-        with:
-          job_name: Build
-          status: ${{ job.status }}
-          fields: repo,pullRequest,commit,author,workflow,took
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: always()


### PR DESCRIPTION
## Description

Fixing [this issue](https://github.com/ajuna-network/Ajuna/actions/runs/3905990960/jobs/6674478626) by removing the `notify` job.

We'll subscribe for changes via the official Github Slack integration.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [x] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
