### PR TITLE
Revert max avatar decrement

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -1251,7 +1251,7 @@ mod forging {
 					legendary_avatar_ids[0],
 					legendary_avatar_ids[1..].to_vec()
 				));
-				max_tier_avatars -= 3;
+				max_tier_avatars += 1;
 				assert_eq!(AAvatars::current_season_status().max_tier_avatars, max_tier_avatars);
 				assert_eq!(AAvatars::owners(BOB).len(), (4 - 3) + (4 - 3));
 				assert_eq!(


### PR DESCRIPTION
## Description

Seasonal `max_tier_avatars` should increment only (as a way of triggering premature end).

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [x] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
