### PR TITLE
Move default values in genesis build

### DIFF
--- a/node/service/src/chain_spec/bajun.rs
+++ b/node/service/src/chain_spec/bajun.rs
@@ -167,5 +167,6 @@ fn testnet_genesis(
 		aura_ext: Default::default(),
 		parachain_system: Default::default(),
 		polkadot_xcm: bajun_runtime::PolkadotXcmConfig { safe_xcm_version: Some(SAFE_XCM_VERSION) },
+		awesome_avatars: Default::default(),
 	}
 }

--- a/node/service/src/chain_spec/solo.rs
+++ b/node/service/src/chain_spec/solo.rs
@@ -202,5 +202,6 @@ fn compose_genesis_config(config: Config) -> GenesisConfig {
 		council_membership: Default::default(),
 		treasury: Default::default(),
 		democracy: Default::default(),
+		awesome_avatars: Default::default(),
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -113,15 +113,10 @@ pub mod pallet {
 	#[pallet::getter(fn treasurer)]
 	pub type Treasurer<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
 
-	#[pallet::type_value]
-	pub fn DefaultSeasonId() -> SeasonId {
-		1
-	}
-
 	/// Contains the identifier of the current season.
 	#[pallet::storage]
 	#[pallet::getter(fn current_season_id)]
-	pub type CurrentSeasonId<T: Config> = StorageValue<_, SeasonId, ValueQuery, DefaultSeasonId>;
+	pub type CurrentSeasonId<T: Config> = StorageValue<_, SeasonId, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn current_season_status)]
@@ -136,36 +131,9 @@ pub mod pallet {
 	#[pallet::getter(fn treasury)]
 	pub type Treasury<T: Config> = StorageMap<_, Identity, SeasonId, BalanceOf<T>, ValueQuery>;
 
-	#[pallet::type_value]
-	pub fn DefaultGlobalConfig<T: Config>() -> GlobalConfigOf<T> {
-		GlobalConfig {
-			mint: MintConfig {
-				open: true,
-				fees: MintFees {
-					one: 550_000_000_000_u64.unique_saturated_into(), // 0.55 BAJU
-					three: 500_000_000_000_u64.unique_saturated_into(), // 0.5 BAJU
-					six: 450_000_000_000_u64.unique_saturated_into(), // 0.45 BAJU
-				},
-				cooldown: 5_u8.into(),
-				free_mint_fee_multiplier: 1,
-				free_mint_transfer_fee: 1,
-				min_free_mint_transfer: 1,
-			},
-			forge: ForgeConfig { open: true },
-			trade: TradeConfig {
-				open: true,
-				buy_fee: 1_000_000_000_u64.unique_saturated_into(), // 0.01 BAJU
-			},
-			account: AccountConfig {
-				storage_upgrade_fee: 1_000_000_000_000_u64.unique_saturated_into(), // 1 BAJU
-			},
-		}
-	}
-
 	#[pallet::storage]
 	#[pallet::getter(fn global_configs)]
-	pub type GlobalConfigs<T: Config> =
-		StorageValue<_, GlobalConfigOf<T>, ValueQuery, DefaultGlobalConfig<T>>;
+	pub type GlobalConfigs<T: Config> = StorageValue<_, GlobalConfigOf<T>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn avatars)]
@@ -189,6 +157,47 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn trade)]
 	pub type Trade<T: Config> = StorageMap<_, Identity, AvatarIdOf<T>, BalanceOf<T>, OptionQuery>;
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		_phantom: sp_std::marker::PhantomData<T>,
+	}
+
+	#[cfg(feature = "std")]
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			GenesisConfig { _phantom: Default::default() }
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+		fn build(&self) {
+			CurrentSeasonId::<T>::put(1);
+			GlobalConfigs::<T>::put(GlobalConfig {
+				mint: MintConfig {
+					open: true,
+					fees: MintFees {
+						one: 550_000_000_000_u64.unique_saturated_into(), // 0.55 BAJU
+						three: 500_000_000_000_u64.unique_saturated_into(), // 0.5 BAJU
+						six: 450_000_000_000_u64.unique_saturated_into(), // 0.45 BAJU
+					},
+					cooldown: 5_u8.into(),
+					free_mint_fee_multiplier: 1,
+					free_mint_transfer_fee: 1,
+					min_free_mint_transfer: 1,
+				},
+				forge: ForgeConfig { open: true },
+				trade: TradeConfig {
+					open: true,
+					buy_fee: 1_000_000_000_u64.unique_saturated_into(), // 0.01 BAJU
+				},
+				account: AccountConfig {
+					storage_upgrade_fee: 1_000_000_000_000_u64.unique_saturated_into(), // 1 BAJU
+				},
+			});
+		}
+	}
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -17,13 +17,12 @@
 use crate::{self as pallet_ajuna_awesome_avatars, types::*, *};
 use frame_support::{
 	parameter_types,
-	traits::{ConstU16, ConstU64, Hooks},
+	traits::{ConstU16, ConstU64, GenesisBuild, Hooks},
 };
 use frame_system::mocking::{MockBlock, MockUncheckedExtrinsic};
 use sp_runtime::{
 	testing::{Header, H256},
 	traits::{BlakeTwo256, IdentityLookup},
-	BuildStorage,
 };
 
 pub type MockAccountId = u32;
@@ -178,12 +177,15 @@ impl ExtBuilder {
 	}
 
 	pub fn build(self) -> sp_io::TestExternalities {
-		let config = GenesisConfig {
-			system: Default::default(),
-			balances: BalancesConfig { balances: self.balances },
-		};
+		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+		pallet_balances::GenesisConfig::<Test> { balances: self.balances }
+			.assimilate_storage(&mut t)
+			.unwrap();
+		pallet_ajuna_awesome_avatars::GenesisConfig::<Test>::default()
+			.assimilate_storage(&mut t)
+			.unwrap();
 
-		let mut ext: sp_io::TestExternalities = config.build_storage().unwrap().into();
+		let mut ext = sp_io::TestExternalities::new(t);
 		ext.execute_with(|| System::set_block_number(1));
 		ext.execute_with(|| {
 			if let Some(organizer) = self.organizer {


### PR DESCRIPTION
## Description

The default values are not populated in the storage items. Instead, they are fetched when the storage is empty to require SDKs to handle fallback.

Moving the default values to `genesis_build` so the corresponding storage items are populated at genesis.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
