### PR TITLE
[PLAT-754] Remove unused free mint calls

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/benchmarking.rs
+++ b/pallets/ajuna-awesome-avatars/src/benchmarking.rs
@@ -337,29 +337,6 @@ benchmarks! {
 		assert_last_event::<T>(Event::UpdatedGlobalConfig(config).into())
 	}
 
-	issue_free_mints {
-		let organizer = account::<T>("organizer");
-		Organizer::<T>::put(&organizer);
-
-		let to = account::<T>("to");
-		let how_many = MintCount::MAX;
-	}: _(RawOrigin::Signed(organizer), to.clone(), how_many)
-	verify {
-		assert_last_event::<T>(Event::FreeMintsIssued { to, how_many }.into())
-	}
-
-	withdraw_free_mints {
-		let organizer = account::<T>("organizer");
-		Organizer::<T>::put(&organizer);
-
-		let from = account::<T>("from");
-		let how_many = MintCount::MAX;
-		Accounts::<T>::mutate(&from, |account|account.free_mints = how_many);
-	}: _(RawOrigin::Signed(organizer), from.clone(), how_many)
-	verify {
-		assert_last_event::<T>(Event::FreeMintsWithdrawn { from, how_many }.into())
-	}
-
 	set_free_mints {
 		let organizer = account::<T>("organizer");
 		Organizer::<T>::put(&organizer);

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -1250,6 +1250,18 @@ mod minting {
 				assert_eq!(AAvatars::accounts(BOB).free_mints, 0);
 			})
 	}
+
+	#[test]
+	fn set_free_mints_rejects_non_organizer_calls() {
+		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
+			for not_organizer in [BOB, CHARLIE] {
+				assert_noop!(
+					AAvatars::set_free_mints(RuntimeOrigin::signed(not_organizer), ALICE, 123),
+					DispatchError::BadOrigin
+				);
+			}
+		})
+	}
 }
 
 mod forging {

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -1237,64 +1237,6 @@ mod minting {
 	}
 
 	#[test]
-	fn issue_free_mints_should_work() {
-		ExtBuilder::default()
-			.organizer(ALICE)
-			.free_mints(&[(BOB, 7)])
-			.build()
-			.execute_with(|| {
-				assert_ok!(AAvatars::issue_free_mints(RuntimeOrigin::signed(ALICE), BOB, 7));
-				System::assert_last_event(mock::RuntimeEvent::AAvatars(
-					crate::Event::FreeMintsIssued { to: BOB, how_many: 7 },
-				));
-				assert_eq!(AAvatars::accounts(BOB).free_mints, 7 + 7);
-			});
-	}
-
-	#[test]
-	fn issue_free_mints_rejects_overflow() {
-		ExtBuilder::default()
-			.organizer(ALICE)
-			.free_mints(&[(BOB, MintCount::MAX)])
-			.build()
-			.execute_with(|| {
-				assert_noop!(
-					AAvatars::issue_free_mints(RuntimeOrigin::signed(ALICE), BOB, 1),
-					ArithmeticError::Overflow
-				);
-			})
-	}
-
-	#[test]
-	fn withdraw_free_mints_works() {
-		ExtBuilder::default()
-			.organizer(BOB)
-			.free_mints(&[(ALICE, 369)])
-			.build()
-			.execute_with(|| {
-				assert_ok!(AAvatars::withdraw_free_mints(RuntimeOrigin::signed(BOB), ALICE, 135));
-				assert_eq!(AAvatars::accounts(ALICE).free_mints, 369 - 135);
-				System::assert_last_event(mock::RuntimeEvent::AAvatars(
-					crate::Event::FreeMintsWithdrawn { from: ALICE, how_many: 135 },
-				));
-			})
-	}
-
-	#[test]
-	fn withdraw_free_mints_rejects_underflow() {
-		ExtBuilder::default()
-			.organizer(ALICE)
-			.free_mints(&[(BOB, 123)])
-			.build()
-			.execute_with(|| {
-				assert_noop!(
-					AAvatars::withdraw_free_mints(RuntimeOrigin::signed(ALICE), BOB, 124),
-					ArithmeticError::Underflow
-				);
-			})
-	}
-
-	#[test]
 	fn set_free_mints_works() {
 		ExtBuilder::default()
 			.organizer(ALICE)
@@ -1307,33 +1249,6 @@ mod minting {
 				assert_ok!(AAvatars::set_free_mints(RuntimeOrigin::signed(ALICE), BOB, 0));
 				assert_eq!(AAvatars::accounts(BOB).free_mints, 0);
 			})
-	}
-
-	#[test]
-	fn managing_free_mints_rejects_zero_amount() {
-		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
-			for extrinsic in [
-				AAvatars::issue_free_mints(RuntimeOrigin::signed(ALICE), BOB, 0),
-				AAvatars::withdraw_free_mints(RuntimeOrigin::signed(ALICE), BOB, 0),
-			] {
-				assert_noop!(extrinsic, Error::<Test>::TooLowFreeMints);
-			}
-		})
-	}
-
-	#[test]
-	fn managing_free_mints_requires_organizer() {
-		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
-			for not_organizer in [BOB, CHARLIE] {
-				for extrinsic in [
-					AAvatars::issue_free_mints(RuntimeOrigin::signed(not_organizer), ALICE, 123),
-					AAvatars::withdraw_free_mints(RuntimeOrigin::signed(not_organizer), ALICE, 123),
-					AAvatars::set_free_mints(RuntimeOrigin::signed(not_organizer), ALICE, 123),
-				] {
-					assert_noop!(extrinsic, DispatchError::BadOrigin);
-				}
-			}
-		})
 	}
 }
 

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/nft.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/nft.rs
@@ -1,6 +1,7 @@
 use crate::types::{Avatar, AvatarCodec, Force, RarityTier};
 use codec::{Decode, Encode};
 use pallet_ajuna_nft_transfer::traits::{AttributeCode, NftConvertible};
+use sp_std::prelude::*;
 
 pub const DNA_ATTRIBUTE_CODE: u16 = 10;
 pub const SOUL_POINTS_ATTRIBUTE_CODE: u16 = 11;


### PR DESCRIPTION
## Description

Removing these two redundant calls:
- `issue_free_mints`
- `withdraw_free_mints`

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
