### PR TITLE
[PLAT-686] Accumulate soul points regardless of outcome

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -1057,11 +1057,19 @@ mod forging {
 					})
 				}
 
-				assert_ok!(AAvatars::forge(
-					RuntimeOrigin::signed(BOB),
-					*leader_id,
-					AAvatars::owners(BOB)[1..=4].to_vec()
-				));
+				let original_leader_souls = AAvatars::avatars(leader_id).unwrap().1.souls;
+				let sacrifice_ids = AAvatars::owners(BOB)[1..=4].to_vec();
+				let sacrifice_souls = sacrifice_ids
+					.iter()
+					.map(|id| AAvatars::avatars(id).unwrap().1.souls)
+					.sum::<SoulCount>();
+				assert_ne!(sacrifice_souls, 0);
+
+				assert_ok!(AAvatars::forge(RuntimeOrigin::signed(BOB), *leader_id, sacrifice_ids));
+				assert_eq!(
+					AAvatars::avatars(leader_id).unwrap().1.souls,
+					original_leader_souls + sacrifice_souls
+				);
 				assert_eq!(AAvatars::avatars(leader_id).unwrap().1.dna.to_vec(), expected_dna);
 
 				forged_count += 1;

--- a/pallets/ajuna-awesome-avatars/src/types/avatar.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar.rs
@@ -21,7 +21,7 @@ use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
 
 pub type SeasonId = u16;
 pub type Dna = BoundedVec<u8, ConstU32<100>>;
-pub type SoulCount = u32; // TODO: is u32 enough?
+pub type SoulCount = u32;
 
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Default)]
 pub struct Avatar {
@@ -52,10 +52,8 @@ impl Avatar {
 						matches += 1;
 						matched_components.extend(matching_components.iter());
 					}
-
-					// TODO: is u32 enough?
-					self.souls.saturating_accrue(other.souls);
 				}
+				self.souls.saturating_accrue(other.souls);
 				Ok((matched_components, matches))
 			},
 		)


### PR DESCRIPTION
## Description

Soul points were increased only when avatars could potentially be forged into a higher tier. Fixing this so that they accumulate regardless of the outcome of forging.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
