### PR TITLE
[PLAT-695] Allow free mints at premature ending

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -723,17 +723,7 @@ pub mod pallet {
 		pub(crate) fn do_mint(player: &T::AccountId, mint_option: &MintOption) -> DispatchResult {
 			let GlobalConfig { mint, .. } = Self::global_configs();
 			ensure!(mint.open, Error::<T>::MintClosed);
-
-			let SeasonStatus { active, early, early_ended, .. } = Self::current_season_status();
-			let free_mints = Self::accounts(player).free_mints;
-			let is_whitelisted = free_mints > Zero::zero();
-			ensure!(!early_ended || is_whitelisted, Error::<T>::PrematureSeasonEnd);
-			ensure!(
-				active ||
-					early && is_whitelisted ||
-					early && mint_option.mint_type == MintType::Free,
-				Error::<T>::SeasonClosed
-			);
+			let free_mints = Self::ensure_for_mint(player, &mint_option.mint_type)?;
 
 			let current_block = <frame_system::Pallet<T>>::block_number();
 			let last_block = Self::accounts(player).stats.mint.last;
@@ -924,6 +914,21 @@ pub mod pallet {
 			let (owner, avatar) = Self::avatars(avatar_id).ok_or(Error::<T>::UnknownAvatar)?;
 			ensure!(player == &owner, Error::<T>::Ownership);
 			Ok(avatar)
+		}
+
+		pub(crate) fn ensure_for_mint(
+			player: &T::AccountId,
+			mint_type: &MintType,
+		) -> Result<MintCount, DispatchError> {
+			let SeasonStatus { active, early, early_ended, .. } = Self::current_season_status();
+			let free_mints = Self::accounts(player).free_mints;
+			let is_whitelisted = free_mints > Zero::zero();
+			ensure!(!early_ended || is_whitelisted, Error::<T>::PrematureSeasonEnd);
+			ensure!(
+				active || early && is_whitelisted || early && mint_type == &MintType::Free,
+				Error::<T>::SeasonClosed
+			);
+			Ok(free_mints)
 		}
 
 		fn ensure_for_trade(

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -923,9 +923,10 @@ pub mod pallet {
 			let SeasonStatus { active, early, early_ended, .. } = Self::current_season_status();
 			let free_mints = Self::accounts(player).free_mints;
 			let is_whitelisted = free_mints > Zero::zero();
-			ensure!(!early_ended || is_whitelisted, Error::<T>::PrematureSeasonEnd);
+			let is_free_mint = mint_type == &MintType::Free;
+			ensure!(!early_ended || is_free_mint, Error::<T>::PrematureSeasonEnd);
 			ensure!(
-				active || early && is_whitelisted || early && mint_type == &MintType::Free,
+				active || early && is_whitelisted || early && is_free_mint,
 				Error::<T>::SeasonClosed
 			);
 			Ok(free_mints)

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -576,20 +576,20 @@ mod minting {
 					}
 				}
 
-				// At premature end, only whitelisted accounts can mint.
+				// At premature end, only free mint is available for all accounts.
 				for n in season.start..=season.end {
 					run_to_block(n);
 					CurrentSeasonStatus::<Test>::mutate(|status| status.early_ended = true);
-					assert_ok!(AAvatars::ensure_for_mint(&ALICE, &MintType::Normal), 42);
+					assert_noop!(
+						AAvatars::ensure_for_mint(&ALICE, &MintType::Normal),
+						Error::<Test>::PrematureSeasonEnd
+					);
 					assert_ok!(AAvatars::ensure_for_mint(&ALICE, &MintType::Free), 42);
 					assert_noop!(
 						AAvatars::ensure_for_mint(&BOB, &MintType::Normal),
 						Error::<Test>::PrematureSeasonEnd
 					);
-					assert_noop!(
-						AAvatars::ensure_for_mint(&BOB, &MintType::Free),
-						Error::<Test>::PrematureSeasonEnd
-					);
+					assert_ok!(AAvatars::ensure_for_mint(&BOB, &MintType::Free), 0);
 					CurrentSeasonStatus::<Test>::mutate(|status| status.early_ended = false);
 				}
 
@@ -1373,7 +1373,7 @@ mod forging {
 				assert_noop!(
 					AAvatars::mint(
 						RuntimeOrigin::signed(BOB),
-						MintOption { count: MintPackSize::One, mint_type: MintType::Free }
+						MintOption { count: MintPackSize::One, mint_type: MintType::Normal }
 					),
 					Error::<Test>::PrematureSeasonEnd
 				);


### PR DESCRIPTION
## Description

Allows free mint for all players at premature season ending.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
