### PR TITLE
Avatar V2 prototype

### DIFF
--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -120,7 +120,12 @@ fn create_avatars<T: Config>(name: &'static str, n: u32) -> Result<(), &'static 
 	for _ in 0..n {
 		AAvatars::<T>::mint(
 			RawOrigin::Signed(player.clone()).into(),
-			MintOption { mint_type: MintType::Free, count: MintPackSize::One },
+			MintOption {
+				mint_type: MintType::Free,
+				count: MintPackSize::One,
+				mint_pack: PackType::Material,
+				mint_version: AvatarVersion::V1,
+			},
 		)?;
 		Accounts::<T>::mutate(&player, |account| account.stats.mint.last = Zero::zero());
 	}
@@ -179,7 +184,8 @@ benchmarks! {
 		let caller = account::<T>(name);
 		Accounts::<T>::mutate(&caller, |account| account.free_mints = MintCount::MAX);
 
-		let mint_option = MintOption { mint_type: MintType::Free, count: MintPackSize::Six };
+		let mint_option = MintOption { mint_type: MintType::Free, count: MintPackSize::Six,
+			mint_pack: PackType::Material, mint_version: AvatarVersion::V1 };
 	}: mint(RawOrigin::Signed(caller.clone()), mint_option)
 	verify {
 		let n = n as usize;
@@ -196,7 +202,8 @@ benchmarks! {
 		let mint_fee = GlobalConfigs::<T>::get().mint.fees.fee_for(&MintPackSize::Six);
 		CurrencyOf::<T>::make_free_balance_be(&caller, mint_fee);
 
-		let mint_option = MintOption { mint_type: MintType::Normal, count: MintPackSize::Six };
+		let mint_option = MintOption { mint_type: MintType::Normal, count: MintPackSize::Six,
+			mint_pack: PackType::Material, mint_version: AvatarVersion::V1 };
 	}: mint(RawOrigin::Signed(caller.clone()), mint_option)
 	verify {
 		let n = n as usize;
@@ -226,7 +233,7 @@ benchmarks! {
 				count
 			}
 		);
-		assert_last_event::<T>(Event::AvatarForged { avatar_id, upgraded_components })
+		assert_last_event::<T>(Event::AvatarsForged { avatar_ids: vec![(avatar_id, upgraded_components)] })
 	}
 
 	transfer_avatar_normal {

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -82,7 +82,7 @@ use sp_runtime::{
 	},
 	ArithmeticError,
 };
-use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
+use sp_std::{collections::btree_set::BTreeSet, prelude::*};
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -247,7 +247,7 @@ pub mod pallet {
 		/// Avatars minted.
 		AvatarsMinted { avatar_ids: Vec<AvatarIdOf<T>> },
 		/// Avatar forged.
-		AvatarForged { avatar_id: AvatarIdOf<T>, upgraded_components: u8 },
+		AvatarsForged { avatar_ids: Vec<(AvatarIdOf<T>, UpgradedComponents)> },
 		/// Avatar transferred.
 		AvatarTransferred { from: T::AccountId, to: T::AccountId, avatar_id: AvatarIdOf<T> },
 		/// A season has started.
@@ -385,12 +385,20 @@ pub mod pallet {
 		AvatarUnlocked,
 		/// Tried to forge avatars from different seasons.
 		IncorrectAvatarSeason,
+		/// Tried to forge avatars with different DNA versions.
+		IncompatibleAvatarVersions,
 		/// Tried transferring to his or her own account.
 		CannotTransferToSelf,
 		/// Tried claiming treasury during a season.
 		CannotClaimDuringSeason,
 		/// Tried claiming treasury which is zero.
 		CannotClaimZero,
+		/// The components tried to forge were not compatible.
+		InvalidForgeComponents,
+		/// The amount of sacrifices is not sufficient for forging.
+		InsufficientSacrifices,
+		/// The amount of sacrifices is too much for forging.
+		ExcessiveSacrifices,
 		/// Tried to prepare an already prepared avatar.
 		AlreadyPrepared,
 		/// Tried to prepare an IPFS URL for an avatar, that is not yet prepared.
@@ -1029,7 +1037,7 @@ pub mod pallet {
 		}
 
 		#[inline]
-		fn random_hash(phrase: &[u8], who: &T::AccountId) -> T::Hash {
+		pub(crate) fn random_hash(phrase: &[u8], who: &T::AccountId) -> T::Hash {
 			let (seed, _) = T::Randomness::random(phrase);
 			let seed = T::Hash::decode(&mut TrailingZeroInput::new(seed.as_ref()))
 				.expect("input is padded with zeroes; qed");
@@ -1038,66 +1046,23 @@ pub mod pallet {
 			(seed, &who, nonce.encode()).using_encoded(T::Hashing::hash)
 		}
 
-		#[inline]
-		fn random_component(
-			season: &SeasonOf<T>,
-			hash: &T::Hash,
-			index: usize,
-			batched_mint: bool,
-		) -> (u8, u8) {
-			let hash = hash.as_ref();
-			let random_tier = {
-				let random_prob = hash[index] % MAX_PERCENTAGE;
-				let probs =
-					if batched_mint { &season.batch_mint_probs } else { &season.single_mint_probs };
-				let mut cumulative_sum = 0;
-				let mut random_tier = season.tiers[0].clone() as u8;
-				for i in 0..probs.len() {
-					let new_cumulative_sum = cumulative_sum + probs[i];
-					if random_prob >= cumulative_sum && random_prob < new_cumulative_sum {
-						random_tier = season.tiers[i].clone() as u8;
-						break
-					}
-					cumulative_sum = new_cumulative_sum;
-				}
-				random_tier
-			};
-			let random_variation = hash[index + 1] % season.max_variations;
-			(random_tier, random_variation)
-		}
-
-		fn random_dna(
-			hash: &T::Hash,
-			season: &SeasonOf<T>,
-			batched_mint: bool,
-		) -> Result<Dna, DispatchError> {
-			let dna = (0..season.max_components)
-				.map(|i| {
-					let (random_tier, random_variation) =
-						Self::random_component(season, hash, i as usize * 2, batched_mint);
-					((random_tier << 4) | random_variation) as u8
-				})
-				.collect::<Vec<_>>();
-			Dna::try_from(dna).map_err(|_| Error::<T>::IncorrectDna.into())
-		}
-
 		/// Mint a new avatar.
 		pub(crate) fn do_mint(player: &T::AccountId, mint_option: &MintOption) -> DispatchResult {
 			Self::ensure_for_mint(player, mint_option)?;
 
 			let season_id = CurrentSeasonStatus::<T>::get().season_id;
 			let season = Seasons::<T>::get(season_id).ok_or(Error::<T>::UnknownSeason)?;
-			let is_batched = mint_option.count.is_batched();
-			let generated_avatar_ids = (0..mint_option.count as usize)
-				.map(|_| {
-					let avatar_id = Self::random_hash(b"create_avatar", player);
-					let dna = Self::random_dna(&avatar_id, &season, is_batched)?;
-					let souls = (dna.iter().map(|x| *x as SoulCount).sum::<SoulCount>() % 100) + 1;
-					let avatar = Avatar { season_id, dna, souls };
-					Avatars::<T>::insert(avatar_id, (&player, avatar));
-					Owners::<T>::try_append(&player, avatar_id)
-						.map_err(|_| Error::<T>::MaxOwnershipReached)?;
-					Ok(avatar_id)
+			let mint_output =
+				mint_option.mint_version.with_minter(|minter: Box<dyn Minter<T>>| {
+					minter.mint_avatar_set(player, &season_id, &season, mint_option)
+				})?;
+
+			// Add generated avatars from minter to storage
+			let generated_avatar_ids = mint_output
+				.into_iter()
+				.map(|(minted_avatar_id, minted_avatar)| {
+					Self::try_add_avatar_to(player, minted_avatar_id, minted_avatar)?;
+					Ok(minted_avatar_id)
 				})
 				.collect::<Result<Vec<AvatarIdOf<T>>, DispatchError>>()?;
 
@@ -1112,7 +1077,7 @@ pub mod pallet {
 					let fee = (mint_option.count as MintCount)
 						.saturating_mul(mint.free_mint_fee_multiplier);
 					Accounts::<T>::try_mutate(player, |account| -> DispatchResult {
-						account.free_mints = Accounts::<T>::get(player)
+						account.free_mints = account
 							.free_mints
 							.checked_sub(fee)
 							.ok_or(Error::<T>::InsufficientFreeMints)?;
@@ -1152,79 +1117,24 @@ pub mod pallet {
 			ensure!(forge.open, Error::<T>::ForgeClosed);
 
 			let (season_id, season) = Self::current_season_with_id()?;
-			let (mut leader, sacrifice_ids, sacrifices) =
+			let (leader, sacrifice_ids, sacrifices) =
 				Self::ensure_for_forge(player, leader_id, sacrifice_ids, &season_id, &season)?;
-			let prev_leader_tier = leader.min_tier();
 
-			let max_tier = season.tiers.iter().max().ok_or(Error::<T>::UnknownTier)?.clone() as u8;
-			let (mut unique_matched_indexes, matches) =
-				leader.compare_all::<T>(&sacrifices, season.max_variations, max_tier)?;
+			let forger: Box<dyn Forger<T>> = leader.version.get_forger();
+			let input_leader = (*leader_id, leader);
+			let input_sacrifices =
+				sacrifice_ids.into_iter().zip(sacrifices).collect::<Vec<ForgeItem<T>>>();
+			let (output_leader, output_other) = forger.forge_with(
+				player,
+				season_id,
+				&season,
+				input_leader.clone(),
+				input_sacrifices,
+			)?;
 
-			let random_hash = Self::random_hash(b"forging avatar", player);
-			let random_hash = random_hash.as_ref();
-			let mut upgraded_components = 0;
-
-			let current_block = <frame_system::Pallet<T>>::block_number();
-			let prob = leader.forge_probability::<T>(&season, &current_block, matches)?;
-
-			let rolls = sacrifices.len();
-			for hash in random_hash.iter().take(rolls) {
-				let roll = hash % MAX_PERCENTAGE;
-				if roll <= prob {
-					if let Some(first_matched_index) = unique_matched_indexes.pop_first() {
-						let nucleotide = leader.dna[first_matched_index];
-						let current_tier_index = season
-							.tiers
-							.iter()
-							.position(|tier| tier.clone() as u8 == nucleotide >> 4)
-							.ok_or(Error::<T>::UnknownTier)?;
-
-						let already_maxed_out = current_tier_index == (season.tiers.len() - 1);
-						if !already_maxed_out {
-							let next_tier = season.tiers[current_tier_index + 1].clone() as u8;
-							let upgraded_nucleotide = (next_tier << 4) | (nucleotide & 0b0000_1111);
-							leader.dna[first_matched_index] = upgraded_nucleotide;
-							upgraded_components += 1;
-						}
-					}
-				}
-			}
-
-			let after_leader_tier = leader.min_tier();
-			if prev_leader_tier != max_tier && after_leader_tier == max_tier {
-				CurrentSeasonStatus::<T>::mutate(|status| {
-					status.max_tier_avatars.saturating_inc();
-					if status.max_tier_avatars == season.max_tier_forges {
-						status.early_ended = true;
-					}
-				});
-			}
-
-			Avatars::<T>::insert(leader_id, (player, leader));
-			sacrifice_ids.iter().for_each(Avatars::<T>::remove);
-			let remaining_avatar_ids: BoundedAvatarIdsOf<T> = Owners::<T>::take(player)
-				.into_iter()
-				.filter(|avatar_id| !sacrifice_ids.contains(avatar_id))
-				.collect::<Vec<_>>()
-				.try_into()
-				.map_err(|_| Error::<T>::IncorrectAvatarId)?;
-			Owners::<T>::insert(player, remaining_avatar_ids);
-
-			Accounts::<T>::try_mutate(player, |AccountInfo { stats, .. }| -> DispatchResult {
-				if stats.forge.first.is_zero() {
-					stats.forge.first = current_block;
-				}
-				stats.forge.last = current_block;
-				stats
-					.forge
-					.seasons_participated
-					.try_insert(season_id)
-					.map_err(|_| Error::<T>::IncorrectSeasonId)?;
-				Ok(())
-			})?;
-			SeasonStats::<T>::mutate(season_id, player, |info| info.forged.saturating_inc());
-
-			Self::deposit_event(Event::AvatarForged { avatar_id: *leader_id, upgraded_components });
+			Self::process_leader_forge_output(player, &season, input_leader, output_leader)?;
+			Self::process_other_forge_outputs(player, &season, output_other)?;
+			Self::update_forging_statistics_for_player(player, season_id)?;
 			Ok(())
 		}
 
@@ -1336,22 +1246,148 @@ pub mod pallet {
 			Self::ensure_unlocked(leader_id)?;
 			Self::ensure_unprepared(leader_id)?;
 
+			let leader = Self::ensure_ownership(player, leader_id)?;
+			ensure!(leader.season_id == *season_id, Error::<T>::IncorrectAvatarSeason);
+
 			let deduplicated_sacrifice_ids = sacrifice_ids.iter().copied().collect::<BTreeSet<_>>();
 			let sacrifices = deduplicated_sacrifice_ids
 				.iter()
 				.map(|id| {
 					let avatar = Self::ensure_ownership(player, id)?;
 					ensure!(avatar.season_id == *season_id, Error::<T>::IncorrectAvatarSeason);
+					ensure!(
+						avatar.version == leader.version,
+						Error::<T>::IncompatibleAvatarVersions
+					);
 					Self::ensure_unlocked(id)?;
 					Self::ensure_unprepared(id)?;
 					Ok(avatar)
 				})
 				.collect::<Result<Vec<Avatar>, DispatchError>>()?;
 
-			let leader = Self::ensure_ownership(player, leader_id)?;
-			ensure!(leader.season_id == *season_id, Error::<T>::IncorrectAvatarSeason);
-
 			Ok((leader, deduplicated_sacrifice_ids, sacrifices))
+		}
+
+		#[inline]
+		fn process_leader_forge_output(
+			player: &AccountIdOf<T>,
+			season: &SeasonOf<T>,
+			input_leader: ForgeItem<T>,
+			output_leader: LeaderForgeOutput<T>,
+		) -> Result<(), DispatchError> {
+			match output_leader {
+				LeaderForgeOutput::Forged((leader_id, leader), upgraded_components) => {
+					let prev_leader_tier = input_leader.1.min_tier();
+					let after_leader_tier = leader.min_tier();
+					let max_tier = season.max_tier() as u8;
+
+					if prev_leader_tier != max_tier && after_leader_tier == max_tier {
+						CurrentSeasonStatus::<T>::mutate(|status| {
+							status.max_tier_avatars.saturating_inc();
+							if status.max_tier_avatars == season.max_tier_forges {
+								status.early_ended = true;
+							}
+						});
+					}
+
+					Avatars::<T>::insert(leader_id, (player, leader));
+
+					// TODO: May change in the future
+					Self::deposit_event(Event::AvatarsForged {
+						avatar_ids: vec![(leader_id, upgraded_components)],
+					});
+				},
+				LeaderForgeOutput::Consumed(leader_id) =>
+					Self::remove_avatar_from(player, &leader_id),
+			}
+
+			Ok(())
+		}
+
+		#[inline]
+		fn process_other_forge_outputs(
+			player: &AccountIdOf<T>,
+			_season: &SeasonOf<T>,
+			other_outputs: Vec<ForgeOutput<T>>,
+		) -> Result<(), DispatchError> {
+			let mut minted_avatars: Vec<AvatarIdOf<T>> = Vec::with_capacity(0);
+			let mut forged_avatars: Vec<(AvatarIdOf<T>, UpgradedComponents)> =
+				Vec::with_capacity(0);
+
+			for output in other_outputs {
+				match output {
+					ForgeOutput::Forged((avatar_id, avatar), upgraded_components) => {
+						Avatars::<T>::insert(avatar_id, (player, avatar));
+						forged_avatars.push((avatar_id, upgraded_components));
+					},
+					ForgeOutput::Minted(avatar) => {
+						let avatar_id = Self::random_hash(b"create_avatar", player);
+						Self::try_add_avatar_to(player, avatar_id, avatar)?;
+						minted_avatars.push(avatar_id);
+					},
+					ForgeOutput::Consumed(avatar_id) =>
+						Self::remove_avatar_from(player, &avatar_id),
+				}
+			}
+
+			// TODO: May be removed in the future
+			if !minted_avatars.is_empty() {
+				Self::deposit_event(Event::AvatarsMinted { avatar_ids: minted_avatars });
+			}
+
+			// TODO: May change in the future
+			if !forged_avatars.is_empty() {
+				Self::deposit_event(Event::AvatarsForged { avatar_ids: forged_avatars });
+			}
+
+			Ok(())
+		}
+
+		#[inline]
+		fn update_forging_statistics_for_player(
+			player: &AccountIdOf<T>,
+			season_id: SeasonId,
+		) -> Result<(), DispatchError> {
+			let current_block = <frame_system::Pallet<T>>::block_number();
+
+			Accounts::<T>::try_mutate(player, |AccountInfo { stats, .. }| -> DispatchResult {
+				if stats.forge.first.is_zero() {
+					stats.forge.first = current_block;
+				}
+				stats.forge.last = current_block;
+				stats
+					.forge
+					.seasons_participated
+					.try_insert(season_id)
+					.map_err(|_| Error::<T>::IncorrectSeasonId)?;
+				Ok(())
+			})?;
+
+			SeasonStats::<T>::mutate(season_id, player, |info| {
+				info.forged.saturating_inc();
+			});
+
+			Ok(())
+		}
+
+		#[inline]
+		fn try_add_avatar_to(
+			player: &AccountIdOf<T>,
+			avatar_id: AvatarIdOf<T>,
+			avatar: Avatar,
+		) -> Result<(), DispatchError> {
+			Avatars::<T>::insert(avatar_id, (player, avatar));
+			Owners::<T>::try_append(&player, avatar_id)
+				.map_err(|_| Error::<T>::MaxOwnershipReached)?;
+			Ok(())
+		}
+
+		#[inline]
+		fn remove_avatar_from(player: &AccountIdOf<T>, avatar_id: &AvatarIdOf<T>) {
+			Avatars::<T>::remove(avatar_id);
+			Owners::<T>::mutate(player, |avatars| {
+				avatars.retain(|id| id != avatar_id);
+			});
 		}
 
 		fn ensure_for_trade(

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -826,8 +826,18 @@ mod minting {
 	#[test]
 	fn ensure_for_mint_works() {
 		let season = Season::default().early_start(10).start(20).end(30);
-		let normal_mint = MintOption { mint_type: MintType::Normal, count: MintPackSize::One };
-		let free_mint = MintOption { mint_type: MintType::Free, count: MintPackSize::One };
+		let normal_mint = MintOption {
+			mint_type: MintType::Normal,
+			count: MintPackSize::One,
+			mint_pack: PackType::Material,
+			mint_version: AvatarVersion::V1,
+		};
+		let free_mint = MintOption {
+			mint_type: MintType::Free,
+			count: MintPackSize::One,
+			mint_pack: PackType::Material,
+			mint_version: AvatarVersion::V1,
+		};
 
 		ExtBuilder::default()
 			.seasons(&[(1, season.clone())])
@@ -990,7 +1000,12 @@ mod minting {
 					run_to_block(season_1.start);
 					assert_ok!(AAvatars::mint(
 						RuntimeOrigin::signed(ALICE),
-						MintOption { count: MintPackSize::One, mint_type: mint_type.clone() }
+						MintOption {
+							count: MintPackSize::One,
+							mint_type: mint_type.clone(),
+							mint_pack: PackType::Material,
+							mint_version: AvatarVersion::V1
+						}
 					));
 					match mint_type {
 						MintType::Normal => {
@@ -1027,7 +1042,12 @@ mod minting {
 					run_to_block(System::block_number() + 1 + mint_cooldown);
 					assert_ok!(AAvatars::mint(
 						RuntimeOrigin::signed(ALICE),
-						MintOption { count: MintPackSize::Three, mint_type: mint_type.clone() }
+						MintOption {
+							count: MintPackSize::Three,
+							mint_type: mint_type.clone(),
+							mint_pack: PackType::Material,
+							mint_version: AvatarVersion::V1
+						}
 					));
 					match mint_type {
 						MintType::Normal => {
@@ -1061,7 +1081,12 @@ mod minting {
 					assert_eq!(System::account_nonce(ALICE), expected_nonce);
 					assert_ok!(AAvatars::mint(
 						RuntimeOrigin::signed(ALICE),
-						MintOption { count: MintPackSize::Six, mint_type: mint_type.clone() }
+						MintOption {
+							count: MintPackSize::Six,
+							mint_type: mint_type.clone(),
+							mint_pack: PackType::Material,
+							mint_version: AvatarVersion::V1
+						}
 					));
 					match mint_type {
 						MintType::Normal => {
@@ -1102,7 +1127,9 @@ mod minting {
 								RuntimeOrigin::signed(ALICE),
 								MintOption {
 									count: MintPackSize::One,
-									mint_type: mint_type.clone()
+									mint_type: mint_type.clone(),
+									mint_pack: PackType::Material,
+									mint_version: AvatarVersion::V1,
 								}
 							));
 							minted_count += 1;
@@ -1121,7 +1148,12 @@ mod minting {
 					assert_noop!(
 						AAvatars::mint(
 							RuntimeOrigin::signed(ALICE),
-							MintOption { count: MintPackSize::One, mint_type: mint_type.clone() }
+							MintOption {
+								count: MintPackSize::One,
+								mint_type: mint_type.clone(),
+								mint_pack: PackType::Material,
+								mint_version: AvatarVersion::V1
+							}
 						),
 						Error::<Test>::SeasonClosed
 					);
@@ -1170,7 +1202,12 @@ mod minting {
 					assert_noop!(
 						AAvatars::mint(
 							RuntimeOrigin::signed(ALICE),
-							MintOption { count, mint_type }
+							MintOption {
+								count,
+								mint_type,
+								mint_pack: PackType::Material,
+								mint_version: AvatarVersion::V1
+							}
 						),
 						Error::<Test>::MintClosed
 					);
@@ -1185,7 +1222,15 @@ mod minting {
 			for count in [MintPackSize::One, MintPackSize::Three, MintPackSize::Six] {
 				for mint_type in [MintType::Normal, MintType::Free] {
 					assert_noop!(
-						AAvatars::mint(RuntimeOrigin::none(), MintOption { count, mint_type }),
+						AAvatars::mint(
+							RuntimeOrigin::none(),
+							MintOption {
+								count,
+								mint_type,
+								mint_pack: PackType::Material,
+								mint_version: AvatarVersion::V1
+							}
+						),
 						DispatchError::BadOrigin
 					);
 				}
@@ -1205,7 +1250,12 @@ mod minting {
 						assert_noop!(
 							AAvatars::mint(
 								RuntimeOrigin::signed(ALICE),
-								MintOption { count, mint_type }
+								MintOption {
+									count,
+									mint_type,
+									mint_pack: PackType::Material,
+									mint_version: AvatarVersion::V1
+								}
 							),
 							Error::<Test>::SeasonClosed
 						);
@@ -1240,7 +1290,12 @@ mod minting {
 						assert_noop!(
 							AAvatars::mint(
 								RuntimeOrigin::signed(ALICE),
-								MintOption { count, mint_type }
+								MintOption {
+									count,
+									mint_type,
+									mint_pack: PackType::Material,
+									mint_version: AvatarVersion::V1
+								}
 							),
 							Error::<Test>::MaxOwnershipReached
 						);
@@ -1265,7 +1320,12 @@ mod minting {
 					run_to_block(season.start + 1);
 					assert_ok!(AAvatars::mint(
 						RuntimeOrigin::signed(ALICE),
-						MintOption { count: MintPackSize::One, mint_type: mint_type.clone() }
+						MintOption {
+							count: MintPackSize::One,
+							mint_type: mint_type.clone(),
+							mint_pack: PackType::Material,
+							mint_version: AvatarVersion::V1
+						}
 					));
 
 					for _ in 1..mint_cooldown {
@@ -1275,7 +1335,9 @@ mod minting {
 								RuntimeOrigin::signed(ALICE),
 								MintOption {
 									count: MintPackSize::One,
-									mint_type: mint_type.clone()
+									mint_type: mint_type.clone(),
+									mint_pack: PackType::Material,
+									mint_version: AvatarVersion::V1,
 								}
 							),
 							Error::<Test>::MintCooldown
@@ -1286,7 +1348,12 @@ mod minting {
 					assert_eq!(System::block_number(), (season.start + 1) + mint_cooldown);
 					assert_ok!(AAvatars::mint(
 						RuntimeOrigin::signed(ALICE),
-						MintOption { count: MintPackSize::One, mint_type: MintType::Normal }
+						MintOption {
+							count: MintPackSize::One,
+							mint_type: MintType::Normal,
+							mint_pack: PackType::Material,
+							mint_version: AvatarVersion::V1
+						}
 					));
 
 					// reset for next iteration
@@ -1311,7 +1378,12 @@ mod minting {
 					assert_noop!(
 						AAvatars::mint(
 							RuntimeOrigin::signed(ALICE),
-							MintOption { count: mint_count, mint_type: MintType::Normal }
+							MintOption {
+								count: mint_count,
+								mint_type: MintType::Normal,
+								mint_pack: PackType::Material,
+								mint_version: AvatarVersion::V1
+							}
 						),
 						Error::<Test>::InsufficientBalance
 					);
@@ -1321,7 +1393,12 @@ mod minting {
 					assert_noop!(
 						AAvatars::mint(
 							RuntimeOrigin::signed(ALICE),
-							MintOption { count: mint_count, mint_type: MintType::Free }
+							MintOption {
+								count: mint_count,
+								mint_type: MintType::Free,
+								mint_pack: PackType::Material,
+								mint_version: AvatarVersion::V1
+							}
 						),
 						Error::<Test>::InsufficientFreeMints
 					);
@@ -1360,7 +1437,6 @@ mod minting {
 mod forging {
 	use super::*;
 	use sp_runtime::testing::H256;
-	use sp_std::collections::btree_set::BTreeSet;
 
 	fn create_avatar_for_bob(dna: &[u8]) -> AvatarIdOf<Test> {
 		let avatar = Avatar::default().season_id(1).dna(dna);
@@ -1455,11 +1531,21 @@ mod forging {
 			|leader_id: &AvatarIdOf<Test>, expected_dna: &[u8], insert_dna: Option<&[u8]>| {
 				assert_ok!(AAvatars::mint(
 					RuntimeOrigin::signed(BOB),
-					MintOption { count: MintPackSize::Three, mint_type: MintType::Normal }
+					MintOption {
+						count: MintPackSize::Three,
+						mint_type: MintType::Normal,
+						mint_pack: PackType::Material,
+						mint_version: AvatarVersion::V1
+					}
 				));
 				assert_ok!(AAvatars::mint(
 					RuntimeOrigin::signed(BOB),
-					MintOption { count: MintPackSize::One, mint_type: MintType::Normal }
+					MintOption {
+						count: MintPackSize::One,
+						mint_type: MintType::Normal,
+						mint_pack: PackType::Material,
+						mint_version: AvatarVersion::V1
+					}
 				));
 
 				if let Some(dna) = insert_dna {
@@ -1514,7 +1600,12 @@ mod forging {
 				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					RuntimeOrigin::signed(BOB),
-					MintOption { count: MintPackSize::One, mint_type: MintType::Normal }
+					MintOption {
+						count: MintPackSize::One,
+						mint_type: MintType::Normal,
+						mint_pack: PackType::Material,
+						mint_version: AvatarVersion::V1
+					}
 				));
 				let leader_id = Owners::<Test>::get(BOB)[0];
 				assert_eq!(
@@ -1561,7 +1652,12 @@ mod forging {
 				assert_noop!(
 					AAvatars::mint(
 						RuntimeOrigin::signed(BOB),
-						MintOption { count: MintPackSize::One, mint_type: MintType::Normal }
+						MintOption {
+							count: MintPackSize::One,
+							mint_type: MintType::Normal,
+							mint_pack: PackType::Material,
+							mint_version: AvatarVersion::V1
+						}
 					),
 					Error::<Test>::PrematureSeasonEnd
 				);
@@ -1671,7 +1767,12 @@ mod forging {
 				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					RuntimeOrigin::signed(BOB),
-					MintOption { count: MintPackSize::Six, mint_type: MintType::Free }
+					MintOption {
+						count: MintPackSize::Six,
+						mint_type: MintType::Free,
+						mint_pack: PackType::Material,
+						mint_version: AvatarVersion::V1
+					}
 				));
 
 				// forge
@@ -1692,23 +1793,6 @@ mod forging {
 				));
 				let forged_leader = Avatars::<Test>::get(leader_id).unwrap().1;
 
-				// check the result of the compare method
-				let upgradable_indexes = original_leader.upgradable_indexes::<Test>().unwrap();
-				for (sacrifice, result) in original_sacrifices
-					.iter()
-					.zip([(true, BTreeSet::from([0, 2, 3])), (true, BTreeSet::from([0, 2, 3, 4]))])
-				{
-					assert_eq!(
-						original_leader.compare(
-							sacrifice,
-							&upgradable_indexes,
-							season.max_variations,
-							tiers[tiers.len() - 1].clone() as u8
-						),
-						result
-					)
-				}
-
 				// check all sacrifices are burned
 				for sacrifice_id in sacrifice_ids {
 					assert!(!Avatars::<Test>::contains_key(sacrifice_id));
@@ -1727,7 +1811,7 @@ mod forging {
 					assert_eq!(forged_leader.dna.to_vec()[i] >> 4, RarityTier::Legendary as u8);
 				}
 				System::assert_last_event(mock::RuntimeEvent::AAvatars(
-					crate::Event::AvatarForged { avatar_id: leader_id, upgraded_components: 2 },
+					crate::Event::AvatarsForged { avatar_ids: vec![(leader_id, 2)] },
 				));
 
 				// variations remain the same
@@ -1763,7 +1847,12 @@ mod forging {
 				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					RuntimeOrigin::signed(BOB),
-					MintOption { count: MintPackSize::Six, mint_type: MintType::Free }
+					MintOption {
+						count: MintPackSize::Six,
+						mint_type: MintType::Free,
+						mint_pack: PackType::Material,
+						mint_version: AvatarVersion::V1
+					}
 				));
 
 				// forge
@@ -1781,17 +1870,6 @@ mod forging {
 				));
 				let forged_leader = Avatars::<Test>::get(leader_id).unwrap().1;
 
-				// check the result of the compare method
-				let upgradable_indexes = original_leader.upgradable_indexes::<Test>().unwrap();
-				assert_eq!(
-					original_leader.compare(
-						&original_sacrifice,
-						&upgradable_indexes,
-						season.max_variations,
-						tiers[tiers.len() - 1].clone() as u8
-					),
-					(false, BTreeSet::from([2]))
-				);
 				// check all sacrifices are burned
 				assert!(!Avatars::<Test>::contains_key(sacrifice_id));
 				// check for souls accumulation
@@ -1800,7 +1878,7 @@ mod forging {
 				// check DNAs are the same
 				assert_eq!(original_leader.dna, forged_leader.dna);
 				System::assert_last_event(mock::RuntimeEvent::AAvatars(
-					crate::Event::AvatarForged { avatar_id: leader_id, upgraded_components: 0 },
+					crate::Event::AvatarsForged { avatar_ids: vec![(leader_id, 0)] },
 				));
 			});
 	}
@@ -1827,17 +1905,19 @@ mod forging {
 				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					RuntimeOrigin::signed(ALICE),
-					MintOption { count: MintPackSize::Six, mint_type: MintType::Free }
+					MintOption {
+						count: MintPackSize::Six,
+						mint_type: MintType::Free,
+						mint_pack: PackType::Material,
+						mint_version: AvatarVersion::V1
+					}
 				));
 				let leader_id = Owners::<Test>::get(ALICE)[0];
 				assert_eq!(
 					Avatars::<Test>::get(leader_id).unwrap().1.dna.to_vec(),
 					&[0x04, 0x05, 0x05, 0x03]
 				);
-				assert_eq!(
-					Avatars::<Test>::get(leader_id).unwrap().1.min_tier(),
-					tiers[0].clone() as u8,
-				);
+				assert_eq!(Avatars::<Test>::get(leader_id).unwrap().1.min_tier(), tiers[0] as u8,);
 
 				// mutate the DNA of leader to make it a tier higher
 				let mut leader_avatar = Avatars::<Test>::get(leader_id).unwrap();
@@ -1845,15 +1925,12 @@ mod forging {
 					.1
 					.dna
 					.iter()
-					.map(|x| ((tiers[1].clone() as u8) << 4) | (x & 0b0000_1111))
+					.map(|x| ((tiers[1] as u8) << 4) | (x & 0b0000_1111))
 					.collect::<Vec<_>>()
 					.try_into()
 					.unwrap();
 				Avatars::<Test>::insert(leader_id, &leader_avatar);
-				assert_eq!(
-					Avatars::<Test>::get(leader_id).unwrap().1.min_tier(),
-					tiers[1].clone() as u8
-				);
+				assert_eq!(Avatars::<Test>::get(leader_id).unwrap().1.min_tier(), tiers[1] as u8);
 
 				// forging doesn't take effect
 				let sacrifice_ids = &Owners::<Test>::get(ALICE)[1..5];
@@ -1939,7 +2016,12 @@ mod forging {
 				for _ in 0..33 {
 					assert_ok!(AAvatars::mint(
 						RuntimeOrigin::signed(ALICE),
-						MintOption { count: MintPackSize::Three, mint_type: MintType::Free }
+						MintOption {
+							count: MintPackSize::Three,
+							mint_type: MintType::Free,
+							mint_pack: PackType::Material,
+							mint_version: AvatarVersion::V1
+						}
 					));
 				}
 
@@ -1991,7 +2073,12 @@ mod forging {
 				for _ in 0..season.max_sacrifices {
 					assert_ok!(AAvatars::mint(
 						RuntimeOrigin::signed(ALICE),
-						MintOption { count: MintPackSize::One, mint_type: MintType::Free }
+						MintOption {
+							count: MintPackSize::One,
+							mint_type: MintType::Free,
+							mint_pack: PackType::Material,
+							mint_version: AvatarVersion::V1
+						}
 					));
 				}
 
@@ -2024,7 +2111,12 @@ mod forging {
 					for _ in 0..season.max_sacrifices {
 						assert_ok!(AAvatars::mint(
 							RuntimeOrigin::signed(player),
-							MintOption { count: MintPackSize::One, mint_type: MintType::Free }
+							MintOption {
+								count: MintPackSize::One,
+								mint_type: MintType::Free,
+								mint_pack: PackType::Material,
+								mint_version: AvatarVersion::V1
+							}
 						));
 					}
 				}
@@ -2056,7 +2148,12 @@ mod forging {
 				for _ in 0..season.max_sacrifices {
 					assert_ok!(AAvatars::mint(
 						RuntimeOrigin::signed(ALICE),
-						MintOption { count: MintPackSize::One, mint_type: MintType::Free }
+						MintOption {
+							count: MintPackSize::One,
+							mint_type: MintType::Free,
+							mint_pack: PackType::Material,
+							mint_version: AvatarVersion::V1
+						}
 					));
 				}
 
@@ -2095,11 +2192,21 @@ mod forging {
 				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					RuntimeOrigin::signed(ALICE),
-					MintOption { count: MintPackSize::Six, mint_type: MintType::Normal }
+					MintOption {
+						count: MintPackSize::Six,
+						mint_type: MintType::Normal,
+						mint_pack: PackType::Material,
+						mint_version: AvatarVersion::V1
+					}
 				));
 				assert_ok!(AAvatars::mint(
 					RuntimeOrigin::signed(BOB),
-					MintOption { count: MintPackSize::Six, mint_type: MintType::Normal }
+					MintOption {
+						count: MintPackSize::Six,
+						mint_type: MintType::Normal,
+						mint_pack: PackType::Material,
+						mint_version: AvatarVersion::V1
+					}
 				));
 
 				let leader = Owners::<Test>::get(ALICE)[0];
@@ -2152,7 +2259,12 @@ mod forging {
 				for _ in 0..max_sacrifices {
 					assert_ok!(AAvatars::mint(
 						RuntimeOrigin::signed(ALICE),
-						MintOption { count: MintPackSize::One, mint_type: MintType::Free }
+						MintOption {
+							count: MintPackSize::One,
+							mint_type: MintType::Free,
+							mint_pack: PackType::Material,
+							mint_version: AvatarVersion::V1
+						}
 					));
 					run_to_block(System::block_number() + 1);
 				}
@@ -2161,7 +2273,12 @@ mod forging {
 				for _ in 0..max_sacrifices {
 					assert_ok!(AAvatars::mint(
 						RuntimeOrigin::signed(ALICE),
-						MintOption { count: MintPackSize::One, mint_type: MintType::Free }
+						MintOption {
+							count: MintPackSize::One,
+							mint_type: MintType::Free,
+							mint_pack: PackType::Material,
+							mint_version: AvatarVersion::V1
+						}
 					));
 					run_to_block(System::block_number() + 1);
 				}
@@ -2860,7 +2977,12 @@ mod nft_transfer {
 				run_to_block(season.start);
 				assert_ok!(AAvatars::mint(
 					RuntimeOrigin::signed(ALICE),
-					MintOption { count: MintPackSize::Three, mint_type: MintType::Normal }
+					MintOption {
+						count: MintPackSize::Three,
+						mint_type: MintType::Normal,
+						mint_pack: PackType::Material,
+						mint_version: AvatarVersion::V1
+					}
 				));
 				let avatar_ids = Owners::<Test>::get(ALICE);
 				let avatar_id = avatar_ids[0];
@@ -2885,7 +3007,8 @@ mod nft_transfer {
 					Avatar {
 						season_id: 1,
 						dna: bounded_vec![0x10, 0x10, 0x13, 0x12, 0x00, 0x22, 0x02, 0x00],
-						souls: 6
+						souls: 6,
+						version: AvatarVersion::V1,
 					}
 				);
 

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -963,7 +963,7 @@ mod minting {
 
 		ExtBuilder::default()
 			.seasons(&[(1, season_1.clone()), (2, season_2)])
-			.mint_fees(fees)
+			.mint_fees(fees.clone())
 			.mint_cooldown(mint_cooldown)
 			.balances(&[(ALICE, initial_balance)])
 			.free_mints(&[(ALICE, initial_free_mints)])
@@ -1009,8 +1009,8 @@ mod minting {
 					));
 					match mint_type {
 						MintType::Normal => {
-							initial_balance -= fees.fee_for(&MintPackSize::One);
-							initial_treasury_balance += fees.fee_for(&MintPackSize::One);
+							initial_balance -= fees.clone().fee_for(&MintPackSize::One);
+							initial_treasury_balance += fees.clone().fee_for(&MintPackSize::One);
 
 							assert_eq!(Balances::total_balance(&ALICE), initial_balance);
 							assert_eq!(Treasury::<Test>::get(1), initial_treasury_balance);
@@ -1051,8 +1051,8 @@ mod minting {
 					));
 					match mint_type {
 						MintType::Normal => {
-							initial_balance -= fees.fee_for(&MintPackSize::Three);
-							initial_treasury_balance += fees.fee_for(&MintPackSize::Three);
+							initial_balance -= fees.clone().fee_for(&MintPackSize::Three);
+							initial_treasury_balance += fees.clone().fee_for(&MintPackSize::Three);
 
 							assert_eq!(Balances::total_balance(&ALICE), initial_balance);
 							assert_eq!(Treasury::<Test>::get(1), initial_treasury_balance);
@@ -1090,8 +1090,8 @@ mod minting {
 					));
 					match mint_type {
 						MintType::Normal => {
-							initial_balance -= fees.fee_for(&MintPackSize::Six);
-							initial_treasury_balance += fees.fee_for(&MintPackSize::Six);
+							initial_balance -= fees.clone().fee_for(&MintPackSize::Six);
+							initial_treasury_balance += fees.clone().fee_for(&MintPackSize::Six);
 
 							assert_eq!(Balances::total_balance(&ALICE), initial_balance);
 							assert_eq!(Treasury::<Test>::get(1), initial_treasury_balance);
@@ -1203,7 +1203,7 @@ mod minting {
 						AAvatars::mint(
 							RuntimeOrigin::signed(ALICE),
 							MintOption {
-								count,
+								count: count.clone(),
 								mint_type,
 								mint_pack: PackType::Material,
 								mint_version: AvatarVersion::V1
@@ -1225,7 +1225,7 @@ mod minting {
 						AAvatars::mint(
 							RuntimeOrigin::none(),
 							MintOption {
-								count,
+								count: count.clone(),
 								mint_type,
 								mint_pack: PackType::Material,
 								mint_version: AvatarVersion::V1
@@ -1251,7 +1251,7 @@ mod minting {
 							AAvatars::mint(
 								RuntimeOrigin::signed(ALICE),
 								MintOption {
-									count,
+									count: count.clone(),
 									mint_type,
 									mint_pack: PackType::Material,
 									mint_version: AvatarVersion::V1
@@ -1291,7 +1291,7 @@ mod minting {
 							AAvatars::mint(
 								RuntimeOrigin::signed(ALICE),
 								MintOption {
-									count,
+									count: count.clone(),
 									mint_type,
 									mint_pack: PackType::Material,
 									mint_version: AvatarVersion::V1
@@ -1917,7 +1917,10 @@ mod forging {
 					Avatars::<Test>::get(leader_id).unwrap().1.dna.to_vec(),
 					&[0x04, 0x05, 0x05, 0x03]
 				);
-				assert_eq!(Avatars::<Test>::get(leader_id).unwrap().1.min_tier(), tiers[0] as u8,);
+				assert_eq!(
+					Avatars::<Test>::get(leader_id).unwrap().1.min_tier(),
+					tiers[0].clone() as u8,
+				);
 
 				// mutate the DNA of leader to make it a tier higher
 				let mut leader_avatar = Avatars::<Test>::get(leader_id).unwrap();
@@ -1925,12 +1928,15 @@ mod forging {
 					.1
 					.dna
 					.iter()
-					.map(|x| ((tiers[1] as u8) << 4) | (x & 0b0000_1111))
+					.map(|x| ((tiers[1].clone() as u8) << 4) | (x & 0b0000_1111))
 					.collect::<Vec<_>>()
 					.try_into()
 					.unwrap();
 				Avatars::<Test>::insert(leader_id, &leader_avatar);
-				assert_eq!(Avatars::<Test>::get(leader_id).unwrap().1.min_tier(), tiers[1] as u8);
+				assert_eq!(
+					Avatars::<Test>::get(leader_id).unwrap().1.min_tier(),
+					tiers[1].clone() as u8
+				);
 
 				// forging doesn't take effect
 				let sacrifice_ids = &Owners::<Test>::get(ALICE)[1..5];

--- a/pallets/ajuna-awesome-avatars/src/types/account.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/account.rs
@@ -18,20 +18,15 @@ use super::{MintCount, SeasonId};
 use frame_support::pallet_prelude::*;
 use sp_runtime::{traits::Get, BoundedBTreeSet};
 
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, PartialEq)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
 pub enum StorageTier {
+	#[default]
 	One = 25,
 	Two = 50,
 	Three = 75,
 	Four = 100,
 	Five = 150,
 	Max = 200,
-}
-
-impl Default for StorageTier {
-	fn default() -> Self {
-		Self::One
-	}
 }
 
 impl StorageTier {

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/force.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/force.rs
@@ -18,22 +18,15 @@ use crate::*;
 use codec::alloc::string::ToString;
 use sp_std::{fmt, prelude::*};
 
-#[derive(
-	Encode, Decode, MaxEncodedLen, RuntimeDebug, TypeInfo, Clone, PartialEq, Eq, PartialOrd, Ord,
-)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Default, PartialEq)]
 pub enum Force {
+	#[default]
 	Kinetic = 0,
 	Dream = 1,
 	Solar = 2,
 	Thermal = 3,
 	Astral = 4,
 	Empathy = 5,
-}
-
-impl Default for Force {
-	fn default() -> Self {
-		Force::Kinetic
-	}
 }
 
 impl fmt::Display for Force {

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/mod.rs
@@ -17,15 +17,15 @@
 mod force;
 mod nft;
 mod rarity_tier;
+mod tools;
 
 pub use force::*;
 pub use nft::*;
 pub use rarity_tier::*;
+pub(crate) use tools::*;
 
-use crate::*;
 use frame_support::pallet_prelude::*;
-use sp_runtime::traits::{Saturating, Zero};
-use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
+use sp_std::prelude::*;
 
 pub type IpfsUrl = BoundedVec<u8, MaxIpfsUrl>;
 pub struct MaxIpfsUrl;
@@ -39,310 +39,32 @@ pub type SeasonId = u16;
 pub type Dna = BoundedVec<u8, ConstU32<100>>;
 pub type SoulCount = u32;
 
+/// Used to indicate which version of the forging and/or mint logic should be used.
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum AvatarVersion {
+	#[default]
+	V1,
+	V2,
+}
+
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
 pub struct Avatar {
 	pub season_id: SeasonId,
+	pub version: AvatarVersion,
 	pub dna: Dna,
 	pub souls: SoulCount,
 }
 
 impl Avatar {
-	pub(crate) fn compare_all<T: Config>(
-		&mut self,
-		others: &[Self],
-		max_variations: u8,
-		max_tier: u8,
-	) -> Result<(BTreeSet<usize>, u8), DispatchError> {
-		let upgradable_indexes = self.upgradable_indexes::<T>()?;
-		let leader_tier = self.min_tier();
-		others.iter().try_fold(
-			(BTreeSet::<usize>::new(), 0),
-			|(mut matched_components, mut matches), other| {
-				let sacrifice_tier = other.min_tier();
-				if sacrifice_tier >= leader_tier {
-					let (is_match, matching_components) =
-						self.compare(other, &upgradable_indexes, max_variations, max_tier);
-
-					if is_match {
-						matches += 1;
-						matched_components.extend(matching_components.iter());
-					}
-				}
-				self.souls.saturating_accrue(other.souls);
-				Ok((matched_components, matches))
-			},
-		)
-	}
-
-	pub(crate) fn upgradable_indexes<T: Config>(&self) -> Result<Vec<usize>, DispatchError> {
-		let min_tier = self.min_tier();
-		Ok(self
-			.dna
-			.iter()
-			.enumerate()
-			.filter(|(_, x)| (*x >> 4) == min_tier)
-			.map(|(i, _)| i)
-			.collect::<Vec<usize>>())
-	}
-
+	#[inline]
 	pub(crate) fn min_tier(&self) -> u8 {
-		self.dna.iter().map(|x| *x >> 4).min().unwrap_or_default()
+		self.version
+			.with_mapper(|mapper: Box<dyn AttributeMapper>| mapper.min_tier(self))
 	}
 
-	pub(crate) fn compare(
-		&self,
-		other: &Self,
-		indexes: &[usize],
-		max_variations: u8,
-		max_tier: u8,
-	) -> (bool, BTreeSet<usize>) {
-		let compare_variation = |lhs: u8, rhs: u8| -> bool {
-			let diff = if lhs > rhs { lhs - rhs } else { rhs - lhs };
-			diff == 1 || diff == (max_variations - 1)
-		};
-
-		let (matching_indexes, matches, mirrors) =
-			self.dna.clone().into_iter().zip(other.dna.clone()).enumerate().fold(
-				(BTreeSet::new(), 0, 0),
-				|(mut matching_indexes, mut matches, mut mirrors), (i, (lhs, rhs))| {
-					let lhs_variation = lhs & 0b0000_1111;
-					let rhs_variation = rhs & 0b0000_1111;
-					if lhs_variation == rhs_variation {
-						mirrors += 1;
-					}
-
-					if indexes.contains(&i) {
-						let lhs_tier = lhs >> 4;
-						let rhs_tier = rhs >> 4;
-						let is_matching_tier = lhs_tier == rhs_tier;
-						let is_maxed_tier = lhs_tier == max_tier;
-
-						let is_similar_variation = compare_variation(lhs_variation, rhs_variation);
-
-						if is_matching_tier && !is_maxed_tier && is_similar_variation {
-							matching_indexes.insert(i);
-							matches += 1;
-						}
-					}
-					(matching_indexes, matches, mirrors)
-				},
-			);
-
-		// 1 upgradable component requires 1 match + 4 mirrors
-		// 2 upgradable component requires 2 match + 2 mirrors
-		// 3 upgradable component requires 3 match + 0 mirrors
-		let mirrors_required = (3_u8.saturating_sub(matches)) * 2;
-		let is_match = matches >= 3 || (matches >= 1 && mirrors >= mirrors_required);
-		(is_match, matching_indexes)
-	}
-
-	pub(crate) fn forge_probability<T: Config>(
-		&self,
-		season: &SeasonOf<T>,
-		now: &T::BlockNumber,
-		matches: u8,
-	) -> Result<u8, DispatchError> {
-		let period_multiplier = self.forge_multiplier::<T>(season, now);
-		// p = base_prob + (1 - base_prob) * (matches / max_sacrifices) * (1 / period_multiplier)
-		let prob = season.base_prob +
-			((MAX_PERCENTAGE
-				.checked_sub(season.base_prob)
-				.ok_or(Error::<T>::BaseProbTooHigh)? /
-				season.max_sacrifices) *
-				matches) / period_multiplier;
-		Ok(prob)
-	}
-
-	fn forge_multiplier<T: Config>(&self, season: &SeasonOf<T>, now: &T::BlockNumber) -> u8 {
-		let mut current_period = season.current_period(now);
-		let mut last_variation = self.last_variation() as u16;
-
-		current_period.saturating_inc();
-		last_variation.saturating_inc();
-
-		let max_variations = season.max_variations as u16;
-		let is_in_period = if last_variation == max_variations {
-			(current_period % max_variations).is_zero()
-		} else {
-			(current_period % max_variations) == last_variation
-		};
-
-		if (current_period == last_variation) || is_in_period {
-			1
-		} else {
-			2
-		}
-	}
-
+	#[inline]
 	pub(crate) fn last_variation(&self) -> u8 {
-		self.dna.last().unwrap_or(&0) & 0b0000_1111
-	}
-}
-
-#[cfg(test)]
-mod test {
-	use super::*;
-	use crate::{mock::*, types::*};
-	use frame_support::{assert_err, assert_ok};
-
-	impl Avatar {
-		pub(crate) fn season_id(mut self, season_id: SeasonId) -> Self {
-			self.season_id = season_id;
-			self
-		}
-		pub(crate) fn dna(mut self, dna: &[u8]) -> Self {
-			self.dna = Dna::try_from(dna.to_vec()).unwrap();
-			self
-		}
-	}
-
-	#[test]
-	fn forge_probability_works() {
-		// | variation |  period |
-		// + --------- + ------- +
-		// |         1 |   1,  7 |
-		// |         2 |   2,  8 |
-		// |         3 |   3,  9 |
-		// |         4 |   4, 10 |
-		// |         5 |   5, 11 |
-		// |         6 |   6, 12 |
-		let per_period = 2;
-		let periods = 6;
-		let max_variations = 6;
-		let max_sacrifices = 4;
-
-		let season = Season::default()
-			.per_period(per_period)
-			.periods(periods)
-			.max_variations(max_variations)
-			.max_sacrifices(max_sacrifices)
-			.base_prob(0);
-
-		let avatar = Avatar::default().dna(&[1, 3, 3, 7, 0]);
-
-		// in period
-		let now = 1;
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 1), 25);
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 2), 50);
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 3), 75);
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 4), 100);
-
-		// not in period
-		let now = 2;
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 1), 12);
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 2), 25);
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 3), 37);
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 4), 50);
-
-		// increase base_prob to 10
-		let season = season.base_prob(10);
-		// in period
-		let now = 1;
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 1), 32);
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 2), 54);
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 3), 76);
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 4), 98);
-
-		// not in period
-		let now = 2;
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 1), 21);
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 2), 32);
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 3), 43);
-		assert_ok!(avatar.forge_probability::<Test>(&season, &now, 4), 54);
-
-		// increase base_prob to 101
-		let season = season.base_prob(MAX_PERCENTAGE + 1);
-		for forge_match in [1, 2, 3, 4] {
-			assert_err!(
-				avatar.forge_probability::<Test>(&season, &now, forge_match),
-				Error::<Test>::BaseProbTooHigh
-			);
-		}
-	}
-
-	#[test]
-	fn forge_multiplier_works() {
-		// | variation |      period |
-		// + --------- + ----------- +
-		// |         1 | 1, 4, 7, 10 |
-		// |         2 | 2, 5, 8, 11 |
-		// |         3 | 3, 6, 9, 12 |
-		let per_period = 4;
-		let periods = 3;
-		let max_variations = 3;
-
-		let season = Season::default()
-			.per_period(per_period)
-			.periods(periods)
-			.max_variations(max_variations);
-
-		#[allow(clippy::erasing_op, clippy::identity_op)]
-		for (range, dna, expected_period, expected_multiplier) in [
-			// cycle 0, period 0, last_variation must be 0
-			((0 * per_period)..((0 + 1) * per_period), [7, 3, 5, 7, 0], 0, 1),
-			((0 * per_period)..((0 + 1) * per_period), [7, 3, 5, 7, 1], 0, 2),
-			((0 * per_period)..((0 + 1) * per_period), [7, 3, 5, 7, 2], 0, 2),
-			// cycle 0, period 1, last_variation must be 1
-			((1 * per_period)..((1 + 1) * per_period), [7, 3, 5, 7, 0], 1, 2),
-			((1 * per_period)..((1 + 1) * per_period), [7, 3, 5, 7, 1], 1, 1),
-			((1 * per_period)..((1 + 1) * per_period), [7, 3, 5, 7, 2], 1, 2),
-			// cycle 0, period 2, last_variation must be 2
-			((2 * per_period)..((2 + 1) * per_period), [7, 3, 5, 7, 0], 2, 2),
-			((2 * per_period)..((2 + 1) * per_period), [7, 3, 5, 7, 1], 2, 2),
-			((2 * per_period)..((2 + 1) * per_period), [7, 3, 5, 7, 2], 2, 1),
-			// cycle 1, period 0, last_variation must be 0
-			((3 * per_period)..((3 + 1) * per_period), [7, 3, 5, 7, 0], 0, 1),
-			((3 * per_period)..((3 + 1) * per_period), [7, 3, 5, 7, 1], 0, 2),
-			((3 * per_period)..((3 + 1) * per_period), [7, 3, 5, 7, 2], 0, 2),
-			// cycle 1, period 1, last_variation must be 1
-			((4 * per_period)..((4 + 1) * per_period), [7, 3, 5, 7, 0], 1, 2),
-			((4 * per_period)..((4 + 1) * per_period), [7, 3, 5, 7, 1], 1, 1),
-			((4 * per_period)..((4 + 1) * per_period), [7, 3, 5, 7, 2], 1, 2),
-			// cycle 1, period 2, last_variation must be 2
-			((5 * per_period)..((5 + 1) * per_period), [7, 3, 5, 7, 0], 2, 2),
-			((5 * per_period)..((5 + 1) * per_period), [7, 3, 5, 7, 1], 2, 2),
-			((5 * per_period)..((5 + 1) * per_period), [7, 3, 5, 7, 2], 2, 1),
-		] {
-			for now in range {
-				assert_eq!(season.current_period(&now), expected_period);
-
-				let avatar = Avatar::default().dna(&dna);
-				assert_eq!(avatar.forge_multiplier::<Test>(&season, &now), expected_multiplier);
-			}
-		}
-	}
-
-	#[test]
-	fn compare_works() {
-		let season = Season::default()
-			.early_start(100)
-			.start(200)
-			.end(150_000)
-			.max_tier_forges(100)
-			.max_variations(6)
-			.max_components(11)
-			.min_sacrifices(1)
-			.max_sacrifices(4)
-			.tiers(&[RarityTier::Common, RarityTier::Rare, RarityTier::Legendary])
-			.single_mint_probs(&[95, 5])
-			.batch_mint_probs(&[80, 20])
-			.base_prob(20)
-			.per_period(20)
-			.periods(12);
-
-		let leader = Avatar::default()
-			.dna(&[0x21, 0x05, 0x23, 0x24, 0x20, 0x22, 0x25, 0x23, 0x05, 0x04, 0x02]);
-		let other = Avatar::default()
-			.dna(&[0x04, 0x00, 0x00, 0x04, 0x02, 0x04, 0x02, 0x00, 0x05, 0x05, 0x04]);
-
-		assert_eq!(
-			leader.compare(
-				&other,
-				&[1, 8, 9, 10],
-				season.max_variations,
-				RarityTier::Legendary as u8,
-			),
-			(true, BTreeSet::from([1, 9]))
-		);
+		self.version
+			.with_mapper(|mapper: Box<dyn AttributeMapper>| mapper.last_variation(self))
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/mod.rs
@@ -40,7 +40,7 @@ pub type Dna = BoundedVec<u8, ConstU32<100>>;
 pub type SoulCount = u32;
 
 /// Used to indicate which version of the forging and/or mint logic should be used.
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
 pub enum AvatarVersion {
 	#[default]
 	V1,
@@ -56,13 +56,11 @@ pub struct Avatar {
 }
 
 impl Avatar {
-	#[inline]
 	pub(crate) fn min_tier(&self) -> u8 {
 		self.version
 			.with_mapper(|mapper: Box<dyn AttributeMapper>| mapper.min_tier(self))
 	}
 
-	#[inline]
 	pub(crate) fn last_variation(&self) -> u8 {
 		self.version
 			.with_mapper(|mapper: Box<dyn AttributeMapper>| mapper.last_variation(self))

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/rarity_tier.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/rarity_tier.rs
@@ -19,7 +19,17 @@ use codec::alloc::string::ToString;
 use sp_std::{fmt, prelude::*};
 
 #[derive(
-	Encode, Decode, MaxEncodedLen, RuntimeDebug, TypeInfo, Clone, PartialEq, Eq, PartialOrd, Ord,
+	Encode,
+	Decode,
+	MaxEncodedLen,
+	RuntimeDebug,
+	TypeInfo,
+	Copy,
+	Clone,
+	PartialEq,
+	Eq,
+	PartialOrd,
+	Ord,
 )]
 pub enum RarityTier {
 	Common = 0,

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/rarity_tier.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/rarity_tier.rs
@@ -19,31 +19,16 @@ use codec::alloc::string::ToString;
 use sp_std::{fmt, prelude::*};
 
 #[derive(
-	Encode,
-	Decode,
-	MaxEncodedLen,
-	RuntimeDebug,
-	TypeInfo,
-	Copy,
-	Clone,
-	PartialEq,
-	Eq,
-	PartialOrd,
-	Ord,
+	Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord,
 )]
 pub enum RarityTier {
+	#[default]
 	Common = 0,
 	Uncommon = 1,
 	Rare = 2,
 	Epic = 3,
 	Legendary = 4,
 	Mythical = 5,
-}
-
-impl Default for RarityTier {
-	fn default() -> Self {
-		RarityTier::Common
-	}
 }
 
 impl fmt::Display for RarityTier {

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/mod.rs
@@ -1,0 +1,149 @@
+mod v1;
+mod v2;
+
+use crate::*;
+use frame_support::pallet_prelude::*;
+use sp_std::{boxed::Box, vec::Vec};
+
+pub(crate) trait AttributeProvider {
+	fn get_mapper(&self) -> Box<dyn AttributeMapper>;
+	fn with_mapper<F, R>(&self, func: F) -> R
+	where
+		F: Fn(Box<dyn AttributeMapper>) -> R;
+}
+
+impl AttributeProvider for AvatarVersion {
+	fn get_mapper(&self) -> Box<dyn AttributeMapper> {
+		match self {
+			AvatarVersion::V1 => Box::new(v1::AttributeMapperV1),
+			AvatarVersion::V2 => Box::new(v2::AttributeMapperV2),
+		}
+	}
+
+	fn with_mapper<F, R>(&self, func: F) -> R
+	where
+		F: Fn(Box<dyn AttributeMapper>) -> R,
+	{
+		func(self.get_mapper())
+	}
+}
+
+pub(crate) trait AttributeMapper {
+	/// Used to obtain the RarityTier of a given avatar as an u8.
+	fn min_tier(&self, target: &Avatar) -> u8;
+
+	/// Used to get the ForceType of a given avatar as an u8.
+	fn last_variation(&self, target: &Avatar) -> u8;
+}
+
+/// Trait used to implement generic minting logic for an entity.
+pub(crate) trait MintProvider<T: Config> {
+	fn get_minter(&self) -> Box<dyn Minter<T>>;
+	fn with_minter<F, R>(&self, func: F) -> R
+	where
+		F: Fn(Box<dyn Minter<T>>) -> R;
+}
+
+impl<T> MintProvider<T> for AvatarVersion
+where
+	T: Config,
+{
+	fn get_minter(&self) -> Box<dyn Minter<T>> {
+		match self {
+			AvatarVersion::V1 => Box::new(v1::AvatarMinterV1::<T>(PhantomData)),
+			AvatarVersion::V2 => Box::new(v2::AvatarMinterV2::<T>(PhantomData)),
+		}
+	}
+
+	fn with_minter<F, R>(&self, func: F) -> R
+	where
+		F: Fn(Box<dyn Minter<T>>) -> R,
+	{
+		func(self.get_minter())
+	}
+}
+
+/// A tuple containing and avatar identifier with its represented avatar, returned as mint output.
+pub(crate) type MintOutput<T> = (AvatarIdOf<T>, Avatar);
+
+pub(crate) trait Minter<T: Config> {
+	fn mint_avatar_set(
+		&self,
+		player: &T::AccountId,
+		season_id: &SeasonId,
+		season: &SeasonOf<T>,
+		mint_option: &MintOption,
+	) -> Result<Vec<MintOutput<T>>, DispatchError>;
+}
+
+/// Trait used to implement generic forging logic for an entity.
+pub(crate) trait ForgeProvider<T: Config> {
+	fn get_forger(&self) -> Box<dyn Forger<T>>;
+	fn with_forger<F, R>(&self, func: F) -> R
+	where
+		F: Fn(Box<dyn Forger<T>>) -> R;
+}
+
+impl<T> ForgeProvider<T> for AvatarVersion
+where
+	T: Config,
+{
+	fn get_forger(&self) -> Box<dyn Forger<T>> {
+		match self {
+			AvatarVersion::V1 => Box::new(v1::AvatarForgerV1::<T>(PhantomData)),
+			AvatarVersion::V2 => Box::new(v2::AvatarForgerV2::<T>(PhantomData)),
+		}
+	}
+
+	fn with_forger<F, R>(&self, func: F) -> R
+	where
+		F: Fn(Box<dyn Forger<T>>) -> R,
+	{
+		func(self.get_forger())
+	}
+}
+
+/// A tuple containing and avatar identifier with its represented avatar, used as forging inputs.
+pub(crate) type ForgeItem<T> = (AvatarIdOf<T>, Avatar);
+/// Number of components upgraded after a forge in a given Avatar.
+pub(crate) type UpgradedComponents = u8;
+
+// TODO: Add a new state -> Unchanged to both Leader and Forge outputs
+/// Enum used to express the possible results of the forge on the leader avatar.
+pub(crate) enum LeaderForgeOutput<T: Config> {
+	/// The leader avatar was forged (mutated) in some way.
+	Forged(ForgeItem<T>, UpgradedComponents),
+	/// The leader avatar was consumed in the forging process.
+	Consumed(AvatarIdOf<T>),
+}
+/// Enum used to express the possible results of the forge on the other avatars, also called
+/// sacrifices.
+pub(crate) enum ForgeOutput<T: Config> {
+	/// The avatar was forged (mutate) in some way.
+	Forged(ForgeItem<T>, UpgradedComponents),
+	/// A new avatar was created from the forging process.
+	Minted(Avatar),
+	/// The avatar was consumed in the forging process.
+	Consumed(AvatarIdOf<T>),
+}
+
+/// Trait used to define the surface logic of the forging algorithm.
+pub(crate) trait Forger<T: Config> {
+	/// Tries to use the supplied inputs and forge them.
+	fn forge_with(
+		&self,
+		player: &T::AccountId,
+		season_id: SeasonId,
+		season: &SeasonOf<T>,
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError>;
+
+	/// Validates that all inputs can be used in the forging process.
+	fn can_be_forged(
+		&self,
+		season: &SeasonOf<T>,
+		input_leader: &ForgeItem<T>,
+		input_sacrifices: &[ForgeItem<T>],
+	) -> Result<(), DispatchError>;
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/mod.rs
@@ -145,5 +145,5 @@ pub(crate) trait Forger<T: Config> {
 		season: &SeasonOf<T>,
 		input_leader: &ForgeItem<T>,
 		input_sacrifices: &[ForgeItem<T>],
-	) -> Result<(), DispatchError>;
+	) -> DispatchResult;
 }

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v1.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v1.rs
@@ -1,0 +1,642 @@
+use crate::*;
+use sp_runtime::{traits::Zero, DispatchError, Saturating};
+use sp_std::{collections::btree_set::BTreeSet, marker::PhantomData, vec::Vec};
+
+pub(super) struct AttributeMapperV1;
+
+impl AttributeMapper for AttributeMapperV1 {
+	fn min_tier(&self, target: &Avatar) -> u8 {
+		target.dna.iter().map(|x| *x >> 4).min().unwrap_or_default()
+	}
+
+	fn last_variation(&self, target: &Avatar) -> u8 {
+		target.dna.last().unwrap_or(&0) & 0b0000_1111
+	}
+}
+
+pub(super) struct AvatarMinterV1<'a, T: Config>(pub PhantomData<&'a T>);
+
+impl<'a, T> Minter<T> for AvatarMinterV1<'a, T>
+where
+	T: Config,
+{
+	fn mint_avatar_set(
+		&self,
+		player: &T::AccountId,
+		season_id: &SeasonId,
+		season: &SeasonOf<T>,
+		mint_option: &MintOption,
+	) -> Result<Vec<MintOutput<T>>, DispatchError> {
+		let is_batched = mint_option.count.is_batched();
+		(0..mint_option.count as usize)
+			.map(|_| {
+				let avatar_id = Pallet::<T>::random_hash(b"create_avatar", player);
+				let dna = self.random_dna(&avatar_id, season, is_batched)?;
+				let souls = (dna.iter().map(|x| *x as SoulCount).sum::<SoulCount>() % 100) + 1;
+				let avatar =
+					Avatar { season_id: *season_id, version: AvatarVersion::V1, dna, souls };
+				Ok((avatar_id, avatar))
+			})
+			.collect::<Result<Vec<MintOutput<T>>, _>>()
+	}
+}
+
+impl<'a, T> AvatarMinterV1<'a, T>
+where
+	T: Config,
+{
+	#[inline]
+	fn random_dna(
+		&self,
+		hash: &T::Hash,
+		season: &SeasonOf<T>,
+		batched_mint: bool,
+	) -> Result<Dna, DispatchError> {
+		let dna = (0..season.max_components)
+			.map(|i| {
+				let (random_tier, random_variation) =
+					Self::random_component(season, hash, i as usize * 2, batched_mint);
+				((random_tier << 4) | random_variation) as u8
+			})
+			.collect::<Vec<_>>();
+		Dna::try_from(dna).map_err(|_| Error::<T>::IncorrectDna.into())
+	}
+
+	#[inline]
+	fn random_component(
+		season: &SeasonOf<T>,
+		hash: &T::Hash,
+		index: usize,
+		batched_mint: bool,
+	) -> (u8, u8) {
+		let hash = hash.as_ref();
+		let random_tier = {
+			let random_prob = hash[index] % MAX_PERCENTAGE;
+			let probs =
+				if batched_mint { &season.batch_mint_probs } else { &season.single_mint_probs };
+			let mut cumulative_sum = 0;
+			let mut random_tier = season.tiers[0] as u8;
+			for i in 0..probs.len() {
+				let new_cumulative_sum = cumulative_sum + probs[i];
+				if random_prob >= cumulative_sum && random_prob < new_cumulative_sum {
+					random_tier = season.tiers[i] as u8;
+					break
+				}
+				cumulative_sum = new_cumulative_sum;
+			}
+			random_tier
+		};
+		let random_variation = hash[index + 1] % season.max_variations;
+		(random_tier, random_variation)
+	}
+}
+
+pub(super) struct AvatarForgerV1<'a, T: Config>(pub PhantomData<&'a T>);
+
+impl<'a, T> Forger<T> for AvatarForgerV1<'a, T>
+where
+	T: Config,
+{
+	fn forge_with(
+		&self,
+		player: &T::AccountId,
+		_season_id: SeasonId,
+		season: &SeasonOf<T>,
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		self.can_be_forged(season, &input_leader, &input_sacrifices)?;
+
+		let (leader_id, mut leader) = input_leader;
+
+		let max_tier = season.max_tier() as u8;
+		let current_block = <frame_system::Pallet<T>>::block_number();
+
+		let (sacrifice_ids, sacrifice_avatars): (Vec<AvatarIdOf<T>>, Vec<Avatar>) =
+			input_sacrifices.into_iter().unzip();
+
+		let (mut unique_matched_indexes, matches, soul_count) = self.compare_all(
+			&leader,
+			sacrifice_avatars.as_slice(),
+			season.max_variations,
+			max_tier,
+		)?;
+
+		leader.souls += soul_count;
+
+		let mut upgraded_components = 0;
+		let prob = self.forge_probability(&leader, season, &current_block, matches);
+		let rolls = sacrifice_avatars.len();
+		let random_hash = Pallet::<T>::random_hash(b"forging avatar", player);
+
+		for hash in random_hash.as_ref().iter().take(rolls) {
+			let roll = hash % MAX_PERCENTAGE;
+			if roll <= prob {
+				if let Some(first_matched_index) = unique_matched_indexes.pop_first() {
+					let nucleotide = leader.dna[first_matched_index];
+					let current_tier_index = season
+						.tiers
+						.iter()
+						.position(|tier| *tier as u8 == nucleotide >> 4)
+						.ok_or(Error::<T>::UnknownTier)?;
+
+					let already_maxed_out = current_tier_index == (season.tiers.len() - 1);
+					if !already_maxed_out {
+						let next_tier = season.tiers[current_tier_index + 1] as u8;
+						let upgraded_nucleotide = (next_tier << 4) | (nucleotide & 0b0000_1111);
+						leader.dna[first_matched_index] = upgraded_nucleotide;
+						upgraded_components += 1;
+					}
+				}
+			}
+		}
+
+		Ok((
+			LeaderForgeOutput::Forged((leader_id, leader), upgraded_components),
+			sacrifice_ids
+				.into_iter()
+				.map(|sacrifice_id| ForgeOutput::Consumed(sacrifice_id))
+				.collect(),
+		))
+	}
+
+	fn can_be_forged(
+		&self,
+		_season: &SeasonOf<T>,
+		input_leader: &ForgeItem<T>,
+		input_sacrifices: &[ForgeItem<T>],
+	) -> Result<(), DispatchError> {
+		if input_sacrifices
+			.iter()
+			.all(|(_, avatar)| avatar.version == input_leader.1.version)
+		{
+			Ok(())
+		} else {
+			Err(Error::<T>::IncompatibleAvatarVersions.into())
+		}
+	}
+}
+
+impl<'a, T> AvatarForgerV1<'a, T>
+where
+	T: Config,
+{
+	fn compare_all(
+		&self,
+		target: &Avatar,
+		others: &[Avatar],
+		max_variations: u8,
+		max_tier: u8,
+	) -> Result<(BTreeSet<usize>, u8, SoulCount), DispatchError> {
+		let upgradable_indexes = self.upgradable_indexes_for_target(target)?;
+		let leader_tier = AttributeMapperV1.min_tier(target);
+		others.iter().try_fold(
+			(BTreeSet::<usize>::new(), 0, SoulCount::zero()),
+			|(mut matched_components, mut matches, mut souls), other| {
+				let sacrifice_tier = AttributeMapperV1.min_tier(other);
+				if sacrifice_tier >= leader_tier {
+					let (is_match, matching_components) =
+						self.compare(target, other, &upgradable_indexes, max_variations, max_tier);
+
+					if is_match {
+						matches += 1;
+						matched_components.extend(matching_components.iter());
+					}
+
+					souls.saturating_accrue(other.souls)
+				}
+				Ok((matched_components, matches, souls))
+			},
+		)
+	}
+
+	fn upgradable_indexes_for_target(&self, target: &Avatar) -> Result<Vec<usize>, DispatchError> {
+		let min_tier = AttributeMapperV1.min_tier(target);
+		Ok(target
+			.dna
+			.iter()
+			.enumerate()
+			.filter(|(_, x)| (*x >> 4) == min_tier)
+			.map(|(i, _)| i)
+			.collect::<Vec<usize>>())
+	}
+
+	fn compare(
+		&self,
+		target: &Avatar,
+		other: &Avatar,
+		indexes: &[usize],
+		max_variations: u8,
+		max_tier: u8,
+	) -> (bool, BTreeSet<usize>) {
+		let compare_variation = |lhs: u8, rhs: u8| -> bool {
+			let diff = if lhs > rhs { lhs - rhs } else { rhs - lhs };
+			diff == 1 || diff == (max_variations - 1)
+		};
+
+		let (matching_indexes, matches, mirrors) =
+			target.dna.clone().into_iter().zip(other.dna.clone()).enumerate().fold(
+				(BTreeSet::new(), 0, 0),
+				|(mut matching_indexes, mut matches, mut mirrors), (i, (lhs, rhs))| {
+					let lhs_variation = lhs & 0b0000_1111;
+					let rhs_variation = rhs & 0b0000_1111;
+					if lhs_variation == rhs_variation {
+						mirrors += 1;
+					}
+
+					if indexes.contains(&i) {
+						let lhs_tier = lhs >> 4;
+						let rhs_tier = rhs >> 4;
+						let is_matching_tier = lhs_tier == rhs_tier;
+						let is_maxed_tier = lhs_tier == max_tier;
+
+						let is_similar_variation = compare_variation(lhs_variation, rhs_variation);
+
+						if is_matching_tier && !is_maxed_tier && is_similar_variation {
+							matching_indexes.insert(i);
+							matches += 1;
+						}
+					}
+					(matching_indexes, matches, mirrors)
+				},
+			);
+
+		// 1 upgradable component requires 1 match + 4 mirrors
+		// 2 upgradable component requires 2 match + 2 mirrors
+		// 3 upgradable component requires 3 match + 0 mirrors
+		let mirrors_required = (3_u8.saturating_sub(matches)) * 2;
+		let is_match = matches >= 3 || (matches >= 1 && mirrors >= mirrors_required);
+		(is_match, matching_indexes)
+	}
+
+	fn forge_probability(
+		&self,
+		target: &Avatar,
+		season: &SeasonOf<T>,
+		now: &T::BlockNumber,
+		matches: u8,
+	) -> u8 {
+		let period_multiplier = self.forge_multiplier(target, season, now);
+		// p = base_prob + (1 - base_prob) * (matches / max_sacrifices) * (1 / period_multiplier)
+		season.base_prob +
+			(((MAX_PERCENTAGE - season.base_prob) / season.max_sacrifices) * matches) /
+				period_multiplier
+	}
+
+	fn forge_multiplier(&self, target: &Avatar, season: &SeasonOf<T>, now: &T::BlockNumber) -> u8 {
+		let mut current_period = season.current_period(now);
+		let mut last_variation = AttributeMapperV1.last_variation(target) as u16;
+
+		current_period.saturating_inc();
+		last_variation.saturating_inc();
+
+		let max_variations = season.max_variations as u16;
+		let is_in_period = if last_variation == max_variations {
+			(current_period % max_variations).is_zero()
+		} else {
+			(current_period % max_variations) == last_variation
+		};
+
+		if (current_period == last_variation) || is_in_period {
+			1
+		} else {
+			2 // TODO: move this to config
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::*;
+	use frame_support::assert_ok;
+
+	impl Avatar {
+		pub(crate) fn season_id(mut self, season_id: SeasonId) -> Self {
+			self.season_id = season_id;
+			self
+		}
+		pub(crate) fn dna(mut self, dna: &[u8]) -> Self {
+			self.dna = Dna::try_from(dna.to_vec()).unwrap();
+			self
+		}
+	}
+
+	#[test]
+	fn forge_probability_works() {
+		// | variation |  period |
+		// + --------- + ------- +
+		// |         1 |   1,  7 |
+		// |         2 |   2,  8 |
+		// |         3 |   3,  9 |
+		// |         4 |   4, 10 |
+		// |         5 |   5, 11 |
+		// |         6 |   6, 12 |
+		let per_period = 2;
+		let periods = 6;
+		let max_variations = 6;
+		let max_sacrifices = 4;
+
+		let season = Season::default()
+			.per_period(per_period)
+			.periods(periods)
+			.max_variations(max_variations)
+			.max_sacrifices(max_sacrifices)
+			.base_prob(0);
+
+		let avatar = Avatar::default().dna(&[1, 3, 3, 7, 0]);
+		let forger = AvatarForgerV1::<Test>(PhantomData);
+
+		// in period
+		let now = 1;
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 1), 25);
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 2), 50);
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 3), 75);
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 4), 100);
+
+		// not in period
+		let now = 2;
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 1), 12);
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 2), 25);
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 3), 37);
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 4), 50);
+
+		// increase base_prob to 10
+		let season = season.base_prob(10);
+		// in period
+		let now = 1;
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 1), 32);
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 2), 54);
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 3), 76);
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 4), 98);
+
+		// not in period
+		let now = 2;
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 1), 21);
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 2), 32);
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 3), 43);
+		assert_eq!(forger.forge_probability(&avatar, &season, &now, 4), 54);
+	}
+
+	#[test]
+	fn forge_multiplier_works() {
+		// | variation |      period |
+		// + --------- + ----------- +
+		// |         1 | 1, 4, 7, 10 |
+		// |         2 | 2, 5, 8, 11 |
+		// |         3 | 3, 6, 9, 12 |
+		let per_period = 4;
+		let periods = 3;
+		let max_variations = 3;
+
+		let season = Season::default()
+			.per_period(per_period)
+			.periods(periods)
+			.max_variations(max_variations);
+
+		#[allow(clippy::erasing_op, clippy::identity_op)]
+		for (range, dna, expected_period, expected_multiplier) in [
+			// cycle 0, period 0, last_variation must be 0
+			((0 * per_period)..((0 + 1) * per_period), [7, 3, 5, 7, 0], 0, 1),
+			((0 * per_period)..((0 + 1) * per_period), [7, 3, 5, 7, 1], 0, 2),
+			((0 * per_period)..((0 + 1) * per_period), [7, 3, 5, 7, 2], 0, 2),
+			// cycle 0, period 1, last_variation must be 1
+			((1 * per_period)..((1 + 1) * per_period), [7, 3, 5, 7, 0], 1, 2),
+			((1 * per_period)..((1 + 1) * per_period), [7, 3, 5, 7, 1], 1, 1),
+			((1 * per_period)..((1 + 1) * per_period), [7, 3, 5, 7, 2], 1, 2),
+			// cycle 0, period 2, last_variation must be 2
+			((2 * per_period)..((2 + 1) * per_period), [7, 3, 5, 7, 0], 2, 2),
+			((2 * per_period)..((2 + 1) * per_period), [7, 3, 5, 7, 1], 2, 2),
+			((2 * per_period)..((2 + 1) * per_period), [7, 3, 5, 7, 2], 2, 1),
+			// cycle 1, period 0, last_variation must be 0
+			((3 * per_period)..((3 + 1) * per_period), [7, 3, 5, 7, 0], 0, 1),
+			((3 * per_period)..((3 + 1) * per_period), [7, 3, 5, 7, 1], 0, 2),
+			((3 * per_period)..((3 + 1) * per_period), [7, 3, 5, 7, 2], 0, 2),
+			// cycle 1, period 1, last_variation must be 1
+			((4 * per_period)..((4 + 1) * per_period), [7, 3, 5, 7, 0], 1, 2),
+			((4 * per_period)..((4 + 1) * per_period), [7, 3, 5, 7, 1], 1, 1),
+			((4 * per_period)..((4 + 1) * per_period), [7, 3, 5, 7, 2], 1, 2),
+			// cycle 1, period 2, last_variation must be 2
+			((5 * per_period)..((5 + 1) * per_period), [7, 3, 5, 7, 0], 2, 2),
+			((5 * per_period)..((5 + 1) * per_period), [7, 3, 5, 7, 1], 2, 2),
+			((5 * per_period)..((5 + 1) * per_period), [7, 3, 5, 7, 2], 2, 1),
+		] {
+			for now in range {
+				assert_eq!(season.current_period(&now), expected_period);
+
+				let avatar = Avatar::default().dna(&dna);
+				let forger = AvatarForgerV1::<Test>(PhantomData);
+				assert_eq!(forger.forge_multiplier(&avatar, &season, &now), expected_multiplier);
+			}
+		}
+	}
+
+	#[test]
+	fn compare_works() {
+		let season = Season::default()
+			.early_start(100)
+			.start(200)
+			.end(150_000)
+			.max_tier_forges(100)
+			.max_variations(6)
+			.max_components(11)
+			.min_sacrifices(1)
+			.max_sacrifices(4)
+			.tiers(&[RarityTier::Common, RarityTier::Rare, RarityTier::Legendary])
+			.single_mint_probs(&[95, 5])
+			.batch_mint_probs(&[80, 20])
+			.base_prob(20)
+			.per_period(20)
+			.periods(12);
+
+		let leader = Avatar::default()
+			.dna(&[0x21, 0x05, 0x23, 0x24, 0x20, 0x22, 0x25, 0x23, 0x05, 0x04, 0x02]);
+		let other = Avatar::default()
+			.dna(&[0x04, 0x00, 0x00, 0x04, 0x02, 0x04, 0x02, 0x00, 0x05, 0x05, 0x04]);
+		let forger = AvatarForgerV1::<Test>(PhantomData);
+
+		assert_eq!(
+			forger.compare(
+				&leader,
+				&other,
+				&[1, 8, 9, 10],
+				season.max_variations,
+				*season.tiers.last().unwrap() as u8,
+			),
+			(true, BTreeSet::from([1, 9]))
+		);
+	}
+
+	#[test]
+	fn forge_should_work_for_matches() {
+		let tiers = &[RarityTier::Common, RarityTier::Legendary];
+		let season = Season::default()
+			.tiers(tiers)
+			.batch_mint_probs(&[100])
+			.max_components(5)
+			.max_variations(3)
+			.min_sacrifices(1)
+			.max_sacrifices(2);
+
+		ExtBuilder::default()
+			.seasons(&[(1, season.clone())])
+			.mint_cooldown(1)
+			.free_mints(&[(BOB, 10)])
+			.build()
+			.execute_with(|| {
+				// prepare avatars to forge
+				run_to_block(season.start);
+				assert_ok!(AAvatars::mint(
+					RuntimeOrigin::signed(BOB),
+					MintOption {
+						count: MintPackSize::Six,
+						mint_type: MintType::Free,
+						mint_version: AvatarVersion::V1,
+						mint_pack: PackType::default(),
+					}
+				));
+
+				// forge
+				let owned_avatar_ids = Owners::<Test>::get(BOB);
+				let leader_id = owned_avatar_ids[0];
+				let sacrifice_ids = &owned_avatar_ids[1..3];
+
+				let original_leader: Avatar = Avatars::<Test>::get(leader_id).unwrap().1;
+				let original_sacrifices = sacrifice_ids
+					.iter()
+					.map(|id| Avatars::<Test>::get(id).unwrap().1)
+					.collect::<Vec<_>>();
+
+				assert_ok!(AAvatars::forge(
+					RuntimeOrigin::signed(BOB),
+					leader_id,
+					sacrifice_ids.to_vec()
+				));
+				let forged_leader = Avatars::<Test>::get(leader_id).unwrap().1;
+
+				// check the result of the compare method
+				let forger = AvatarForgerV1::<Test>(PhantomData);
+				let upgradable_indexes =
+					forger.upgradable_indexes_for_target(&original_leader).unwrap();
+				for (sacrifice, result) in original_sacrifices
+					.iter()
+					.zip([(true, BTreeSet::from([0, 2, 3])), (true, BTreeSet::from([0, 2, 3, 4]))])
+				{
+					assert_eq!(
+						forger.compare(
+							&original_leader,
+							sacrifice,
+							&upgradable_indexes,
+							season.max_variations,
+							tiers[tiers.len() - 1] as u8
+						),
+						result
+					)
+				}
+
+				// check all sacrifices are burned
+				for sacrifice_id in sacrifice_ids {
+					assert!(!Avatars::<Test>::contains_key(sacrifice_id));
+				}
+				// check for souls accumulation
+				assert_eq!(
+					forged_leader.souls,
+					original_leader.souls +
+						original_sacrifices.iter().map(|x| x.souls).sum::<SoulCount>(),
+				);
+
+				// check for the upgraded DNA
+				assert_ne!(original_leader.dna[0..=1], forged_leader.dna[0..=1]);
+				assert_eq!(original_leader.dna.to_vec()[0] >> 4, RarityTier::Common as u8);
+				assert_eq!(original_leader.dna.to_vec()[1] >> 4, RarityTier::Common as u8);
+				assert_eq!(forged_leader.dna.to_vec()[0] >> 4, RarityTier::Legendary as u8);
+				assert_eq!(forged_leader.dna.to_vec()[1] >> 4, RarityTier::Common as u8);
+				System::assert_last_event(mock::RuntimeEvent::AAvatars(
+					crate::Event::AvatarsForged { avatar_ids: vec![(leader_id, 1)] },
+				));
+
+				// variations remain the same
+				assert_eq!(
+					original_leader.dna[0..=1].iter().map(|x| x & 0b0000_1111).collect::<Vec<_>>(),
+					forged_leader.dna[0..=1].iter().map(|x| x & 0b0000_1111).collect::<Vec<_>>(),
+				);
+				// other components remain the same
+				assert_eq!(
+					original_leader.dna[2..season.max_components as usize],
+					forged_leader.dna[2..season.max_components as usize]
+				);
+			});
+	}
+
+	#[test]
+	fn forge_should_work_for_non_matches() {
+		let tiers =
+			&[RarityTier::Common, RarityTier::Uncommon, RarityTier::Rare, RarityTier::Legendary];
+		let season = Season::default()
+			.tiers(tiers)
+			.batch_mint_probs(&[33, 33, 34])
+			.max_components(10)
+			.max_variations(12)
+			.min_sacrifices(1)
+			.max_sacrifices(5);
+
+		ExtBuilder::default()
+			.seasons(&[(1, season.clone())])
+			.mint_cooldown(1)
+			.free_mints(&[(BOB, 10)])
+			.build()
+			.execute_with(|| {
+				// prepare avatars to forge
+				run_to_block(season.start);
+				assert_ok!(AAvatars::mint(
+					RuntimeOrigin::signed(BOB),
+					MintOption {
+						count: MintPackSize::Six,
+						mint_type: MintType::Free,
+						mint_version: AvatarVersion::V1,
+						mint_pack: PackType::default(),
+					}
+				));
+
+				// forge
+				let owned_avatar_ids = Owners::<Test>::get(BOB);
+				let leader_id = owned_avatar_ids[0];
+				let sacrifice_id = owned_avatar_ids[1];
+
+				let original_leader: Avatar = Avatars::<Test>::get(leader_id).unwrap().1;
+				let original_sacrifice = Avatars::<Test>::get(sacrifice_id).unwrap().1;
+
+				assert_ok!(AAvatars::forge(
+					RuntimeOrigin::signed(BOB),
+					leader_id,
+					vec![sacrifice_id]
+				));
+				let forged_leader = Avatars::<Test>::get(leader_id).unwrap().1;
+
+				// check the result of the compare method
+				let forger = AvatarForgerV1::<Test>(PhantomData);
+				let upgradable_indexes =
+					forger.upgradable_indexes_for_target(&original_leader).unwrap();
+				assert_eq!(
+					forger.compare(
+						&original_leader,
+						&original_sacrifice,
+						&upgradable_indexes,
+						season.max_variations,
+						tiers[tiers.len() - 1] as u8
+					),
+					(false, BTreeSet::from([2]))
+				);
+				// check all sacrifices are burned
+				assert!(!Avatars::<Test>::contains_key(sacrifice_id));
+				// check for souls accumulation
+				assert_eq!(forged_leader.souls, original_leader.souls + original_sacrifice.souls);
+
+				// check DNAs are the same
+				assert_eq!(original_leader.dna, forged_leader.dna);
+				System::assert_last_event(mock::RuntimeEvent::AAvatars(
+					crate::Event::AvatarsForged { avatar_ids: vec![(leader_id, 0)] },
+				));
+			});
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v1.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v1.rs
@@ -14,12 +14,9 @@ impl AttributeMapper for AttributeMapperV1 {
 	}
 }
 
-pub(super) struct AvatarMinterV1<'a, T: Config>(pub PhantomData<&'a T>);
+pub(super) struct AvatarMinterV1<T: Config>(pub PhantomData<T>);
 
-impl<'a, T> Minter<T> for AvatarMinterV1<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> Minter<T> for AvatarMinterV1<T> {
 	fn mint_avatar_set(
 		&self,
 		player: &T::AccountId,
@@ -28,7 +25,7 @@ where
 		mint_option: &MintOption,
 	) -> Result<Vec<MintOutput<T>>, DispatchError> {
 		let is_batched = mint_option.count.is_batched();
-		(0..mint_option.count as usize)
+		(0..mint_option.count.clone() as usize)
 			.map(|_| {
 				let avatar_id = Pallet::<T>::random_hash(b"create_avatar", player);
 				let dna = self.random_dna(&avatar_id, season, is_batched)?;
@@ -41,11 +38,7 @@ where
 	}
 }
 
-impl<'a, T> AvatarMinterV1<'a, T>
-where
-	T: Config,
-{
-	#[inline]
+impl<T: Config> AvatarMinterV1<T> {
 	fn random_dna(
 		&self,
 		hash: &T::Hash,
@@ -62,7 +55,6 @@ where
 		Dna::try_from(dna).map_err(|_| Error::<T>::IncorrectDna.into())
 	}
 
-	#[inline]
 	fn random_component(
 		season: &SeasonOf<T>,
 		hash: &T::Hash,
@@ -75,11 +67,11 @@ where
 			let probs =
 				if batched_mint { &season.batch_mint_probs } else { &season.single_mint_probs };
 			let mut cumulative_sum = 0;
-			let mut random_tier = season.tiers[0] as u8;
+			let mut random_tier = season.tiers[0].clone() as u8;
 			for i in 0..probs.len() {
 				let new_cumulative_sum = cumulative_sum + probs[i];
 				if random_prob >= cumulative_sum && random_prob < new_cumulative_sum {
-					random_tier = season.tiers[i] as u8;
+					random_tier = season.tiers[i].clone() as u8;
 					break
 				}
 				cumulative_sum = new_cumulative_sum;
@@ -91,12 +83,9 @@ where
 	}
 }
 
-pub(super) struct AvatarForgerV1<'a, T: Config>(pub PhantomData<&'a T>);
+pub(super) struct AvatarForgerV1<T: Config>(pub PhantomData<T>);
 
-impl<'a, T> Forger<T> for AvatarForgerV1<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> Forger<T> for AvatarForgerV1<T> {
 	fn forge_with(
 		&self,
 		player: &T::AccountId,
@@ -136,13 +125,14 @@ where
 					let nucleotide = leader.dna[first_matched_index];
 					let current_tier_index = season
 						.tiers
-						.iter()
-						.position(|tier| *tier as u8 == nucleotide >> 4)
+						.clone()
+						.into_iter()
+						.position(|tier| tier as u8 == nucleotide >> 4)
 						.ok_or(Error::<T>::UnknownTier)?;
 
 					let already_maxed_out = current_tier_index == (season.tiers.len() - 1);
 					if !already_maxed_out {
-						let next_tier = season.tiers[current_tier_index + 1] as u8;
+						let next_tier = season.tiers[current_tier_index + 1].clone() as u8;
 						let upgraded_nucleotide = (next_tier << 4) | (nucleotide & 0b0000_1111);
 						leader.dna[first_matched_index] = upgraded_nucleotide;
 						upgraded_components += 1;
@@ -165,22 +155,18 @@ where
 		_season: &SeasonOf<T>,
 		input_leader: &ForgeItem<T>,
 		input_sacrifices: &[ForgeItem<T>],
-	) -> Result<(), DispatchError> {
-		if input_sacrifices
-			.iter()
-			.all(|(_, avatar)| avatar.version == input_leader.1.version)
-		{
-			Ok(())
-		} else {
-			Err(Error::<T>::IncompatibleAvatarVersions.into())
-		}
+	) -> DispatchResult {
+		ensure!(
+			input_sacrifices
+				.iter()
+				.all(|(_, avatar)| avatar.version == input_leader.1.version),
+			Error::<T>::IncompatibleAvatarVersions
+		);
+		Ok(())
 	}
 }
 
-impl<'a, T> AvatarForgerV1<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarForgerV1<T> {
 	fn compare_all(
 		&self,
 		target: &Avatar,
@@ -461,7 +447,7 @@ mod test {
 				&other,
 				&[1, 8, 9, 10],
 				season.max_variations,
-				*season.tiers.last().unwrap() as u8,
+				season.max_tier() as u8,
 			),
 			(true, BTreeSet::from([1, 9]))
 		);
@@ -528,7 +514,7 @@ mod test {
 							sacrifice,
 							&upgradable_indexes,
 							season.max_variations,
-							tiers[tiers.len() - 1] as u8
+							season.max_tier() as u8,
 						),
 						result
 					)
@@ -623,7 +609,7 @@ mod test {
 						&original_sacrifice,
 						&upgradable_indexes,
 						season.max_variations,
-						tiers[tiers.len() - 1] as u8
+						season.max_tier() as u8,
 					),
 					(false, BTreeSet::from([2]))
 				);

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/avatar_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/avatar_utils.rs
@@ -88,15 +88,26 @@ impl AvatarBuilder {
 		pet_type: PetType,
 		pet_variation: u8,
 		spec_bytes: [u8; 16],
-		progress_array: [u8; 11],
+		progress_array: Option<[u8; 11]>,
 		soul_points: SoulCount,
 	) -> Self {
+		let rarity_type = RarityType::Legendary;
+
+		let progress_array = progress_array.unwrap_or_else(|| {
+			AvatarUtils::generate_progress_bytes(
+				rarity_type,
+				SCALING_FACTOR_PERC,
+				PROGRESS_PROBABILITY_PERC,
+				AvatarUtils::read_progress_array(&self.inner),
+			)
+		});
+
 		self.with_attribute(AvatarAttributes::ItemType, ItemType::Pet)
 			.with_attribute(AvatarAttributes::ItemSubType, PetItemType::Pet)
 			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
 			.with_attribute(AvatarAttributes::ClassType2, pet_type)
 			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
-			.with_attribute(AvatarAttributes::RarityType, RarityType::Legendary)
+			.with_attribute(AvatarAttributes::RarityType, rarity_type)
 			.with_attribute_raw(AvatarAttributes::Quantity, 1)
 			.with_attribute_raw(AvatarAttributes::CustomType2, pet_variation)
 			.with_spec_bytes(spec_bytes)

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/avatar_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/avatar_utils.rs
@@ -305,6 +305,84 @@ impl AvatarBuilder {
 			.with_soul_count(soul_points)
 	}
 
+	pub fn into_paint_flask(
+		self,
+		color_pair: (ColorType, ColorType),
+		soul_points: SoulCount,
+		progress_array: Option<[u8; 11]>,
+	) -> Self {
+		let rarity_type = RarityType::Rare;
+
+		let color_bytes = ((color_pair.0.as_byte() - 1) << 6) | ((color_pair.1.as_byte() - 1) << 4);
+
+		let progress_array = progress_array.unwrap_or_else(|| {
+			AvatarUtils::generate_progress_bytes(
+				rarity_type,
+				SCALING_FACTOR_PERC,
+				SPARK_PROGRESS_PROB_PERC,
+				AvatarUtils::read_progress_array(&self.inner),
+			)
+		});
+
+		self.with_attribute(AvatarAttributes::ItemType, ItemType::Essence)
+			.with_attribute(AvatarAttributes::ItemSubType, EssenceItemType::PaintFlask)
+			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
+			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
+			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+			// Unused
+			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_attribute(AvatarAttributes::RarityType, rarity_type)
+			.with_attribute_raw(AvatarAttributes::Quantity, 1)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, color_bytes)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte8, 0)
+			.with_progress_array(progress_array)
+			.with_soul_count(soul_points)
+	}
+
+	pub fn into_force_glow(
+		self,
+		force_type: ForceType,
+		soul_points: SoulCount,
+		progress_array: Option<[u8; 11]>,
+	) -> Self {
+		let rarity_type = RarityType::Epic;
+
+		let progress_array = progress_array.unwrap_or_else(|| {
+			AvatarUtils::generate_progress_bytes(
+				rarity_type,
+				SCALING_FACTOR_PERC,
+				SPARK_PROGRESS_PROB_PERC,
+				AvatarUtils::read_progress_array(&self.inner),
+			)
+		});
+
+		self.with_attribute(AvatarAttributes::ItemType, ItemType::Essence)
+			.with_attribute(AvatarAttributes::ItemSubType, EssenceItemType::ForceGlow)
+			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
+			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
+			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+			// Unused
+			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_attribute(AvatarAttributes::RarityType, rarity_type)
+			.with_attribute_raw(AvatarAttributes::Quantity, 1)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, force_type.as_byte())
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte8, 0)
+			.with_progress_array(progress_array)
+			.with_soul_count(soul_points)
+	}
+
 	pub fn try_into_armor_and_component(
 		self,
 		pet_type: PetType,

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/avatar_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/avatar_utils.rs
@@ -1,10 +1,13 @@
 use super::{constants::*, types::*, ByteType};
-use crate::types::{Avatar, AvatarVersion, Dna, SeasonId, SoulCount};
+use crate::{
+	types::{Avatar, AvatarVersion, Dna, SeasonId, SoulCount},
+	Config,
+};
 use frame_support::traits::Len;
 use sp_runtime::traits::Hash;
 use sp_std::{marker::PhantomData, vec::Vec};
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone)]
 pub enum AvatarAttributes {
 	ItemType,
 	ItemSubType,
@@ -17,7 +20,7 @@ pub enum AvatarAttributes {
 }
 
 #[allow(dead_code)]
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone)]
 pub enum AvatarSpecBytes {
 	SpecByte1,
 	SpecByte2,
@@ -51,19 +54,19 @@ impl AvatarBuilder {
 		Self { inner: avatar }
 	}
 
-	pub fn with_attribute<T>(self, attribute: AvatarAttributes, value: T) -> Self
+	pub fn with_attribute<T>(self, attribute: &AvatarAttributes, value: &T) -> Self
 	where
 		T: ByteConvertible,
 	{
 		self.with_attribute_raw(attribute, value.as_byte())
 	}
 
-	pub fn with_attribute_raw(mut self, attribute: AvatarAttributes, value: u8) -> Self {
+	pub fn with_attribute_raw(mut self, attribute: &AvatarAttributes, value: u8) -> Self {
 		AvatarUtils::write_attribute(&mut self.inner, attribute, value);
 		self
 	}
 
-	pub fn with_spec_byte_raw(mut self, spec_byte: AvatarSpecBytes, value: u8) -> Self {
+	pub fn with_spec_byte_raw(mut self, spec_byte: &AvatarSpecBytes, value: u8) -> Self {
 		AvatarUtils::write_spec_byte(&mut self.inner, spec_byte, value);
 		self
 	}
@@ -85,7 +88,7 @@ impl AvatarBuilder {
 
 	pub fn into_pet(
 		self,
-		pet_type: PetType,
+		pet_type: &PetType,
 		pet_variation: u8,
 		spec_bytes: [u8; 16],
 		progress_array: Option<[u8; 11]>,
@@ -95,27 +98,27 @@ impl AvatarBuilder {
 
 		let progress_array = progress_array.unwrap_or_else(|| {
 			AvatarUtils::generate_progress_bytes(
-				rarity_type,
+				&rarity_type,
 				SCALING_FACTOR_PERC,
 				PROGRESS_PROBABILITY_PERC,
 				AvatarUtils::read_progress_array(&self.inner),
 			)
 		});
 
-		self.with_attribute(AvatarAttributes::ItemType, ItemType::Pet)
-			.with_attribute(AvatarAttributes::ItemSubType, PetItemType::Pet)
-			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
-			.with_attribute(AvatarAttributes::ClassType2, pet_type)
-			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
-			.with_attribute(AvatarAttributes::RarityType, rarity_type)
-			.with_attribute_raw(AvatarAttributes::Quantity, 1)
-			.with_attribute_raw(AvatarAttributes::CustomType2, pet_variation)
+		self.with_attribute(&AvatarAttributes::ItemType, &ItemType::Pet)
+			.with_attribute(&AvatarAttributes::ItemSubType, &PetItemType::Pet)
+			.with_attribute(&AvatarAttributes::ClassType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::ClassType2, pet_type)
+			.with_attribute(&AvatarAttributes::CustomType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::RarityType, &rarity_type)
+			.with_attribute_raw(&AvatarAttributes::Quantity, 1)
+			.with_attribute_raw(&AvatarAttributes::CustomType2, pet_variation)
 			.with_spec_bytes(spec_bytes)
 			.with_progress_array(progress_array)
 			.with_soul_count(soul_points)
 	}
 
-	pub fn into_pet_part(self, pet_type: PetType, slot_type: SlotType, quantity: u8) -> Self {
+	pub fn into_pet_part(self, pet_type: &PetType, slot_type: &SlotType, quantity: u8) -> Self {
 		let custom_type_1 = HexType::X1;
 
 		let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
@@ -136,45 +139,45 @@ impl AvatarBuilder {
 			EquipableItemType::ArmorComponent3.as_byte() as usize,
 		);
 
-		self.with_attribute(AvatarAttributes::ItemType, ItemType::Pet)
-			.with_attribute(AvatarAttributes::ItemSubType, PetItemType::PetPart)
-			.with_attribute(AvatarAttributes::ClassType1, slot_type)
-			.with_attribute(AvatarAttributes::ClassType2, pet_type)
-			.with_attribute(AvatarAttributes::CustomType1, HexType::X1)
-			.with_attribute(AvatarAttributes::RarityType, RarityType::Uncommon)
-			.with_attribute_raw(AvatarAttributes::Quantity, quantity)
+		self.with_attribute(&AvatarAttributes::ItemType, &ItemType::Pet)
+			.with_attribute(&AvatarAttributes::ItemSubType, &PetItemType::PetPart)
+			.with_attribute(&AvatarAttributes::ClassType1, slot_type)
+			.with_attribute(&AvatarAttributes::ClassType2, pet_type)
+			.with_attribute(&AvatarAttributes::CustomType1, &HexType::X1)
+			.with_attribute(&AvatarAttributes::RarityType, &RarityType::Uncommon)
+			.with_attribute_raw(&AvatarAttributes::Quantity, quantity)
 			// Unused
-			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_attribute(&AvatarAttributes::CustomType2, &HexType::X0)
 			.with_spec_byte_raw(
-				AvatarSpecBytes::SpecByte1,
+				&AvatarSpecBytes::SpecByte1,
 				AvatarUtils::enums_to_bits(&base_0) as u8,
 			)
 			.with_spec_byte_raw(
-				AvatarSpecBytes::SpecByte2,
+				&AvatarSpecBytes::SpecByte2,
 				AvatarUtils::enums_order_to_bits(&base_0) as u8,
 			)
 			.with_spec_byte_raw(
-				AvatarSpecBytes::SpecByte3,
+				&AvatarSpecBytes::SpecByte3,
 				AvatarUtils::enums_to_bits(&comp_1) as u8,
 			)
 			.with_spec_byte_raw(
-				AvatarSpecBytes::SpecByte4,
+				&AvatarSpecBytes::SpecByte4,
 				AvatarUtils::enums_order_to_bits(&comp_1) as u8,
 			)
 			.with_spec_byte_raw(
-				AvatarSpecBytes::SpecByte5,
+				&AvatarSpecBytes::SpecByte5,
 				AvatarUtils::enums_to_bits(&comp_2) as u8,
 			)
 			.with_spec_byte_raw(
-				AvatarSpecBytes::SpecByte6,
+				&AvatarSpecBytes::SpecByte6,
 				AvatarUtils::enums_order_to_bits(&comp_2) as u8,
 			)
 			.with_spec_byte_raw(
-				AvatarSpecBytes::SpecByte7,
+				&AvatarSpecBytes::SpecByte7,
 				AvatarUtils::enums_to_bits(&comp_3) as u8,
 			)
 			.with_spec_byte_raw(
-				AvatarSpecBytes::SpecByte8,
+				&AvatarSpecBytes::SpecByte8,
 				AvatarUtils::enums_order_to_bits(&comp_3) as u8,
 			)
 			.with_soul_count((quantity * custom_type_1.as_byte()) as SoulCount)
@@ -182,7 +185,7 @@ impl AvatarBuilder {
 
 	pub fn into_egg(
 		self,
-		rarity_type: RarityType,
+		rarity_type: &RarityType,
 		pet_variation: u8,
 		soul_points: SoulCount,
 		progress_array: Option<[u8; 11]>,
@@ -196,53 +199,53 @@ impl AvatarBuilder {
 			)
 		});
 
-		self.with_attribute(AvatarAttributes::ItemType, ItemType::Pet)
-			.with_attribute(AvatarAttributes::ItemSubType, PetItemType::Egg)
+		self.with_attribute(&AvatarAttributes::ItemType, &ItemType::Pet)
+			.with_attribute(&AvatarAttributes::ItemSubType, &PetItemType::Egg)
 			// Unused
-			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
+			.with_attribute(&AvatarAttributes::ClassType1, &HexType::X0)
 			// Unused
-			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
-			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
-			.with_attribute(AvatarAttributes::RarityType, rarity_type)
-			.with_attribute_raw(AvatarAttributes::Quantity, 1)
-			.with_attribute_raw(AvatarAttributes::CustomType2, pet_variation)
+			.with_attribute(&AvatarAttributes::ClassType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::CustomType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::RarityType, rarity_type)
+			.with_attribute_raw(&AvatarAttributes::Quantity, 1)
+			.with_attribute_raw(&AvatarAttributes::CustomType2, pet_variation)
 			.with_progress_array(progress_array)
 			.with_soul_count(soul_points as SoulCount)
 	}
 
-	pub fn into_material(self, material_type: MaterialItemType, quantity: u8) -> Self {
+	pub fn into_material(self, material_type: &MaterialItemType, quantity: u8) -> Self {
 		let custom_type_1 = HexType::X1;
 
-		self.with_attribute(AvatarAttributes::ItemType, ItemType::Material)
-			.with_attribute(AvatarAttributes::ItemSubType, material_type)
-			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
-			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
-			.with_attribute(AvatarAttributes::CustomType1, custom_type_1)
-			.with_attribute(AvatarAttributes::RarityType, RarityType::Common)
-			.with_attribute_raw(AvatarAttributes::Quantity, quantity)
+		self.with_attribute(&AvatarAttributes::ItemType, &ItemType::Material)
+			.with_attribute(&AvatarAttributes::ItemSubType, material_type)
+			.with_attribute(&AvatarAttributes::ClassType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::ClassType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::CustomType1, &custom_type_1)
+			.with_attribute(&AvatarAttributes::RarityType, &RarityType::Common)
+			.with_attribute_raw(&AvatarAttributes::Quantity, quantity)
 			// Unused
-			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_attribute(&AvatarAttributes::CustomType2, &HexType::X0)
 			.with_soul_count((quantity * custom_type_1.as_byte()) as SoulCount)
 	}
 
 	pub fn into_glimmer(self, quantity: u8) -> Self {
 		let custom_type_1 = HexType::X1;
 
-		self.with_attribute(AvatarAttributes::ItemType, ItemType::Essence)
-			.with_attribute(AvatarAttributes::ItemSubType, EssenceItemType::Glimmer)
-			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
-			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
-			.with_attribute(AvatarAttributes::CustomType1, custom_type_1)
+		self.with_attribute(&AvatarAttributes::ItemType, &ItemType::Essence)
+			.with_attribute(&AvatarAttributes::ItemSubType, &EssenceItemType::Glimmer)
+			.with_attribute(&AvatarAttributes::ClassType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::ClassType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::CustomType1, &custom_type_1)
 			// Unused
-			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
-			.with_attribute(AvatarAttributes::RarityType, RarityType::Uncommon)
-			.with_attribute_raw(AvatarAttributes::Quantity, quantity)
+			.with_attribute(&AvatarAttributes::CustomType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::RarityType, &RarityType::Uncommon)
+			.with_attribute_raw(&AvatarAttributes::Quantity, quantity)
 			.with_soul_count(quantity as SoulCount * custom_type_1 as SoulCount)
 	}
 
 	pub fn into_color_spark(
 		self,
-		color_pair: (ColorType, ColorType),
+		color_pair: &(ColorType, ColorType),
 		soul_points: SoulCount,
 		progress_array: Option<[u8; 11]>,
 	) -> Self {
@@ -250,37 +253,37 @@ impl AvatarBuilder {
 
 		let progress_array = progress_array.unwrap_or_else(|| {
 			AvatarUtils::generate_progress_bytes(
-				rarity_type,
+				&rarity_type,
 				SCALING_FACTOR_PERC,
 				SPARK_PROGRESS_PROB_PERC,
 				AvatarUtils::read_progress_array(&self.inner),
 			)
 		});
 
-		self.with_attribute(AvatarAttributes::ItemType, ItemType::Essence)
-			.with_attribute(AvatarAttributes::ItemSubType, EssenceItemType::ColorSpark)
-			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
-			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
-			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+		self.with_attribute(&AvatarAttributes::ItemType, &ItemType::Essence)
+			.with_attribute(&AvatarAttributes::ItemSubType, &EssenceItemType::ColorSpark)
+			.with_attribute(&AvatarAttributes::ClassType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::ClassType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::CustomType1, &HexType::X0)
 			// Unused
-			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
-			.with_attribute(AvatarAttributes::RarityType, rarity_type)
-			.with_attribute_raw(AvatarAttributes::Quantity, 1)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, color_pair.0.as_byte())
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, color_pair.1.as_byte())
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte8, 0)
+			.with_attribute(&AvatarAttributes::CustomType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::RarityType, &rarity_type)
+			.with_attribute_raw(&AvatarAttributes::Quantity, 1)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte1, color_pair.0.as_byte())
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte2, color_pair.1.as_byte())
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte3, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte4, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte5, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte6, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte7, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte8, 0)
 			.with_progress_array(progress_array)
 			.with_soul_count(soul_points)
 	}
 
 	pub fn into_glow_spark(
 		self,
-		force_type: ForceType,
+		force_type: &ForceType,
 		soul_points: SoulCount,
 		progress_array: Option<[u8; 11]>,
 	) -> Self {
@@ -288,37 +291,37 @@ impl AvatarBuilder {
 
 		let progress_array = progress_array.unwrap_or_else(|| {
 			AvatarUtils::generate_progress_bytes(
-				rarity_type,
+				&rarity_type,
 				SCALING_FACTOR_PERC,
 				SPARK_PROGRESS_PROB_PERC,
 				AvatarUtils::read_progress_array(&self.inner),
 			)
 		});
 
-		self.with_attribute(AvatarAttributes::ItemType, ItemType::Essence)
-			.with_attribute(AvatarAttributes::ItemSubType, EssenceItemType::GlowSpark)
-			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
-			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
-			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+		self.with_attribute(&AvatarAttributes::ItemType, &ItemType::Essence)
+			.with_attribute(&AvatarAttributes::ItemSubType, &EssenceItemType::GlowSpark)
+			.with_attribute(&AvatarAttributes::ClassType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::ClassType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::CustomType1, &HexType::X0)
 			// Unused
-			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
-			.with_attribute(AvatarAttributes::RarityType, rarity_type)
-			.with_attribute_raw(AvatarAttributes::Quantity, 1)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, force_type.as_byte())
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte8, 0)
+			.with_attribute(&AvatarAttributes::CustomType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::RarityType, &rarity_type)
+			.with_attribute_raw(&AvatarAttributes::Quantity, 1)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte1, force_type.as_byte())
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte2, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte3, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte4, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte5, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte6, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte7, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte8, 0)
 			.with_progress_array(progress_array)
 			.with_soul_count(soul_points)
 	}
 
 	pub fn into_paint_flask(
 		self,
-		color_pair: (ColorType, ColorType),
+		color_pair: &(ColorType, ColorType),
 		soul_points: SoulCount,
 		progress_array: Option<[u8; 11]>,
 	) -> Self {
@@ -328,37 +331,37 @@ impl AvatarBuilder {
 
 		let progress_array = progress_array.unwrap_or_else(|| {
 			AvatarUtils::generate_progress_bytes(
-				rarity_type,
+				&rarity_type,
 				SCALING_FACTOR_PERC,
 				SPARK_PROGRESS_PROB_PERC,
 				AvatarUtils::read_progress_array(&self.inner),
 			)
 		});
 
-		self.with_attribute(AvatarAttributes::ItemType, ItemType::Essence)
-			.with_attribute(AvatarAttributes::ItemSubType, EssenceItemType::PaintFlask)
-			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
-			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
-			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+		self.with_attribute(&AvatarAttributes::ItemType, &ItemType::Essence)
+			.with_attribute(&AvatarAttributes::ItemSubType, &EssenceItemType::PaintFlask)
+			.with_attribute(&AvatarAttributes::ClassType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::ClassType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::CustomType1, &HexType::X0)
 			// Unused
-			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
-			.with_attribute(AvatarAttributes::RarityType, rarity_type)
-			.with_attribute_raw(AvatarAttributes::Quantity, 1)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, color_bytes)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte8, 0)
+			.with_attribute(&AvatarAttributes::CustomType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::RarityType, &rarity_type)
+			.with_attribute_raw(&AvatarAttributes::Quantity, 1)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte1, color_bytes)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte2, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte3, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte4, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte5, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte6, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte7, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte8, 0)
 			.with_progress_array(progress_array)
 			.with_soul_count(soul_points)
 	}
 
 	pub fn into_force_glow(
 		self,
-		force_type: ForceType,
+		force_type: &ForceType,
 		soul_points: SoulCount,
 		progress_array: Option<[u8; 11]>,
 	) -> Self {
@@ -366,52 +369,52 @@ impl AvatarBuilder {
 
 		let progress_array = progress_array.unwrap_or_else(|| {
 			AvatarUtils::generate_progress_bytes(
-				rarity_type,
+				&rarity_type,
 				SCALING_FACTOR_PERC,
 				SPARK_PROGRESS_PROB_PERC,
 				AvatarUtils::read_progress_array(&self.inner),
 			)
 		});
 
-		self.with_attribute(AvatarAttributes::ItemType, ItemType::Essence)
-			.with_attribute(AvatarAttributes::ItemSubType, EssenceItemType::ForceGlow)
-			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
-			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
-			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+		self.with_attribute(&AvatarAttributes::ItemType, &ItemType::Essence)
+			.with_attribute(&AvatarAttributes::ItemSubType, &EssenceItemType::ForceGlow)
+			.with_attribute(&AvatarAttributes::ClassType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::ClassType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::CustomType1, &HexType::X0)
 			// Unused
-			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
-			.with_attribute(AvatarAttributes::RarityType, rarity_type)
-			.with_attribute_raw(AvatarAttributes::Quantity, 1)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, force_type.as_byte())
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte8, 0)
+			.with_attribute(&AvatarAttributes::CustomType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::RarityType, &rarity_type)
+			.with_attribute_raw(&AvatarAttributes::Quantity, 1)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte1, force_type.as_byte())
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte2, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte3, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte4, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte5, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte6, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte7, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte8, 0)
 			.with_progress_array(progress_array)
 			.with_soul_count(soul_points)
 	}
 
 	pub fn try_into_armor_and_component(
 		self,
-		pet_type: PetType,
-		slot_type: SlotType,
-		equipable_type: Vec<EquipableItemType>,
-		rarity_type: RarityType,
-		color_pair: (ColorType, ColorType),
-		force_type: ForceType,
+		pet_type: &PetType,
+		slot_type: &SlotType,
+		equipable_type: &[EquipableItemType],
+		rarity_type: &RarityType,
+		color_pair: &(ColorType, ColorType),
+		force_type: &ForceType,
 		soul_points: SoulCount,
 	) -> Result<Self, ()> {
 		if equipable_type.is_empty() ||
-			equipable_type.iter().any(|equip| !EquipableItemType::is_armor(*equip))
+			equipable_type.iter().any(|equip| !EquipableItemType::is_armor(equip.clone()))
 		{
 			return Err(())
 		}
 
 		let armor_assemble_progress = {
-			let mut progress = AvatarUtils::enums_to_bits(&equipable_type) as u8;
+			let mut progress = AvatarUtils::enums_to_bits(equipable_type) as u8;
 
 			if color_pair.0 != ColorType::None && color_pair.1 != ColorType::None {
 				progress |=
@@ -422,7 +425,7 @@ impl AvatarBuilder {
 		};
 
 		// Guaranteed to work because of check above
-		let first_equipable = equipable_type.first().copied().unwrap();
+		let first_equipable = equipable_type.first().unwrap();
 
 		let progress_array = AvatarUtils::generate_progress_bytes(
 			rarity_type,
@@ -432,42 +435,42 @@ impl AvatarBuilder {
 		);
 
 		Ok(self
-			.with_attribute(AvatarAttributes::ItemType, ItemType::Equipable)
-			.with_attribute(AvatarAttributes::ItemSubType, first_equipable)
-			.with_attribute(AvatarAttributes::ClassType1, slot_type)
-			.with_attribute(AvatarAttributes::ClassType2, pet_type)
-			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
-			.with_attribute(AvatarAttributes::RarityType, rarity_type)
-			.with_attribute_raw(AvatarAttributes::Quantity, 1)
+			.with_attribute(&AvatarAttributes::ItemType, &ItemType::Equipable)
+			.with_attribute(&AvatarAttributes::ItemSubType, first_equipable)
+			.with_attribute(&AvatarAttributes::ClassType1, slot_type)
+			.with_attribute(&AvatarAttributes::ClassType2, pet_type)
+			.with_attribute(&AvatarAttributes::CustomType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::RarityType, rarity_type)
+			.with_attribute_raw(&AvatarAttributes::Quantity, 1)
 			// Unused
-			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, armor_assemble_progress)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, force_type.as_byte())
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte8, 0)
+			.with_attribute(&AvatarAttributes::CustomType2, &HexType::X0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte1, armor_assemble_progress)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte2, force_type.as_byte())
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte3, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte4, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte5, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte6, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte7, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte8, 0)
 			.with_progress_array(progress_array)
 			.with_soul_count(soul_points))
 	}
 
 	pub fn try_into_weapon(
 		self,
-		pet_type: PetType,
-		slot_type: SlotType,
-		equipable_type: EquipableItemType,
-		color_pair: (ColorType, ColorType),
-		force_type: ForceType,
+		pet_type: &PetType,
+		slot_type: &SlotType,
+		equipable_type: &EquipableItemType,
+		color_pair: &(ColorType, ColorType),
+		force_type: &ForceType,
 		soul_points: SoulCount,
 	) -> Result<Self, ()> {
-		if !EquipableItemType::is_weapon(equipable_type) {
+		if !EquipableItemType::is_weapon(equipable_type.clone()) {
 			return Err(())
 		}
 
 		let weapon_info = {
-			let mut info = AvatarUtils::enums_to_bits(&[equipable_type]) as u8 >> 4;
+			let mut info = AvatarUtils::enums_to_bits(&[equipable_type.clone()]) as u8 >> 4;
 
 			if color_pair.0 != ColorType::None && color_pair.1 != ColorType::None {
 				info |= ((color_pair.0.as_byte() - 1) << 6) | ((color_pair.1.as_byte() - 1) << 4)
@@ -479,41 +482,41 @@ impl AvatarBuilder {
 		let rarity_type = RarityType::Legendary;
 
 		let progress_array = AvatarUtils::generate_progress_bytes(
-			rarity_type,
+			&rarity_type,
 			SCALING_FACTOR_PERC,
 			PROGRESS_PROBABILITY_PERC,
 			AvatarUtils::read_progress_array(&self.inner),
 		);
 
 		Ok(self
-			.with_attribute(AvatarAttributes::ItemType, ItemType::Equipable)
-			.with_attribute(AvatarAttributes::ItemSubType, equipable_type)
-			.with_attribute(AvatarAttributes::ClassType1, slot_type)
-			.with_attribute(AvatarAttributes::ClassType2, pet_type)
-			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
-			.with_attribute(AvatarAttributes::RarityType, rarity_type)
-			.with_attribute_raw(AvatarAttributes::Quantity, 1)
+			.with_attribute(&AvatarAttributes::ItemType, &ItemType::Equipable)
+			.with_attribute(&AvatarAttributes::ItemSubType, equipable_type)
+			.with_attribute(&AvatarAttributes::ClassType1, slot_type)
+			.with_attribute(&AvatarAttributes::ClassType2, pet_type)
+			.with_attribute(&AvatarAttributes::CustomType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::RarityType, &rarity_type)
+			.with_attribute_raw(&AvatarAttributes::Quantity, 1)
 			// Unused
-			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, weapon_info)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, force_type.as_byte())
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, 0)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte8, 0)
+			.with_attribute(&AvatarAttributes::CustomType2, &HexType::X0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte1, weapon_info)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte2, force_type.as_byte())
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte3, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte4, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte5, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte6, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte7, 0)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte8, 0)
 			.with_progress_array(progress_array)
 			.with_soul_count(soul_points))
 	}
 
 	pub fn into_blueprint(
 		self,
-		blueprint_type: BlueprintItemType,
-		pet_type: PetType,
-		slot_type: SlotType,
-		equipable_item_type: EquipableItemType,
-		pattern: Vec<MaterialItemType>,
+		blueprint_type: &BlueprintItemType,
+		pet_type: &PetType,
+		slot_type: &SlotType,
+		equipable_item_type: &EquipableItemType,
+		pattern: &[MaterialItemType],
 		soul_points: SoulCount,
 	) -> Self {
 		// TODO: add a quantity algorithm
@@ -524,28 +527,28 @@ impl AvatarBuilder {
 		let mat_req3 = 1;
 		let mat_req4 = 1;
 
-		self.with_attribute(AvatarAttributes::ItemType, ItemType::Blueprint)
-			.with_attribute(AvatarAttributes::ItemSubType, blueprint_type)
-			.with_attribute(AvatarAttributes::ClassType1, slot_type)
-			.with_attribute(AvatarAttributes::ClassType2, pet_type)
-			.with_attribute(AvatarAttributes::CustomType1, HexType::X1)
-			.with_attribute(AvatarAttributes::RarityType, RarityType::Rare)
-			.with_attribute_raw(AvatarAttributes::Quantity, soul_points as u8)
+		self.with_attribute(&AvatarAttributes::ItemType, &ItemType::Blueprint)
+			.with_attribute(&AvatarAttributes::ItemSubType, blueprint_type)
+			.with_attribute(&AvatarAttributes::ClassType1, slot_type)
+			.with_attribute(&AvatarAttributes::ClassType2, pet_type)
+			.with_attribute(&AvatarAttributes::CustomType1, &HexType::X1)
+			.with_attribute(&AvatarAttributes::RarityType, &RarityType::Rare)
+			.with_attribute_raw(&AvatarAttributes::Quantity, soul_points as u8)
 			// Unused
-			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_attribute(&AvatarAttributes::CustomType2, &HexType::X0)
 			.with_spec_byte_raw(
-				AvatarSpecBytes::SpecByte1,
-				AvatarUtils::enums_to_bits(&pattern) as u8,
+				&AvatarSpecBytes::SpecByte1,
+				AvatarUtils::enums_to_bits(pattern) as u8,
 			)
 			.with_spec_byte_raw(
-				AvatarSpecBytes::SpecByte2,
-				AvatarUtils::enums_order_to_bits(&pattern) as u8,
+				&AvatarSpecBytes::SpecByte2,
+				AvatarUtils::enums_order_to_bits(pattern) as u8,
 			)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, equipable_item_type.as_byte())
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, mat_req1)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, mat_req2)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, mat_req3)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, mat_req4)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte3, equipable_item_type.as_byte())
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte4, mat_req1)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte5, mat_req2)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte6, mat_req3)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte7, mat_req4)
 			.with_soul_count(soul_points)
 	}
 
@@ -559,29 +562,29 @@ impl AvatarBuilder {
 			((color_pair.0.as_byte().saturating_sub(1)) << 6 |
 				(color_pair.1.as_byte().saturating_sub(1)) << 4);
 
-		self.with_attribute(AvatarAttributes::ItemType, ItemType::Special)
-			.with_attribute(AvatarAttributes::ItemSubType, SpecialItemType::Unidentified)
-			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
-			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
-			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+		self.with_attribute(&AvatarAttributes::ItemType, &ItemType::Special)
+			.with_attribute(&AvatarAttributes::ItemSubType, &SpecialItemType::Unidentified)
+			.with_attribute(&AvatarAttributes::ClassType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::ClassType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::CustomType1, &HexType::X0)
 			// Unused
-			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
-			.with_attribute(AvatarAttributes::RarityType, RarityType::Legendary)
-			.with_attribute_raw(AvatarAttributes::Quantity, 1)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, git_info)
-			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, force_type.as_byte())
+			.with_attribute(&AvatarAttributes::CustomType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::RarityType, &RarityType::Legendary)
+			.with_attribute_raw(&AvatarAttributes::Quantity, 1)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte1, git_info)
+			.with_spec_byte_raw(&AvatarSpecBytes::SpecByte2, force_type.as_byte())
 			.with_soul_count(soul_points)
 	}
 
 	pub fn into_dust(self, soul_points: SoulCount) -> Self {
-		self.with_attribute(AvatarAttributes::ItemType, ItemType::Special)
-			.with_attribute(AvatarAttributes::ItemSubType, SpecialItemType::Dust)
-			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
-			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
-			.with_attribute(AvatarAttributes::CustomType1, HexType::X1)
-			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
-			.with_attribute(AvatarAttributes::RarityType, RarityType::Common)
-			.with_attribute_raw(AvatarAttributes::Quantity, soul_points as u8)
+		self.with_attribute(&AvatarAttributes::ItemType, &ItemType::Special)
+			.with_attribute(&AvatarAttributes::ItemSubType, &SpecialItemType::Dust)
+			.with_attribute(&AvatarAttributes::ClassType1, &HexType::X0)
+			.with_attribute(&AvatarAttributes::ClassType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::CustomType1, &HexType::X1)
+			.with_attribute(&AvatarAttributes::CustomType2, &HexType::X0)
+			.with_attribute(&AvatarAttributes::RarityType, &RarityType::Common)
+			.with_attribute_raw(&AvatarAttributes::Quantity, soul_points as u8)
 			.with_soul_count(soul_points)
 	}
 
@@ -598,7 +601,7 @@ impl AvatarUtils {
 	pub fn has_attribute_with_same_value_as(
 		avatar: &Avatar,
 		other: &Avatar,
-		attribute: AvatarAttributes,
+		attribute: &AvatarAttributes,
 	) -> bool {
 		Self::read_attribute(avatar, attribute) == Self::read_attribute(other, attribute)
 	}
@@ -610,28 +613,25 @@ impl AvatarUtils {
 	) -> bool {
 		attribute_set
 			.iter()
-			.all(|attribute| Self::has_attribute_with_same_value_as(avatar, other, *attribute))
+			.all(|attribute| Self::has_attribute_with_same_value_as(avatar, other, attribute))
 	}
 
-	fn read_dna_strand(avatar: &Avatar, position: usize, byte_type: ByteType) -> u8 {
+	fn read_dna_strand(avatar: &Avatar, position: usize, byte_type: &ByteType) -> u8 {
 		Self::read_dna_at(avatar.dna.as_slice(), position, byte_type)
 	}
 
-	#[inline]
-	fn read_dna_at(dna: &[u8], position: usize, byte_type: ByteType) -> u8 {
+	fn read_dna_at(dna: &[u8], position: usize, byte_type: &ByteType) -> u8 {
 		match byte_type {
 			ByteType::Full => dna[position],
-			ByteType::High => dna[position] >> 4,
-			ByteType::Low => dna[position] & ByteType::High as u8,
+			ByteType::High => Self::high_nibble_of(dna[position]),
+			ByteType::Low => Self::low_nibble_of(dna[position]),
 		}
 	}
 
-	#[inline]
 	pub fn high_nibble_of(byte: u8) -> u8 {
 		byte >> 4
 	}
 
-	#[inline]
 	pub fn low_nibble_of(byte: u8) -> u8 {
 		byte & 0x0F
 	}
@@ -648,7 +648,6 @@ impl AvatarUtils {
 		}
 	}
 
-	#[inline]
 	fn write_dna_at(dna: &mut [u8], position: usize, byte_type: ByteType, value: u8) {
 		match byte_type {
 			ByteType::Full => dna[position] = value,
@@ -666,12 +665,12 @@ impl AvatarUtils {
 	) -> bool {
 		attribute_value_set
 			.iter()
-			.all(|(attr, value)| Self::has_attribute_with_value_raw(avatar, *attr, *value))
+			.all(|(attr, value)| Self::has_attribute_with_value_raw(avatar, attr, *value))
 	}
 
 	pub fn has_attribute_with_value<T>(
 		avatar: &Avatar,
-		attribute: AvatarAttributes,
+		attribute: &AvatarAttributes,
 		value: T,
 	) -> bool
 	where
@@ -682,51 +681,51 @@ impl AvatarUtils {
 
 	pub fn has_attribute_with_value_different_than<T>(
 		avatar: &Avatar,
-		attribute: AvatarAttributes,
+		attribute: &AvatarAttributes,
 		value: T,
 	) -> bool
 	where
-		T: ByteConvertible + PartialEq + Eq,
+		T: ByteConvertible + PartialEq,
 	{
 		Self::read_attribute_as::<T>(avatar, attribute) != value
 	}
 
 	pub fn has_attribute_with_value_raw(
 		avatar: &Avatar,
-		attribute: AvatarAttributes,
+		attribute: &AvatarAttributes,
 		value: u8,
 	) -> bool {
 		Self::read_attribute(avatar, attribute) == value
 	}
 
-	pub fn read_attribute_as<T>(avatar: &Avatar, attribute: AvatarAttributes) -> T
+	pub fn read_attribute_as<T>(avatar: &Avatar, attribute: &AvatarAttributes) -> T
 	where
 		T: ByteConvertible,
 	{
 		T::from_byte(Self::read_attribute(avatar, attribute))
 	}
 
-	pub fn read_attribute(avatar: &Avatar, attribute: AvatarAttributes) -> u8 {
+	pub fn read_attribute(avatar: &Avatar, attribute: &AvatarAttributes) -> u8 {
 		match attribute {
-			AvatarAttributes::ItemType => Self::read_dna_strand(avatar, 0, ByteType::High),
-			AvatarAttributes::ItemSubType => Self::read_dna_strand(avatar, 0, ByteType::Low),
-			AvatarAttributes::ClassType1 => Self::read_dna_strand(avatar, 1, ByteType::High),
-			AvatarAttributes::ClassType2 => Self::read_dna_strand(avatar, 1, ByteType::Low),
-			AvatarAttributes::CustomType1 => Self::read_dna_strand(avatar, 2, ByteType::High),
-			AvatarAttributes::CustomType2 => Self::read_dna_strand(avatar, 4, ByteType::Full),
-			AvatarAttributes::RarityType => Self::read_dna_strand(avatar, 2, ByteType::Low),
-			AvatarAttributes::Quantity => Self::read_dna_strand(avatar, 3, ByteType::Full),
+			AvatarAttributes::ItemType => Self::read_dna_strand(avatar, 0, &ByteType::High),
+			AvatarAttributes::ItemSubType => Self::read_dna_strand(avatar, 0, &ByteType::Low),
+			AvatarAttributes::ClassType1 => Self::read_dna_strand(avatar, 1, &ByteType::High),
+			AvatarAttributes::ClassType2 => Self::read_dna_strand(avatar, 1, &ByteType::Low),
+			AvatarAttributes::CustomType1 => Self::read_dna_strand(avatar, 2, &ByteType::High),
+			AvatarAttributes::CustomType2 => Self::read_dna_strand(avatar, 4, &ByteType::Full),
+			AvatarAttributes::RarityType => Self::read_dna_strand(avatar, 2, &ByteType::Low),
+			AvatarAttributes::Quantity => Self::read_dna_strand(avatar, 3, &ByteType::Full),
 		}
 	}
 
-	pub fn write_typed_attribute<T>(avatar: &mut Avatar, attribute: AvatarAttributes, value: T)
+	pub fn write_typed_attribute<T>(avatar: &mut Avatar, attribute: &AvatarAttributes, value: &T)
 	where
 		T: ByteConvertible,
 	{
 		Self::write_attribute(avatar, attribute, value.as_byte())
 	}
 
-	pub fn write_attribute(avatar: &mut Avatar, attribute: AvatarAttributes, value: u8) {
+	pub fn write_attribute(avatar: &mut Avatar, attribute: &AvatarAttributes, value: u8) {
 		match attribute {
 			AvatarAttributes::ItemType => Self::write_dna_strand(avatar, 0, ByteType::High, value),
 			AvatarAttributes::ItemSubType =>
@@ -749,28 +748,28 @@ impl AvatarUtils {
 		out
 	}
 
-	pub fn read_spec_byte(avatar: &Avatar, spec_byte: AvatarSpecBytes) -> u8 {
+	pub fn read_spec_byte(avatar: &Avatar, spec_byte: &AvatarSpecBytes) -> u8 {
 		match spec_byte {
-			AvatarSpecBytes::SpecByte1 => Self::read_dna_strand(avatar, 5, ByteType::Full),
-			AvatarSpecBytes::SpecByte2 => Self::read_dna_strand(avatar, 6, ByteType::Full),
-			AvatarSpecBytes::SpecByte3 => Self::read_dna_strand(avatar, 7, ByteType::Full),
-			AvatarSpecBytes::SpecByte4 => Self::read_dna_strand(avatar, 8, ByteType::Full),
-			AvatarSpecBytes::SpecByte5 => Self::read_dna_strand(avatar, 9, ByteType::Full),
-			AvatarSpecBytes::SpecByte6 => Self::read_dna_strand(avatar, 10, ByteType::Full),
-			AvatarSpecBytes::SpecByte7 => Self::read_dna_strand(avatar, 11, ByteType::Full),
-			AvatarSpecBytes::SpecByte8 => Self::read_dna_strand(avatar, 12, ByteType::Full),
-			AvatarSpecBytes::SpecByte9 => Self::read_dna_strand(avatar, 13, ByteType::Full),
-			AvatarSpecBytes::SpecByte10 => Self::read_dna_strand(avatar, 14, ByteType::Full),
-			AvatarSpecBytes::SpecByte11 => Self::read_dna_strand(avatar, 15, ByteType::Full),
-			AvatarSpecBytes::SpecByte12 => Self::read_dna_strand(avatar, 16, ByteType::Full),
-			AvatarSpecBytes::SpecByte13 => Self::read_dna_strand(avatar, 17, ByteType::Full),
-			AvatarSpecBytes::SpecByte14 => Self::read_dna_strand(avatar, 18, ByteType::Full),
-			AvatarSpecBytes::SpecByte15 => Self::read_dna_strand(avatar, 19, ByteType::Full),
-			AvatarSpecBytes::SpecByte16 => Self::read_dna_strand(avatar, 20, ByteType::Full),
+			AvatarSpecBytes::SpecByte1 => Self::read_dna_strand(avatar, 5, &ByteType::Full),
+			AvatarSpecBytes::SpecByte2 => Self::read_dna_strand(avatar, 6, &ByteType::Full),
+			AvatarSpecBytes::SpecByte3 => Self::read_dna_strand(avatar, 7, &ByteType::Full),
+			AvatarSpecBytes::SpecByte4 => Self::read_dna_strand(avatar, 8, &ByteType::Full),
+			AvatarSpecBytes::SpecByte5 => Self::read_dna_strand(avatar, 9, &ByteType::Full),
+			AvatarSpecBytes::SpecByte6 => Self::read_dna_strand(avatar, 10, &ByteType::Full),
+			AvatarSpecBytes::SpecByte7 => Self::read_dna_strand(avatar, 11, &ByteType::Full),
+			AvatarSpecBytes::SpecByte8 => Self::read_dna_strand(avatar, 12, &ByteType::Full),
+			AvatarSpecBytes::SpecByte9 => Self::read_dna_strand(avatar, 13, &ByteType::Full),
+			AvatarSpecBytes::SpecByte10 => Self::read_dna_strand(avatar, 14, &ByteType::Full),
+			AvatarSpecBytes::SpecByte11 => Self::read_dna_strand(avatar, 15, &ByteType::Full),
+			AvatarSpecBytes::SpecByte12 => Self::read_dna_strand(avatar, 16, &ByteType::Full),
+			AvatarSpecBytes::SpecByte13 => Self::read_dna_strand(avatar, 17, &ByteType::Full),
+			AvatarSpecBytes::SpecByte14 => Self::read_dna_strand(avatar, 18, &ByteType::Full),
+			AvatarSpecBytes::SpecByte15 => Self::read_dna_strand(avatar, 19, &ByteType::Full),
+			AvatarSpecBytes::SpecByte16 => Self::read_dna_strand(avatar, 20, &ByteType::Full),
 		}
 	}
 
-	pub fn read_spec_byte_as<T>(avatar: &Avatar, spec_byte: AvatarSpecBytes) -> T
+	pub fn read_spec_byte_as<T>(avatar: &Avatar, spec_byte: &AvatarSpecBytes) -> T
 	where
 		T: ByteConvertible,
 	{
@@ -783,16 +782,16 @@ impl AvatarUtils {
 
 	pub fn add_spec_byte_from(
 		avatar: &mut Avatar,
-		spec_byte: AvatarSpecBytes,
+		spec_byte: &AvatarSpecBytes,
 		from: &Avatar,
-		from_spec_bye: AvatarSpecBytes,
+		from_spec_bye: &AvatarSpecBytes,
 	) {
 		let current_value = Self::read_spec_byte(avatar, spec_byte);
 		let from_value = Self::read_spec_byte(from, from_spec_bye);
 		Self::write_spec_byte(avatar, spec_byte, current_value.saturating_add(from_value));
 	}
 
-	pub fn write_spec_byte(avatar: &mut Avatar, spec_byte: AvatarSpecBytes, value: u8) {
+	pub fn write_spec_byte(avatar: &mut Avatar, spec_byte: &AvatarSpecBytes, value: u8) {
 		match spec_byte {
 			AvatarSpecBytes::SpecByte1 => Self::write_dna_strand(avatar, 5, ByteType::Full, value),
 			AvatarSpecBytes::SpecByte2 => Self::write_dna_strand(avatar, 6, ByteType::Full, value),
@@ -856,14 +855,14 @@ impl AvatarUtils {
 		let mut matches = Vec::<u32>::new();
 		let mut mirror: u32 = 0;
 
-		let lowest_1 = Self::read_lowest_progress_byte(&array_1, ByteType::High);
+		let lowest_1 = Self::read_lowest_progress_byte(&array_1, &ByteType::High);
 
 		for i in 0..array_1.len() {
-			let rarity_1 = Self::read_dna_at(&array_1, i, ByteType::High);
-			let variation_1 = Self::read_dna_at(&array_1, i, ByteType::Low);
+			let rarity_1 = Self::read_dna_at(&array_1, i, &ByteType::High);
+			let variation_1 = Self::read_dna_at(&array_1, i, &ByteType::Low);
 
-			let rarity_2 = Self::read_dna_at(&array_2, i, ByteType::High);
-			let variation_2 = Self::read_dna_at(&array_2, i, ByteType::Low);
+			let rarity_2 = Self::read_dna_at(&array_2, i, &ByteType::High);
+			let variation_2 = Self::read_dna_at(&array_2, i, &ByteType::Low);
 
 			let have_same_rarity = rarity_1 == rarity_2;
 			let is_maxed = rarity_1 > lowest_1 || lowest_1 == RarityType::Legendary.as_byte();
@@ -889,25 +888,25 @@ impl AvatarUtils {
 	}
 
 	pub fn can_use_avatar(avatar: &Avatar, quantity: u8) -> bool {
-		Self::read_attribute(avatar, AvatarAttributes::Quantity) >= quantity
+		Self::read_attribute(avatar, &AvatarAttributes::Quantity) >= quantity
 	}
 
 	pub fn use_avatar(avatar: &mut Avatar, quantity: u8) -> (bool, bool, SoulCount) {
-		let current_qty = Self::read_attribute(avatar, AvatarAttributes::Quantity);
+		let current_qty = Self::read_attribute(avatar, &AvatarAttributes::Quantity);
 
 		if current_qty < quantity {
 			return (false, false, 0)
 		}
 
 		let new_qty = current_qty - quantity;
-		Self::write_attribute(avatar, AvatarAttributes::Quantity, new_qty);
+		Self::write_attribute(avatar, &AvatarAttributes::Quantity, new_qty);
 
 		let (avatar_consumed, output_soul_points) = if new_qty == 0 {
 			let soul_points = avatar.souls;
 			avatar.souls = 0;
 			(true, soul_points)
 		} else {
-			let diff = Self::read_attribute(avatar, AvatarAttributes::CustomType1)
+			let diff = Self::read_attribute(avatar, &AvatarAttributes::CustomType1)
 				.saturating_mul(quantity) as SoulCount;
 			avatar.souls = avatar.souls.saturating_sub(diff);
 			(false, diff)
@@ -918,7 +917,7 @@ impl AvatarUtils {
 
 	pub fn create_pattern<T>(mut base_speed: usize, increase_seed: usize) -> Vec<T>
 	where
-		T: Ranged + Ord,
+		T: Ranged,
 	{
 		// Equivalent to "0X35AAB76B4482CADFF35BB3BD1C86648697B6F6833B47B939AECE95EDCD0347"
 		let fixed_seed: [u8; 32] = [
@@ -1004,7 +1003,7 @@ impl AvatarUtils {
 			let bit_position = (bit_segment >> (mask_width - (i + 2))) as usize;
 
 			if sorted_enum_list.len() > bit_position {
-				output_enums.push(sorted_enum_list[bit_position]);
+				output_enums.push(sorted_enum_list[bit_position].clone());
 			}
 		}
 
@@ -1012,13 +1011,13 @@ impl AvatarUtils {
 	}
 
 	pub fn generate_progress_bytes(
-		rarity_type: RarityType,
+		rarity_type: &RarityType,
 		scale_factor: u32,
 		probability: u32,
 		mut progress_bytes: [u8; 11],
 	) -> [u8; 11] {
 		for i in 0..progress_bytes.len() {
-			let random_value = Self::read_dna_at(&progress_bytes, i, ByteType::Full);
+			let random_value = Self::read_dna_at(&progress_bytes, i, &ByteType::Full);
 			let mut new_rarity = rarity_type.as_byte();
 
 			// Upcast random_value
@@ -1040,7 +1039,7 @@ impl AvatarUtils {
 		progress_bytes
 	}
 
-	pub fn read_lowest_progress_byte(progress_bytes: &[u8; 11], byte_type: ByteType) -> u8 {
+	pub fn read_lowest_progress_byte(progress_bytes: &[u8; 11], byte_type: &ByteType) -> u8 {
 		let mut result = u8::MAX;
 
 		for i in 0..progress_bytes.len() {
@@ -1054,28 +1053,19 @@ impl AvatarUtils {
 	}
 }
 
-pub(crate) struct HashProvider<'a, T, const N: usize>
-where
-	T: crate::Config,
-{
+pub(crate) struct HashProvider<T: Config, const N: usize> {
 	pub(crate) hash: [u8; N],
 	current_index: usize,
-	_marker: PhantomData<&'a T>,
+	_marker: PhantomData<T>,
 }
 
-impl<'a, T, const N: usize> Default for HashProvider<'a, T, N>
-where
-	T: crate::Config,
-{
+impl<T: Config, const N: usize> Default for HashProvider<T, N> {
 	fn default() -> Self {
 		Self { hash: [0; N], current_index: 0, _marker: PhantomData }
 	}
 }
 
-impl<'a, T, const N: usize> HashProvider<'a, T, N>
-where
-	T: crate::Config,
-{
+impl<T: Config, const N: usize> HashProvider<T, N> {
 	pub fn new(hash: &T::Hash) -> Self {
 		Self::new_starting_at(hash, 0)
 	}
@@ -1087,7 +1077,7 @@ where
 
 	pub fn new_starting_at(hash: &T::Hash, index: usize) -> Self {
 		// TODO: Improve
-		let mut bytes: [u8; N] = [0; N];
+		let mut bytes = [0; N];
 
 		let hash_ref = hash.as_ref();
 		let hash_len = hash_ref.len();
@@ -1107,16 +1097,12 @@ where
 		T::Hashing::hash(&full_hash)
 	}
 
-	#[inline]
 	pub fn get_hash_byte(&mut self) -> u8 {
 		self.next().unwrap_or_default()
 	}
 }
 
-impl<'a, T, const N: usize> Iterator for HashProvider<'a, T, N>
-where
-	T: crate::Config,
-{
+impl<T: Config, const N: usize> Iterator for HashProvider<T, N> {
 	type Item = u8;
 
 	fn next(&mut self) -> Option<Self::Item> {

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/avatar_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/avatar_utils.rs
@@ -1,0 +1,1278 @@
+use super::{constants::*, types::*, ByteType};
+use crate::types::{Avatar, AvatarVersion, Dna, SeasonId, SoulCount};
+use frame_support::traits::Len;
+use sp_runtime::traits::Hash;
+use sp_std::{marker::PhantomData, vec::Vec};
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AvatarAttributes {
+	ItemType,
+	ItemSubType,
+	ClassType1,
+	ClassType2,
+	CustomType1,
+	CustomType2,
+	RarityType,
+	Quantity,
+}
+
+#[allow(dead_code)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AvatarSpecBytes {
+	SpecByte1,
+	SpecByte2,
+	SpecByte3,
+	SpecByte4,
+	SpecByte5,
+	SpecByte6,
+	SpecByte7,
+	SpecByte8,
+	SpecByte9,
+	SpecByte10,
+	SpecByte11,
+	SpecByte12,
+	SpecByte13,
+	SpecByte14,
+	SpecByte15,
+	SpecByte16,
+}
+
+#[derive(Default)]
+pub(crate) struct AvatarBuilder {
+	inner: Avatar,
+}
+
+impl AvatarBuilder {
+	pub fn with_dna(season_id: SeasonId, dna: Dna) -> Self {
+		Self { inner: Avatar { season_id, version: AvatarVersion::V2, dna, souls: 0 } }
+	}
+
+	pub fn with_base_avatar(avatar: Avatar) -> Self {
+		Self { inner: avatar }
+	}
+
+	pub fn with_attribute<T>(self, attribute: AvatarAttributes, value: T) -> Self
+	where
+		T: ByteConvertible,
+	{
+		self.with_attribute_raw(attribute, value.as_byte())
+	}
+
+	pub fn with_attribute_raw(mut self, attribute: AvatarAttributes, value: u8) -> Self {
+		AvatarUtils::write_attribute(&mut self.inner, attribute, value);
+		self
+	}
+
+	pub fn with_spec_byte_raw(mut self, spec_byte: AvatarSpecBytes, value: u8) -> Self {
+		AvatarUtils::write_spec_byte(&mut self.inner, spec_byte, value);
+		self
+	}
+
+	pub fn with_spec_bytes(mut self, spec_bytes: [u8; 16]) -> Self {
+		AvatarUtils::write_full_spec_bytes(&mut self.inner, spec_bytes);
+		self
+	}
+
+	pub fn with_soul_count(mut self, soul_count: SoulCount) -> Self {
+		self.inner.souls = soul_count;
+		self
+	}
+
+	pub fn with_progress_array(mut self, progress_array: [u8; 11]) -> Self {
+		AvatarUtils::write_progress_array(&mut self.inner, progress_array);
+		self
+	}
+
+	pub fn into_pet(
+		self,
+		pet_type: PetType,
+		pet_variation: u8,
+		spec_bytes: [u8; 16],
+		progress_array: [u8; 11],
+		soul_points: SoulCount,
+	) -> Self {
+		self.with_attribute(AvatarAttributes::ItemType, ItemType::Pet)
+			.with_attribute(AvatarAttributes::ItemSubType, PetItemType::Pet)
+			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
+			.with_attribute(AvatarAttributes::ClassType2, pet_type)
+			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+			.with_attribute(AvatarAttributes::RarityType, RarityType::Legendary)
+			.with_attribute_raw(AvatarAttributes::Quantity, 1)
+			.with_attribute_raw(AvatarAttributes::CustomType2, pet_variation)
+			.with_spec_bytes(spec_bytes)
+			.with_progress_array(progress_array)
+			.with_soul_count(soul_points)
+	}
+
+	pub fn into_pet_part(self, pet_type: PetType, slot_type: SlotType, quantity: u8) -> Self {
+		let custom_type_1 = HexType::X1;
+
+		let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+		let base_0 = AvatarUtils::create_pattern::<NibbleType>(
+			base_seed,
+			EquipableItemType::ArmorBase.as_byte() as usize,
+		);
+		let comp_1 = AvatarUtils::create_pattern::<NibbleType>(
+			base_seed,
+			EquipableItemType::ArmorComponent1.as_byte() as usize,
+		);
+		let comp_2 = AvatarUtils::create_pattern::<NibbleType>(
+			base_seed,
+			EquipableItemType::ArmorComponent2.as_byte() as usize,
+		);
+		let comp_3 = AvatarUtils::create_pattern::<NibbleType>(
+			base_seed,
+			EquipableItemType::ArmorComponent3.as_byte() as usize,
+		);
+
+		self.with_attribute(AvatarAttributes::ItemType, ItemType::Pet)
+			.with_attribute(AvatarAttributes::ItemSubType, PetItemType::PetPart)
+			.with_attribute(AvatarAttributes::ClassType1, slot_type)
+			.with_attribute(AvatarAttributes::ClassType2, pet_type)
+			.with_attribute(AvatarAttributes::CustomType1, HexType::X1)
+			.with_attribute(AvatarAttributes::RarityType, RarityType::Uncommon)
+			.with_attribute_raw(AvatarAttributes::Quantity, quantity)
+			// Unused
+			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_spec_byte_raw(
+				AvatarSpecBytes::SpecByte1,
+				AvatarUtils::enums_to_bits(&base_0) as u8,
+			)
+			.with_spec_byte_raw(
+				AvatarSpecBytes::SpecByte2,
+				AvatarUtils::enums_order_to_bits(&base_0) as u8,
+			)
+			.with_spec_byte_raw(
+				AvatarSpecBytes::SpecByte3,
+				AvatarUtils::enums_to_bits(&comp_1) as u8,
+			)
+			.with_spec_byte_raw(
+				AvatarSpecBytes::SpecByte4,
+				AvatarUtils::enums_order_to_bits(&comp_1) as u8,
+			)
+			.with_spec_byte_raw(
+				AvatarSpecBytes::SpecByte5,
+				AvatarUtils::enums_to_bits(&comp_2) as u8,
+			)
+			.with_spec_byte_raw(
+				AvatarSpecBytes::SpecByte6,
+				AvatarUtils::enums_order_to_bits(&comp_2) as u8,
+			)
+			.with_spec_byte_raw(
+				AvatarSpecBytes::SpecByte7,
+				AvatarUtils::enums_to_bits(&comp_3) as u8,
+			)
+			.with_spec_byte_raw(
+				AvatarSpecBytes::SpecByte8,
+				AvatarUtils::enums_order_to_bits(&comp_3) as u8,
+			)
+			.with_soul_count((quantity * custom_type_1.as_byte()) as SoulCount)
+	}
+
+	pub fn into_egg(
+		self,
+		rarity_type: RarityType,
+		pet_variation: u8,
+		soul_points: SoulCount,
+		progress_array: Option<[u8; 11]>,
+	) -> Self {
+		let progress_array = progress_array.unwrap_or_else(|| {
+			AvatarUtils::generate_progress_bytes(
+				rarity_type,
+				SCALING_FACTOR_PERC,
+				PROGRESS_PROBABILITY_PERC,
+				AvatarUtils::read_progress_array(&self.inner),
+			)
+		});
+
+		self.with_attribute(AvatarAttributes::ItemType, ItemType::Pet)
+			.with_attribute(AvatarAttributes::ItemSubType, PetItemType::Egg)
+			// Unused
+			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
+			// Unused
+			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
+			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+			.with_attribute(AvatarAttributes::RarityType, rarity_type)
+			.with_attribute_raw(AvatarAttributes::Quantity, 1)
+			.with_attribute_raw(AvatarAttributes::CustomType2, pet_variation)
+			.with_progress_array(progress_array)
+			.with_soul_count(soul_points as SoulCount)
+	}
+
+	pub fn into_material(self, material_type: MaterialItemType, quantity: u8) -> Self {
+		let custom_type_1 = HexType::X1;
+
+		self.with_attribute(AvatarAttributes::ItemType, ItemType::Material)
+			.with_attribute(AvatarAttributes::ItemSubType, material_type)
+			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
+			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
+			.with_attribute(AvatarAttributes::CustomType1, custom_type_1)
+			.with_attribute(AvatarAttributes::RarityType, RarityType::Common)
+			.with_attribute_raw(AvatarAttributes::Quantity, quantity)
+			// Unused
+			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_soul_count((quantity * custom_type_1.as_byte()) as SoulCount)
+	}
+
+	pub fn into_glimmer(self, quantity: u8) -> Self {
+		let custom_type_1 = HexType::X1;
+
+		self.with_attribute(AvatarAttributes::ItemType, ItemType::Essence)
+			.with_attribute(AvatarAttributes::ItemSubType, EssenceItemType::Glimmer)
+			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
+			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
+			.with_attribute(AvatarAttributes::CustomType1, custom_type_1)
+			// Unused
+			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_attribute(AvatarAttributes::RarityType, RarityType::Uncommon)
+			.with_attribute_raw(AvatarAttributes::Quantity, quantity)
+			.with_soul_count(quantity as SoulCount * custom_type_1 as SoulCount)
+	}
+
+	pub fn into_color_spark(
+		self,
+		color_pair: (ColorType, ColorType),
+		soul_points: SoulCount,
+		progress_array: Option<[u8; 11]>,
+	) -> Self {
+		let rarity_type = RarityType::Uncommon;
+
+		let progress_array = progress_array.unwrap_or_else(|| {
+			AvatarUtils::generate_progress_bytes(
+				rarity_type,
+				SCALING_FACTOR_PERC,
+				SPARK_PROGRESS_PROB_PERC,
+				AvatarUtils::read_progress_array(&self.inner),
+			)
+		});
+
+		self.with_attribute(AvatarAttributes::ItemType, ItemType::Essence)
+			.with_attribute(AvatarAttributes::ItemSubType, EssenceItemType::ColorSpark)
+			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
+			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
+			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+			// Unused
+			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_attribute(AvatarAttributes::RarityType, rarity_type)
+			.with_attribute_raw(AvatarAttributes::Quantity, 1)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, color_pair.0.as_byte())
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, color_pair.1.as_byte())
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte8, 0)
+			.with_progress_array(progress_array)
+			.with_soul_count(soul_points)
+	}
+
+	pub fn into_glow_spark(
+		self,
+		force_type: ForceType,
+		soul_points: SoulCount,
+		progress_array: Option<[u8; 11]>,
+	) -> Self {
+		let rarity_type = RarityType::Rare;
+
+		let progress_array = progress_array.unwrap_or_else(|| {
+			AvatarUtils::generate_progress_bytes(
+				rarity_type,
+				SCALING_FACTOR_PERC,
+				SPARK_PROGRESS_PROB_PERC,
+				AvatarUtils::read_progress_array(&self.inner),
+			)
+		});
+
+		self.with_attribute(AvatarAttributes::ItemType, ItemType::Essence)
+			.with_attribute(AvatarAttributes::ItemSubType, EssenceItemType::GlowSpark)
+			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
+			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
+			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+			// Unused
+			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_attribute(AvatarAttributes::RarityType, rarity_type)
+			.with_attribute_raw(AvatarAttributes::Quantity, 1)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, force_type.as_byte())
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte8, 0)
+			.with_progress_array(progress_array)
+			.with_soul_count(soul_points)
+	}
+
+	pub fn try_into_armor_and_component(
+		self,
+		pet_type: PetType,
+		slot_type: SlotType,
+		equipable_type: Vec<EquipableItemType>,
+		rarity_type: RarityType,
+		color_pair: (ColorType, ColorType),
+		force_type: ForceType,
+		soul_points: SoulCount,
+	) -> Result<Self, ()> {
+		if equipable_type.is_empty() ||
+			equipable_type.iter().any(|equip| !EquipableItemType::is_armor(*equip))
+		{
+			return Err(())
+		}
+
+		let armor_assemble_progress = {
+			let mut progress = AvatarUtils::enums_to_bits(&equipable_type) as u8;
+
+			if color_pair.0 != ColorType::None && color_pair.1 != ColorType::None {
+				progress |=
+					((color_pair.0.as_byte() - 1) << 6) | ((color_pair.1.as_byte() - 1) << 4)
+			}
+
+			progress
+		};
+
+		// Guaranteed to work because of check above
+		let first_equipable = equipable_type.first().copied().unwrap();
+
+		let progress_array = AvatarUtils::generate_progress_bytes(
+			rarity_type,
+			SCALING_FACTOR_PERC,
+			PROGRESS_PROBABILITY_PERC,
+			AvatarUtils::read_progress_array(&self.inner),
+		);
+
+		Ok(self
+			.with_attribute(AvatarAttributes::ItemType, ItemType::Equipable)
+			.with_attribute(AvatarAttributes::ItemSubType, first_equipable)
+			.with_attribute(AvatarAttributes::ClassType1, slot_type)
+			.with_attribute(AvatarAttributes::ClassType2, pet_type)
+			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+			.with_attribute(AvatarAttributes::RarityType, rarity_type)
+			.with_attribute_raw(AvatarAttributes::Quantity, 1)
+			// Unused
+			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, armor_assemble_progress)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, force_type.as_byte())
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte8, 0)
+			.with_progress_array(progress_array)
+			.with_soul_count(soul_points))
+	}
+
+	pub fn try_into_weapon(
+		self,
+		pet_type: PetType,
+		slot_type: SlotType,
+		equipable_type: EquipableItemType,
+		color_pair: (ColorType, ColorType),
+		force_type: ForceType,
+		soul_points: SoulCount,
+	) -> Result<Self, ()> {
+		if !EquipableItemType::is_weapon(equipable_type) {
+			return Err(())
+		}
+
+		let weapon_info = {
+			let mut info = AvatarUtils::enums_to_bits(&[equipable_type]) as u8 >> 4;
+
+			if color_pair.0 != ColorType::None && color_pair.1 != ColorType::None {
+				info |= ((color_pair.0.as_byte() - 1) << 6) | ((color_pair.1.as_byte() - 1) << 4)
+			}
+
+			info
+		};
+
+		let rarity_type = RarityType::Legendary;
+
+		let progress_array = AvatarUtils::generate_progress_bytes(
+			rarity_type,
+			SCALING_FACTOR_PERC,
+			PROGRESS_PROBABILITY_PERC,
+			AvatarUtils::read_progress_array(&self.inner),
+		);
+
+		Ok(self
+			.with_attribute(AvatarAttributes::ItemType, ItemType::Equipable)
+			.with_attribute(AvatarAttributes::ItemSubType, equipable_type)
+			.with_attribute(AvatarAttributes::ClassType1, slot_type)
+			.with_attribute(AvatarAttributes::ClassType2, pet_type)
+			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+			.with_attribute(AvatarAttributes::RarityType, rarity_type)
+			.with_attribute_raw(AvatarAttributes::Quantity, 1)
+			// Unused
+			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, weapon_info)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, force_type.as_byte())
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, 0)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte8, 0)
+			.with_progress_array(progress_array)
+			.with_soul_count(soul_points))
+	}
+
+	pub fn into_blueprint(
+		self,
+		blueprint_type: BlueprintItemType,
+		pet_type: PetType,
+		slot_type: SlotType,
+		equipable_item_type: EquipableItemType,
+		pattern: Vec<MaterialItemType>,
+		soul_points: SoulCount,
+	) -> Self {
+		// TODO: add a quantity algorithm
+		// - base 8 - 16 and
+		// - components 6 - 12
+		let mat_req1 = 1;
+		let mat_req2 = 1;
+		let mat_req3 = 1;
+		let mat_req4 = 1;
+
+		self.with_attribute(AvatarAttributes::ItemType, ItemType::Blueprint)
+			.with_attribute(AvatarAttributes::ItemSubType, blueprint_type)
+			.with_attribute(AvatarAttributes::ClassType1, slot_type)
+			.with_attribute(AvatarAttributes::ClassType2, pet_type)
+			.with_attribute(AvatarAttributes::CustomType1, HexType::X1)
+			.with_attribute(AvatarAttributes::RarityType, RarityType::Rare)
+			.with_attribute_raw(AvatarAttributes::Quantity, soul_points as u8)
+			// Unused
+			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_spec_byte_raw(
+				AvatarSpecBytes::SpecByte1,
+				AvatarUtils::enums_to_bits(&pattern) as u8,
+			)
+			.with_spec_byte_raw(
+				AvatarSpecBytes::SpecByte2,
+				AvatarUtils::enums_order_to_bits(&pattern) as u8,
+			)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte3, equipable_item_type.as_byte())
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte4, mat_req1)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte5, mat_req2)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte6, mat_req3)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte7, mat_req4)
+			.with_soul_count(soul_points)
+	}
+
+	pub fn into_unidentified(
+		self,
+		color_pair: (ColorType, ColorType),
+		force_type: ForceType,
+		soul_points: SoulCount,
+	) -> Self {
+		let git_info = 0b0000_1111 |
+			((color_pair.0.as_byte().saturating_sub(1)) << 6 |
+				(color_pair.1.as_byte().saturating_sub(1)) << 4);
+
+		self.with_attribute(AvatarAttributes::ItemType, ItemType::Special)
+			.with_attribute(AvatarAttributes::ItemSubType, SpecialItemType::Unidentified)
+			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
+			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
+			.with_attribute(AvatarAttributes::CustomType1, HexType::X0)
+			// Unused
+			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_attribute(AvatarAttributes::RarityType, RarityType::Legendary)
+			.with_attribute_raw(AvatarAttributes::Quantity, 1)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte1, git_info)
+			.with_spec_byte_raw(AvatarSpecBytes::SpecByte2, force_type.as_byte())
+			.with_soul_count(soul_points)
+	}
+
+	pub fn into_dust(self, soul_points: SoulCount) -> Self {
+		self.with_attribute(AvatarAttributes::ItemType, ItemType::Special)
+			.with_attribute(AvatarAttributes::ItemSubType, SpecialItemType::Dust)
+			.with_attribute(AvatarAttributes::ClassType1, HexType::X0)
+			.with_attribute(AvatarAttributes::ClassType2, HexType::X0)
+			.with_attribute(AvatarAttributes::CustomType1, HexType::X1)
+			.with_attribute(AvatarAttributes::CustomType2, HexType::X0)
+			.with_attribute(AvatarAttributes::RarityType, RarityType::Common)
+			.with_attribute_raw(AvatarAttributes::Quantity, soul_points as u8)
+			.with_soul_count(soul_points)
+	}
+
+	pub fn build(self) -> Avatar {
+		self.inner
+	}
+}
+
+/// Struct to wrap DNA interactions with Avatars from V2 upwards.
+/// Don't use with Avatars with V1.
+pub(crate) struct AvatarUtils;
+
+impl AvatarUtils {
+	pub fn has_attribute_with_same_value_as(
+		avatar: &Avatar,
+		other: &Avatar,
+		attribute: AvatarAttributes,
+	) -> bool {
+		Self::read_attribute(avatar, attribute) == Self::read_attribute(other, attribute)
+	}
+
+	pub fn has_attribute_set_with_same_values_as(
+		avatar: &Avatar,
+		other: &Avatar,
+		attribute_set: &[AvatarAttributes],
+	) -> bool {
+		attribute_set
+			.iter()
+			.all(|attribute| Self::has_attribute_with_same_value_as(avatar, other, *attribute))
+	}
+
+	fn read_dna_strand(avatar: &Avatar, position: usize, byte_type: ByteType) -> u8 {
+		Self::read_dna_at(avatar.dna.as_slice(), position, byte_type)
+	}
+
+	#[inline]
+	fn read_dna_at(dna: &[u8], position: usize, byte_type: ByteType) -> u8 {
+		match byte_type {
+			ByteType::Full => dna[position],
+			ByteType::High => dna[position] >> 4,
+			ByteType::Low => dna[position] & ByteType::High as u8,
+		}
+	}
+
+	#[inline]
+	pub fn high_nibble_of(byte: u8) -> u8 {
+		byte >> 4
+	}
+
+	#[inline]
+	pub fn low_nibble_of(byte: u8) -> u8 {
+		byte & 0x0F
+	}
+
+	fn write_dna_strand(avatar: &mut Avatar, position: usize, byte_type: ByteType, value: u8) {
+		match byte_type {
+			ByteType::Full => avatar.dna[position] = value,
+			ByteType::High =>
+				avatar.dna[position] =
+					(avatar.dna[position] & (ByteType::High as u8)) | (value << 4),
+			ByteType::Low =>
+				avatar.dna[position] = (avatar.dna[position] & (ByteType::Low as u8)) |
+					(value & (ByteType::High as u8)),
+		}
+	}
+
+	#[inline]
+	fn write_dna_at(dna: &mut [u8], position: usize, byte_type: ByteType, value: u8) {
+		match byte_type {
+			ByteType::Full => dna[position] = value,
+			ByteType::High =>
+				dna[position] = (dna[position] & (ByteType::High as u8)) | (value << 4),
+			ByteType::Low =>
+				dna[position] =
+					(dna[position] & (ByteType::Low as u8)) | (value & (ByteType::High as u8)),
+		}
+	}
+
+	pub fn has_attribute_set_with_values(
+		avatar: &Avatar,
+		attribute_value_set: &[(AvatarAttributes, u8)],
+	) -> bool {
+		attribute_value_set
+			.iter()
+			.all(|(attr, value)| Self::has_attribute_with_value_raw(avatar, *attr, *value))
+	}
+
+	pub fn has_attribute_with_value<T>(
+		avatar: &Avatar,
+		attribute: AvatarAttributes,
+		value: T,
+	) -> bool
+	where
+		T: ByteConvertible,
+	{
+		Self::has_attribute_with_value_raw(avatar, attribute, value.as_byte())
+	}
+
+	pub fn has_attribute_with_value_different_than<T>(
+		avatar: &Avatar,
+		attribute: AvatarAttributes,
+		value: T,
+	) -> bool
+	where
+		T: ByteConvertible + PartialEq + Eq,
+	{
+		Self::read_attribute_as::<T>(avatar, attribute) != value
+	}
+
+	pub fn has_attribute_with_value_raw(
+		avatar: &Avatar,
+		attribute: AvatarAttributes,
+		value: u8,
+	) -> bool {
+		Self::read_attribute(avatar, attribute) == value
+	}
+
+	pub fn read_attribute_as<T>(avatar: &Avatar, attribute: AvatarAttributes) -> T
+	where
+		T: ByteConvertible,
+	{
+		T::from_byte(Self::read_attribute(avatar, attribute))
+	}
+
+	pub fn read_attribute(avatar: &Avatar, attribute: AvatarAttributes) -> u8 {
+		match attribute {
+			AvatarAttributes::ItemType => Self::read_dna_strand(avatar, 0, ByteType::High),
+			AvatarAttributes::ItemSubType => Self::read_dna_strand(avatar, 0, ByteType::Low),
+			AvatarAttributes::ClassType1 => Self::read_dna_strand(avatar, 1, ByteType::High),
+			AvatarAttributes::ClassType2 => Self::read_dna_strand(avatar, 1, ByteType::Low),
+			AvatarAttributes::CustomType1 => Self::read_dna_strand(avatar, 2, ByteType::High),
+			AvatarAttributes::CustomType2 => Self::read_dna_strand(avatar, 4, ByteType::Full),
+			AvatarAttributes::RarityType => Self::read_dna_strand(avatar, 2, ByteType::Low),
+			AvatarAttributes::Quantity => Self::read_dna_strand(avatar, 3, ByteType::Full),
+		}
+	}
+
+	pub fn write_typed_attribute<T>(avatar: &mut Avatar, attribute: AvatarAttributes, value: T)
+	where
+		T: ByteConvertible,
+	{
+		Self::write_attribute(avatar, attribute, value.as_byte())
+	}
+
+	pub fn write_attribute(avatar: &mut Avatar, attribute: AvatarAttributes, value: u8) {
+		match attribute {
+			AvatarAttributes::ItemType => Self::write_dna_strand(avatar, 0, ByteType::High, value),
+			AvatarAttributes::ItemSubType =>
+				Self::write_dna_strand(avatar, 0, ByteType::Low, value),
+			AvatarAttributes::ClassType1 =>
+				Self::write_dna_strand(avatar, 1, ByteType::High, value),
+			AvatarAttributes::ClassType2 => Self::write_dna_strand(avatar, 1, ByteType::Low, value),
+			AvatarAttributes::CustomType1 =>
+				Self::write_dna_strand(avatar, 2, ByteType::High, value),
+			AvatarAttributes::CustomType2 =>
+				Self::write_dna_strand(avatar, 4, ByteType::Full, value),
+			AvatarAttributes::RarityType => Self::write_dna_strand(avatar, 2, ByteType::Low, value),
+			AvatarAttributes::Quantity => Self::write_dna_strand(avatar, 3, ByteType::Full, value),
+		}
+	}
+
+	pub fn read_full_spec_bytes(avatar: &Avatar) -> [u8; 16] {
+		let mut out = [0; 16];
+		out.copy_from_slice(&avatar.dna[5..21]);
+		out
+	}
+
+	pub fn read_spec_byte(avatar: &Avatar, spec_byte: AvatarSpecBytes) -> u8 {
+		match spec_byte {
+			AvatarSpecBytes::SpecByte1 => Self::read_dna_strand(avatar, 5, ByteType::Full),
+			AvatarSpecBytes::SpecByte2 => Self::read_dna_strand(avatar, 6, ByteType::Full),
+			AvatarSpecBytes::SpecByte3 => Self::read_dna_strand(avatar, 7, ByteType::Full),
+			AvatarSpecBytes::SpecByte4 => Self::read_dna_strand(avatar, 8, ByteType::Full),
+			AvatarSpecBytes::SpecByte5 => Self::read_dna_strand(avatar, 9, ByteType::Full),
+			AvatarSpecBytes::SpecByte6 => Self::read_dna_strand(avatar, 10, ByteType::Full),
+			AvatarSpecBytes::SpecByte7 => Self::read_dna_strand(avatar, 11, ByteType::Full),
+			AvatarSpecBytes::SpecByte8 => Self::read_dna_strand(avatar, 12, ByteType::Full),
+			AvatarSpecBytes::SpecByte9 => Self::read_dna_strand(avatar, 13, ByteType::Full),
+			AvatarSpecBytes::SpecByte10 => Self::read_dna_strand(avatar, 14, ByteType::Full),
+			AvatarSpecBytes::SpecByte11 => Self::read_dna_strand(avatar, 15, ByteType::Full),
+			AvatarSpecBytes::SpecByte12 => Self::read_dna_strand(avatar, 16, ByteType::Full),
+			AvatarSpecBytes::SpecByte13 => Self::read_dna_strand(avatar, 17, ByteType::Full),
+			AvatarSpecBytes::SpecByte14 => Self::read_dna_strand(avatar, 18, ByteType::Full),
+			AvatarSpecBytes::SpecByte15 => Self::read_dna_strand(avatar, 19, ByteType::Full),
+			AvatarSpecBytes::SpecByte16 => Self::read_dna_strand(avatar, 20, ByteType::Full),
+		}
+	}
+
+	pub fn read_spec_byte_as<T>(avatar: &Avatar, spec_byte: AvatarSpecBytes) -> T
+	where
+		T: ByteConvertible,
+	{
+		T::from_byte(Self::read_spec_byte(avatar, spec_byte))
+	}
+
+	pub fn write_full_spec_bytes(avatar: &mut Avatar, value: [u8; 16]) {
+		(avatar.dna[5..21]).copy_from_slice(&value);
+	}
+
+	pub fn add_spec_byte_from(
+		avatar: &mut Avatar,
+		spec_byte: AvatarSpecBytes,
+		from: &Avatar,
+		from_spec_bye: AvatarSpecBytes,
+	) {
+		let current_value = Self::read_spec_byte(avatar, spec_byte);
+		let from_value = Self::read_spec_byte(from, from_spec_bye);
+		Self::write_spec_byte(avatar, spec_byte, current_value.saturating_add(from_value));
+	}
+
+	pub fn write_spec_byte(avatar: &mut Avatar, spec_byte: AvatarSpecBytes, value: u8) {
+		match spec_byte {
+			AvatarSpecBytes::SpecByte1 => Self::write_dna_strand(avatar, 5, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte2 => Self::write_dna_strand(avatar, 6, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte3 => Self::write_dna_strand(avatar, 7, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte4 => Self::write_dna_strand(avatar, 8, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte5 => Self::write_dna_strand(avatar, 9, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte6 => Self::write_dna_strand(avatar, 10, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte7 => Self::write_dna_strand(avatar, 11, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte8 => Self::write_dna_strand(avatar, 12, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte9 => Self::write_dna_strand(avatar, 13, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte10 =>
+				Self::write_dna_strand(avatar, 14, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte11 =>
+				Self::write_dna_strand(avatar, 15, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte12 =>
+				Self::write_dna_strand(avatar, 16, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte13 =>
+				Self::write_dna_strand(avatar, 17, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte14 =>
+				Self::write_dna_strand(avatar, 18, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte15 =>
+				Self::write_dna_strand(avatar, 19, ByteType::Full, value),
+			AvatarSpecBytes::SpecByte16 =>
+				Self::write_dna_strand(avatar, 20, ByteType::Full, value),
+		}
+	}
+
+	// TODO: Improve return type to [[u8; 3]; 10] if possible
+	pub fn spec_byte_split_ten(avatar: &Avatar) -> Vec<Vec<u8>> {
+		Self::read_full_spec_bytes(avatar)
+			.into_iter()
+			.flat_map(|entry| [entry >> 4, entry & 0x0F])
+			.take(30)
+			.collect::<Vec<u8>>()
+			.chunks_exact(3)
+			.map(|item| item.into())
+			.collect::<Vec<Vec<u8>>>()
+	}
+
+	pub fn spec_byte_split_ten_count(avatar: &Avatar) -> usize {
+		Self::spec_byte_split_ten(avatar)
+			.into_iter()
+			.filter(|segment| segment.iter().sum::<u8>() > 0)
+			.count()
+	}
+
+	pub fn read_progress_array(avatar: &Avatar) -> [u8; 11] {
+		let mut out = [0; 11];
+		out.copy_from_slice(&avatar.dna[21..32]);
+		out
+	}
+
+	pub fn is_array_match(array_1: [u8; 11], array_2: [u8; 11]) -> Option<Vec<u32>> {
+		let (mirror, matches) = Self::match_progress_arrays(array_1, array_2);
+		let match_count = matches.len() as u32;
+
+		(match_count > 0 && (((match_count * 2) + mirror) >= 6)).then_some(matches)
+	}
+
+	pub fn match_progress_arrays(array_1: [u8; 11], array_2: [u8; 11]) -> (u32, Vec<u32>) {
+		let mut matches = Vec::<u32>::new();
+		let mut mirror: u32 = 0;
+
+		let lowest_1 = Self::read_lowest_progress_byte(&array_1, ByteType::High);
+
+		for i in 0..array_1.len() {
+			let rarity_1 = Self::read_dna_at(&array_1, i, ByteType::High);
+			let variation_1 = Self::read_dna_at(&array_1, i, ByteType::Low);
+
+			let rarity_2 = Self::read_dna_at(&array_2, i, ByteType::High);
+			let variation_2 = Self::read_dna_at(&array_2, i, ByteType::Low);
+
+			let have_same_rarity = rarity_1 == rarity_2;
+			let is_maxed = rarity_1 > lowest_1 || lowest_1 == RarityType::Legendary.as_byte();
+			let byte_match = Self::match_progress_byte(variation_1, variation_2);
+
+			if have_same_rarity && !is_maxed && byte_match {
+				matches.push(i as u32);
+			} else if is_maxed && (variation_1 == variation_2) {
+				mirror = mirror.saturating_add(1);
+			}
+		}
+
+		(mirror, matches)
+	}
+
+	fn match_progress_byte(byte_1: u8, byte_2: u8) -> bool {
+		let diff = if byte_1 >= byte_2 { byte_1 - byte_2 } else { byte_2 - byte_1 };
+		diff == 1 || diff == (PROGRESS_VARIATIONS - 1)
+	}
+
+	pub fn write_progress_array(avatar: &mut Avatar, value: [u8; 11]) {
+		(avatar.dna[21..32]).copy_from_slice(&value);
+	}
+
+	pub fn can_use_avatar(avatar: &Avatar, quantity: u8) -> bool {
+		Self::read_attribute(avatar, AvatarAttributes::Quantity) >= quantity
+	}
+
+	pub fn use_avatar(avatar: &mut Avatar, quantity: u8) -> (bool, bool, SoulCount) {
+		let current_qty = Self::read_attribute(avatar, AvatarAttributes::Quantity);
+
+		if current_qty < quantity {
+			return (false, false, 0)
+		}
+
+		let new_qty = current_qty - quantity;
+		Self::write_attribute(avatar, AvatarAttributes::Quantity, new_qty);
+
+		let (avatar_consumed, output_soul_points) = if new_qty == 0 {
+			let soul_points = avatar.souls;
+			avatar.souls = 0;
+			(true, soul_points)
+		} else {
+			let diff = Self::read_attribute(avatar, AvatarAttributes::CustomType1)
+				.saturating_mul(quantity) as SoulCount;
+			avatar.souls = avatar.souls.saturating_sub(diff);
+			(false, diff)
+		};
+
+		(true, avatar_consumed, output_soul_points)
+	}
+
+	pub fn create_pattern<T>(mut base_speed: usize, increase_seed: usize) -> Vec<T>
+	where
+		T: Ranged + Ord,
+	{
+		// Equivalent to "0X35AAB76B4482CADFF35BB3BD1C86648697B6F6833B47B939AECE95EDCD0347"
+		let fixed_seed: [u8; 32] = [
+			0x33, 0x35, 0xAA, 0xB7, 0x6B, 0x44, 0x82, 0xCA, 0xDF, 0xF3, 0x5B, 0xB3, 0xBD, 0x1C,
+			0x86, 0x64, 0x86, 0x97, 0xB6, 0xF6, 0x83, 0x3B, 0x47, 0xB9, 0x39, 0xAE, 0xCE, 0x95,
+			0xED, 0xCD, 0x03, 0x47,
+		];
+
+		let mut all_enum = T::range().into_iter().map(|variant| variant as u8).collect::<Vec<_>>();
+		let mut pattern = Vec::with_capacity(4);
+
+		for _ in 0..4 {
+			base_speed = base_speed.saturating_add(increase_seed);
+			let rand_1 = fixed_seed[base_speed % 32];
+
+			let enum_type = all_enum.remove(rand_1 as usize % all_enum.len());
+			pattern.push(enum_type);
+		}
+
+		pattern.into_iter().map(|item| T::from_byte(item)).collect()
+	}
+
+	pub fn enums_to_bits<T>(enum_list: &[T]) -> u32
+	where
+		T: Ranged,
+	{
+		let range_mod = T::range().start as u8;
+		enum_list
+			.iter()
+			.fold(0_u32, |acc, entry| acc | (1 << (entry.as_byte() - range_mod)))
+	}
+
+	pub fn enums_order_to_bits<T>(enum_list: &[T]) -> u32
+	where
+		T: ByteConvertible + Ord,
+	{
+		let mut sorted_list = Vec::with_capacity(enum_list.len());
+		sorted_list.extend_from_slice(enum_list);
+		sorted_list.sort();
+
+		let mut byte_buff = 0;
+		let fill_amount = usize::BITS - sorted_list.len().saturating_sub(1).leading_zeros();
+
+		for entry in enum_list {
+			if let Ok(index) = sorted_list.binary_search(entry) {
+				byte_buff |= index as u32;
+				byte_buff <<= fill_amount;
+			}
+		}
+
+		byte_buff >> fill_amount
+	}
+
+	pub fn bits_to_enums<T>(bits: u32) -> Vec<T>
+	where
+		T: Ranged,
+	{
+		let mut enums = Vec::new();
+
+		for (i, value) in T::range().enumerate() {
+			if (bits & (1 << i)) != 0 {
+				enums.push(T::from_byte(value as u8));
+			}
+		}
+
+		enums
+	}
+
+	pub fn bits_order_to_enum<T>(bit_order: u32, step_count: usize, enum_list: Vec<T>) -> Vec<T>
+	where
+		T: ByteConvertible + Ord,
+	{
+		let mut sorted_enum_list = enum_list;
+		sorted_enum_list.sort();
+
+		let mut output_enums = Vec::new();
+
+		let mask_width = step_count * 2;
+		let bit_mask = 0b0000_0000_0000_0000_0000_0000_0000_0011 << mask_width.saturating_sub(2);
+
+		for i in (0..mask_width).step_by(2) {
+			let bit_segment = bit_order & (bit_mask >> i);
+			let bit_position = (bit_segment >> (mask_width - (i + 2))) as usize;
+
+			if sorted_enum_list.len() > bit_position {
+				output_enums.push(sorted_enum_list[bit_position]);
+			}
+		}
+
+		output_enums
+	}
+
+	pub fn generate_progress_bytes(
+		rarity_type: RarityType,
+		scale_factor: u32,
+		probability: u32,
+		mut progress_bytes: [u8; 11],
+	) -> [u8; 11] {
+		for i in 0..progress_bytes.len() {
+			let random_value = Self::read_dna_at(&progress_bytes, i, ByteType::Full);
+			let mut new_rarity = rarity_type.as_byte();
+
+			// Upcast random_value
+			if (random_value as u32).saturating_mul(scale_factor) < (probability * MAX_BYTE) {
+				new_rarity = new_rarity.saturating_add(1);
+			}
+
+			Self::write_dna_at(&mut progress_bytes, i, ByteType::High, new_rarity);
+			Self::write_dna_at(
+				&mut progress_bytes,
+				i,
+				ByteType::Low,
+				random_value % PROGRESS_VARIATIONS,
+			);
+		}
+
+		Self::write_dna_at(&mut progress_bytes, 10, ByteType::High, rarity_type.as_byte());
+
+		progress_bytes
+	}
+
+	pub fn read_lowest_progress_byte(progress_bytes: &[u8; 11], byte_type: ByteType) -> u8 {
+		let mut result = u8::MAX;
+
+		for i in 0..progress_bytes.len() {
+			let value = Self::read_dna_at(progress_bytes, i, byte_type);
+			if result > value {
+				result = value;
+			}
+		}
+
+		result
+	}
+}
+
+pub(crate) struct HashProvider<'a, T, const N: usize>
+where
+	T: crate::Config,
+{
+	pub(crate) hash: [u8; N],
+	current_index: usize,
+	_marker: PhantomData<&'a T>,
+}
+
+impl<'a, T, const N: usize> Default for HashProvider<'a, T, N>
+where
+	T: crate::Config,
+{
+	fn default() -> Self {
+		Self { hash: [0; N], current_index: 0, _marker: PhantomData }
+	}
+}
+
+impl<'a, T, const N: usize> HashProvider<'a, T, N>
+where
+	T: crate::Config,
+{
+	pub fn new(hash: &T::Hash) -> Self {
+		Self::new_starting_at(hash, 0)
+	}
+
+	#[cfg(test)]
+	pub fn new_with_bytes(bytes: [u8; N]) -> Self {
+		Self { hash: bytes, current_index: 0, _marker: PhantomData }
+	}
+
+	pub fn new_starting_at(hash: &T::Hash, index: usize) -> Self {
+		// TODO: Improve
+		let mut bytes: [u8; N] = [0; N];
+
+		let hash_ref = hash.as_ref();
+		let hash_len = hash_ref.len();
+
+		bytes[0..hash_len].copy_from_slice(hash_ref);
+
+		Self { hash: bytes, current_index: index, _marker: PhantomData }
+	}
+
+	pub fn full_hash(&self, mutate_seed: usize) -> T::Hash {
+		let mut full_hash = self.hash;
+
+		for (i, hash) in full_hash.iter_mut().enumerate() {
+			*hash = self.hash[(i + mutate_seed) % N];
+		}
+
+		T::Hashing::hash(&full_hash)
+	}
+
+	#[inline]
+	pub fn get_hash_byte(&mut self) -> u8 {
+		self.next().unwrap_or_default()
+	}
+}
+
+impl<'a, T, const N: usize> Iterator for HashProvider<'a, T, N>
+where
+	T: crate::Config,
+{
+	type Item = u8;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		let item = self.hash[self.current_index];
+		self.current_index = (self.current_index + 1) % N;
+		Some(item)
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn test_bits_to_enums_consistency_1() {
+		let bits = 0b_01_01_01_01;
+
+		let result = AvatarUtils::bits_to_enums::<NibbleType>(bits);
+		let expected = vec![NibbleType::X0, NibbleType::X2, NibbleType::X4, NibbleType::X6];
+
+		assert_eq!(result, expected);
+	}
+
+	#[test]
+	fn test_bits_to_enums_consistency_2() {
+		let bits = 0b_11_01_10_01;
+
+		let result = AvatarUtils::bits_to_enums::<MaterialItemType>(bits);
+		let expected = vec![
+			MaterialItemType::Polymers,
+			MaterialItemType::Optics,
+			MaterialItemType::Metals,
+			MaterialItemType::Superconductors,
+			MaterialItemType::Nanomaterials,
+		];
+
+		assert_eq!(result, expected);
+	}
+
+	#[test]
+	fn test_bits_order_to_enums_consistency_1() {
+		let bit_order = 0b_01_10_11_00;
+		let enum_list = vec![NibbleType::X0, NibbleType::X2, NibbleType::X4, NibbleType::X6];
+
+		let result = AvatarUtils::bits_order_to_enum(bit_order, 4, enum_list);
+		let expected = vec![NibbleType::X2, NibbleType::X4, NibbleType::X6, NibbleType::X0];
+		assert_eq!(result, expected);
+
+		let bit_order_2 = 0b_01_11_00_10;
+		let enum_list_2 = vec![NibbleType::X4, NibbleType::X5, NibbleType::X6, NibbleType::X7];
+
+		let result_2 = AvatarUtils::bits_order_to_enum(bit_order_2, 4, enum_list_2);
+		let expected_2 = vec![NibbleType::X5, NibbleType::X7, NibbleType::X4, NibbleType::X6];
+		assert_eq!(result_2, expected_2);
+	}
+
+	#[test]
+	fn test_bits_order_to_enums_consistency_2() {
+		let bit_order = 0b_01_10_00_10;
+		let enum_list = vec![PetType::FoxishDude, PetType::FireDino, PetType::GiantWoodStick];
+
+		let result = AvatarUtils::bits_order_to_enum(bit_order, 4, enum_list);
+		let expected = vec![
+			PetType::FireDino,
+			PetType::GiantWoodStick,
+			PetType::FoxishDude,
+			PetType::GiantWoodStick,
+		];
+
+		assert_eq!(result, expected);
+	}
+
+	#[test]
+	fn test_enum_to_bits_consistency_1() {
+		let pattern = vec![NibbleType::X2, NibbleType::X4, NibbleType::X1, NibbleType::X3];
+		let expected = 0b_00_01_11_10;
+
+		assert_eq!(AvatarUtils::enums_to_bits(&pattern), expected);
+	}
+
+	#[test]
+	fn test_enum_to_bits_consistency_2() {
+		let pattern = vec![PetType::FoxishDude, PetType::BigHybrid, PetType::GiantWoodStick];
+		let expected = 0b_00_11_00_10;
+
+		assert_eq!(AvatarUtils::enums_to_bits(&pattern), expected);
+	}
+
+	#[test]
+	fn test_enum_order_to_bits_consistency() {
+		let pattern = vec![
+			SlotType::LegBack,
+			SlotType::Breast,
+			SlotType::WeaponFront,
+			SlotType::WeaponBack,
+			SlotType::ArmBack,
+		];
+		#[allow(clippy::unusual_byte_groupings)]
+		// We group by 3 because the output is grouped by 3
+		let expected = 0b_010_000_011_100_001;
+
+		assert_eq!(AvatarUtils::enums_order_to_bits(&pattern), expected);
+	}
+
+	#[test]
+	fn test_enum_to_bits_to_enum() {
+		let pattern = vec![
+			MaterialItemType::Polymers,
+			MaterialItemType::Superconductors,
+			MaterialItemType::Ceramics,
+		];
+
+		let expected = vec![
+			MaterialItemType::Polymers,
+			MaterialItemType::Ceramics,
+			MaterialItemType::Superconductors,
+		];
+
+		let bits = AvatarUtils::enums_to_bits(&pattern);
+		assert_eq!(bits, 0b_01_10_00_01);
+
+		let enums = AvatarUtils::bits_to_enums::<MaterialItemType>(bits);
+		assert_eq!(enums, expected);
+	}
+
+	#[test]
+	fn test_create_pattern_consistency() {
+		let base_seed = SlotType::Head.as_byte() as usize;
+		let pattern = AvatarUtils::create_pattern::<NibbleType>(
+			base_seed,
+			SlotType::Breast.as_byte() as usize,
+		);
+
+		let expected = vec![NibbleType::X7, NibbleType::X5, NibbleType::X4, NibbleType::X3];
+
+		assert_eq!(pattern, expected);
+	}
+
+	#[test]
+	fn tests_pattern_and_order() {
+		let base_seed = (PetType::FoxishDude.as_byte() + SlotType::Head.as_byte()) as usize;
+
+		let pattern_1 = AvatarUtils::create_pattern::<NibbleType>(
+			base_seed,
+			EquipableItemType::ArmorBase.as_byte() as usize,
+		);
+		let p10 = AvatarUtils::enums_to_bits(&pattern_1);
+		let p11 = AvatarUtils::enums_order_to_bits(&pattern_1);
+
+		assert_eq!(p10, 0b_01_10_11_00);
+		assert_eq!(p11, 0b_01_11_10_00);
+
+		// Decode Blueprint
+		let unordered_1 = AvatarUtils::bits_to_enums::<NibbleType>(p10);
+		let pattern_1_check = AvatarUtils::bits_order_to_enum(p11, 4, unordered_1);
+		assert_eq!(pattern_1_check, pattern_1);
+
+		// Pattern number and enum number only match if they are according to the index in the list
+		let unordered_material = AvatarUtils::bits_to_enums::<MaterialItemType>(p10);
+		assert_eq!(
+			AvatarUtils::bits_order_to_enum(p11, 4, unordered_material)[0],
+			MaterialItemType::Optics
+		);
+
+		let test_set: Vec<(EquipableItemType, u32, u32)> = vec![
+			(EquipableItemType::ArmorComponent1, 0b_11_01_10_00, 0b_01_11_00_10),
+			(EquipableItemType::ArmorComponent2, 0b_01_01_01_01, 0b_01_11_10_00),
+			(EquipableItemType::ArmorComponent3, 0b_01_10_01_10, 0b_01_10_11_00),
+		];
+
+		for (armor_component, enum_to_bits, enum_order_to_bits) in test_set {
+			let pattern_base = AvatarUtils::create_pattern::<NibbleType>(
+				base_seed,
+				armor_component.as_byte() as usize,
+			);
+			let p_enum_to_bits = AvatarUtils::enums_to_bits(&pattern_base);
+			let p_enum_order_to_bits = AvatarUtils::enums_order_to_bits(&pattern_base);
+			assert_eq!(p_enum_to_bits, enum_to_bits);
+			assert_eq!(p_enum_order_to_bits, enum_order_to_bits);
+			// Decode Blueprint
+			let unordered_base = AvatarUtils::bits_to_enums::<NibbleType>(p_enum_to_bits);
+			let pattern_base_check =
+				AvatarUtils::bits_order_to_enum(p_enum_order_to_bits, 4, unordered_base);
+			assert_eq!(pattern_base_check, pattern_base);
+		}
+	}
+
+	#[test]
+	fn test_match_progress_array_consistency() {
+		let test_sets: Vec<([u8; 11], [u8; 11], usize, u32)> = vec![
+			([0x00; 11], [0x00; 11], 0, 0),
+			([0x10; 11], [0x00; 11], 0, 0),
+			([0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x00], [0x00; 11], 0, 10),
+			([0x00; 11], [0x10; 11], 0, 0),
+			([0x10; 11], [0x10; 11], 0, 0),
+			([0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x00], [0x10; 11], 0, 10),
+			(
+				[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00],
+				[0x01, 0x02, 0x03, 0x04, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x05],
+				11,
+				0,
+			),
+			(
+				[0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10],
+				[0x01, 0x02, 0x03, 0x04, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x05],
+				0,
+				0,
+			),
+			(
+				[0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10],
+				[0x11, 0x12, 0x13, 0x14, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x15],
+				11,
+				0,
+			),
+			(
+				[0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x14, 0x13, 0x12, 0x11, 0x00],
+				[0x11, 0x12, 0x13, 0x14, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x15],
+				0,
+				0,
+			),
+			(
+				[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00],
+				[0x11, 0x12, 0x13, 0x14, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x15],
+				0,
+				0,
+			),
+		];
+
+		for (i, (t_arr_1, t_arr_2, expected_matches, expected_mirror)) in
+			test_sets.into_iter().enumerate()
+		{
+			let (mirror, matches) = AvatarUtils::match_progress_arrays(t_arr_1, t_arr_2);
+			assert_eq!(matches.len(), expected_matches, "Testing test case {}", i);
+			assert_eq!(mirror, expected_mirror);
+		}
+
+		// More complex test
+		let arr_1 = [0x00, 0x11, 0x02, 0x13, 0x04, 0x15, 0x04, 0x13, 0x02, 0x11, 0x00];
+		let arr_2 = [0x01, 0x01, 0x12, 0x13, 0x04, 0x04, 0x13, 0x12, 0x01, 0x01, 0x15];
+
+		let (mirror, matches) = AvatarUtils::match_progress_arrays(arr_1, arr_2);
+		assert_eq!(matches.len(), 2);
+		assert_eq!(mirror, 3);
+
+		assert_eq!(matches[0], 0x00);
+		assert_eq!(matches[1], 0x08);
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/assemble.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/assemble.rs
@@ -1,9 +1,6 @@
 use super::*;
 
-impl<'a, T> AvatarCombinator<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarCombinator<T> {
 	pub(super) fn assemble_avatars(
 		input_leader: ForgeItem<T>,
 		input_sacrifices: Vec<ForgeItem<T>>,
@@ -18,12 +15,12 @@ where
 
 		let rarity_type = RarityType::from_byte(AvatarUtils::read_lowest_progress_byte(
 			&AvatarUtils::read_progress_array(&input_leader),
-			ByteType::High,
+			&ByteType::High,
 		));
 
 		let leader_rarity = AvatarUtils::read_attribute_as::<RarityType>(
 			&input_leader,
-			AvatarAttributes::RarityType,
+			&AvatarAttributes::RarityType,
 		);
 
 		if AvatarUtils::has_attribute_set_with_values(
@@ -38,19 +35,19 @@ where
 			if let Some((_, armor_component)) = matching_sacrifices.iter().find(|(_, sacrifice)| {
 				AvatarUtils::has_attribute_with_value(
 					sacrifice,
-					AvatarAttributes::ItemType,
+					&AvatarAttributes::ItemType,
 					ItemType::Equipable,
 				) && AvatarUtils::has_attribute_with_value_different_than(
 					sacrifice,
-					AvatarAttributes::ItemSubType,
+					&AvatarAttributes::ItemSubType,
 					EquipableItemType::ArmorBase,
 				)
 			}) {
 				AvatarUtils::add_spec_byte_from(
 					&mut input_leader,
-					AvatarSpecBytes::SpecByte1,
+					&AvatarSpecBytes::SpecByte1,
 					armor_component,
-					AvatarSpecBytes::SpecByte1,
+					&AvatarSpecBytes::SpecByte1,
 				);
 			}
 
@@ -58,12 +55,12 @@ where
 			if let Some((_, paint_flask)) = matching_sacrifices.iter().find(|(_, sacrifice)| {
 				let is_essence = AvatarUtils::has_attribute_with_value(
 					sacrifice,
-					AvatarAttributes::ItemType,
+					&AvatarAttributes::ItemType,
 					ItemType::Essence,
 				);
 				let is_paint_flask = AvatarUtils::has_attribute_with_value(
 					sacrifice,
-					AvatarAttributes::ItemSubType,
+					&AvatarAttributes::ItemSubType,
 					EssenceItemType::PaintFlask,
 				);
 
@@ -71,9 +68,9 @@ where
 			}) {
 				AvatarUtils::add_spec_byte_from(
 					&mut input_leader,
-					AvatarSpecBytes::SpecByte1,
+					&AvatarSpecBytes::SpecByte1,
 					paint_flask,
-					AvatarSpecBytes::SpecByte1,
+					&AvatarSpecBytes::SpecByte1,
 				);
 			}
 
@@ -81,12 +78,12 @@ where
 			if let Some((_, force_glow)) = matching_sacrifices.iter().find(|(_, sacrifice)| {
 				let is_essence = AvatarUtils::has_attribute_with_value(
 					sacrifice,
-					AvatarAttributes::ItemType,
+					&AvatarAttributes::ItemType,
 					ItemType::Essence,
 				);
 				let is_force_glow = AvatarUtils::has_attribute_with_value(
 					sacrifice,
-					AvatarAttributes::ItemSubType,
+					&AvatarAttributes::ItemSubType,
 					EssenceItemType::ForceGlow,
 				);
 
@@ -94,17 +91,17 @@ where
 			}) {
 				AvatarUtils::add_spec_byte_from(
 					&mut input_leader,
-					AvatarSpecBytes::SpecByte2,
+					&AvatarSpecBytes::SpecByte2,
 					force_glow,
-					AvatarSpecBytes::SpecByte1,
+					&AvatarSpecBytes::SpecByte1,
 				);
 			}
 		}
 
 		AvatarUtils::write_typed_attribute(
 			&mut input_leader,
-			AvatarAttributes::RarityType,
-			rarity_type,
+			&AvatarAttributes::RarityType,
+			&rarity_type,
 		);
 
 		let output_vec: Vec<ForgeOutput<T>> = non_matching_sacrifices
@@ -141,7 +138,7 @@ mod test {
 			];
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
-			let hash_base: [[u8; 32]; 5] = [
+			let hash_base = [
 				[
 					0xE7, 0x46, 0x00, 0xE4, 0xE8, 0x78, 0x12, 0xC4, 0xCA, 0x86, 0x53, 0x7F, 0x36,
 					0x1B, 0x64, 0xA0, 0xC3, 0x6B, 0x5C, 0x5F, 0x13, 0x40, 0xBC, 0xC6, 0x97, 0x12,
@@ -169,25 +166,19 @@ mod test {
 				],
 			];
 
-			let pet_type = PetType::FoxishDude;
-			let slot_type = SlotType::Head;
-			let equip_type = EquipableItemType::ArmorBase;
-			let rarity_type = RarityType::Common;
-			let color_pair = (ColorType::None, ColorType::None);
-			let force_type = ForceType::None;
-
-			let mut armor_component_set = (0..5)
+			let mut armor_component_set = hash_base
 				.into_iter()
-				.map(|i| {
+				.enumerate()
+				.map(|(i, hash)| {
 					create_random_armor_component(
-						hash_base[i],
+						hash,
 						&ALICE,
-						pet_type,
-						slot_type,
-						rarity_type,
-						vec![equip_type],
-						color_pair,
-						force_type,
+						&PetType::FoxishDude,
+						&SlotType::Head,
+						&RarityType::Common,
+						&[EquipableItemType::ArmorBase],
+						&(ColorType::None, ColorType::None),
+						&ForceType::None,
 						i as SoulCount,
 					)
 				})
@@ -237,7 +228,7 @@ mod test {
 		ExtBuilder::default().build().execute_with(|| {
 			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
 
-			let hash_base: [[u8; 32]; 5] = [
+			let hash_base = [
 				[
 					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
 					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
@@ -265,7 +256,7 @@ mod test {
 				],
 			];
 
-			let progress_arrays: [[u8; 11]; 5] = [
+			let progress_arrays = [
 				[0x21, 0x10, 0x25, 0x23, 0x20, 0x23, 0x21, 0x22, 0x22, 0x22, 0x24],
 				[0x21, 0x15, 0x22, 0x15, 0x13, 0x12, 0x12, 0x10, 0x13, 0x10, 0x15],
 				[0x12, 0x13, 0x11, 0x12, 0x12, 0x20, 0x12, 0x13, 0x13, 0x12, 0x15],
@@ -273,38 +264,33 @@ mod test {
 				[0x11, 0x11, 0x25, 0x24, 0x14, 0x23, 0x13, 0x12, 0x52, 0x12, 0x12],
 			];
 
-			let pet_type = PetType::FoxishDude;
-			let slot_type = SlotType::Head;
-			let equip_type: [EquipableItemType; 5] = [
+			let mut armor_component_set = [
 				EquipableItemType::ArmorBase,
 				EquipableItemType::ArmorBase,
 				EquipableItemType::ArmorBase,
 				EquipableItemType::ArmorBase,
 				EquipableItemType::ArmorComponent1,
-			];
-			let rarity_type = RarityType::Common;
-			let color_pair = (ColorType::None, ColorType::None);
-			let force_type = ForceType::None;
-
-			let mut armor_component_set = (0..5)
-				.into_iter()
-				.map(|i| {
-					let (id, mut avatar) = create_random_armor_component(
-						hash_base[i],
-						&ALICE,
-						pet_type,
-						slot_type,
-						rarity_type,
-						vec![equip_type[i]],
-						color_pair,
-						force_type,
-						i as SoulCount,
-					);
-					AvatarUtils::write_progress_array(&mut avatar, progress_arrays[i]);
-
-					(id, avatar)
-				})
-				.collect::<Vec<_>>();
+			]
+			.into_iter()
+			.zip(hash_base)
+			.zip(progress_arrays)
+			.enumerate()
+			.map(|(i, ((equip_type, hash), progress_array))| {
+				let (id, mut avatar) = create_random_armor_component(
+					hash,
+					&ALICE,
+					&PetType::FoxishDude,
+					&SlotType::Head,
+					&RarityType::Common,
+					&[equip_type],
+					&(ColorType::None, ColorType::None),
+					&ForceType::None,
+					i as SoulCount,
+				);
+				AvatarUtils::write_progress_array(&mut avatar, progress_array);
+				(id, avatar)
+			})
+			.collect::<Vec<_>>();
 
 			let total_soul_points =
 				armor_component_set.iter().map(|(_, avatar)| avatar.souls).sum::<SoulCount>();
@@ -321,7 +307,7 @@ mod test {
 			);
 
 			let pre_assemble = AvatarUtils::bits_to_enums::<EquipableItemType>(
-				AvatarUtils::read_spec_byte(&leader_armor_component.1, AvatarSpecBytes::SpecByte1)
+				AvatarUtils::read_spec_byte(&leader_armor_component.1, &AvatarSpecBytes::SpecByte1)
 					as u32,
 			);
 			assert_eq!(pre_assemble.len(), 1);
@@ -342,7 +328,7 @@ mod test {
 				assert_eq!(avatar.souls, 7);
 
 				let post_assemble = AvatarUtils::bits_to_enums::<EquipableItemType>(
-					AvatarUtils::read_spec_byte(&avatar, AvatarSpecBytes::SpecByte1) as u32,
+					AvatarUtils::read_spec_byte(&avatar, &AvatarSpecBytes::SpecByte1) as u32,
 				);
 				assert_eq!(post_assemble.len(), 2);
 				assert_eq!(post_assemble[0], EquipableItemType::ArmorBase);
@@ -363,7 +349,7 @@ mod test {
 		ExtBuilder::default().build().execute_with(|| {
 			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
 
-			let hash_base: [[u8; 32]; 5] = [
+			let hash_base = [
 				[
 					0xE7, 0x46, 0x00, 0xE4, 0xE8, 0x78, 0x12, 0xC4, 0xCA, 0x86, 0x53, 0x7F, 0x36,
 					0x1B, 0x64, 0xA0, 0xC3, 0x6B, 0x5C, 0x5F, 0x13, 0x40, 0xBC, 0xC6, 0x97, 0x12,
@@ -391,26 +377,23 @@ mod test {
 				],
 			];
 
-			let pet_type = PetType::FoxishDude;
-			let slot_types: [SlotType; 5] =
+			let slot_types =
 				[SlotType::Head, SlotType::Head, SlotType::LegBack, SlotType::Head, SlotType::Head];
-			let equip_type = EquipableItemType::ArmorBase;
-			let rarity_type = RarityType::Common;
-			let color_pair = (ColorType::None, ColorType::None);
-			let force_type = ForceType::None;
 
-			let mut armor_component_set = (0..5)
+			let mut armor_component_set = hash_base
 				.into_iter()
-				.map(|i| {
+				.zip(slot_types)
+				.enumerate()
+				.map(|(i, (hash, slot_type))| {
 					create_random_armor_component(
-						hash_base[i],
+						hash,
 						&ALICE,
-						pet_type,
-						slot_types[i],
-						rarity_type,
-						vec![equip_type],
-						color_pair,
-						force_type,
+						&PetType::FoxishDude,
+						&slot_type,
+						&RarityType::Common,
+						&[EquipableItemType::ArmorBase],
+						&(ColorType::None, ColorType::None),
+						&ForceType::None,
 						i as SoulCount,
 					)
 				})

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/assemble.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/assemble.rs
@@ -1,0 +1,447 @@
+use super::*;
+
+impl<'a, T> AvatarCombinator<'a, T>
+where
+	T: Config,
+{
+	pub(super) fn assemble_avatars(
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		let (
+			(leader_id, mut input_leader),
+			matching_sacrifices,
+			consumed_sacrifices,
+			non_matching_sacrifices,
+		) = Self::match_avatars(input_leader, input_sacrifices, hash_provider);
+
+		let rarity_type = RarityType::from_byte(AvatarUtils::read_lowest_progress_byte(
+			&AvatarUtils::read_progress_array(&input_leader),
+			ByteType::High,
+		));
+
+		let leader_rarity = AvatarUtils::read_attribute_as::<RarityType>(
+			&input_leader,
+			AvatarAttributes::RarityType,
+		);
+
+		if AvatarUtils::has_attribute_set_with_values(
+			&input_leader,
+			&[
+				(AvatarAttributes::ItemType, ItemType::Equipable.as_byte()),
+				(AvatarAttributes::ItemSubType, EquipableItemType::ArmorBase.as_byte()),
+			],
+		) && leader_rarity < rarity_type
+		{
+			// Add a component to the base armor, only first component will be added
+			if let Some((_, armor_component)) = matching_sacrifices.iter().find(|(_, sacrifice)| {
+				AvatarUtils::has_attribute_with_value(
+					sacrifice,
+					AvatarAttributes::ItemType,
+					ItemType::Equipable,
+				) && AvatarUtils::has_attribute_with_value_different_than(
+					sacrifice,
+					AvatarAttributes::ItemSubType,
+					EquipableItemType::ArmorBase,
+				)
+			}) {
+				AvatarUtils::add_spec_byte_from(
+					&mut input_leader,
+					AvatarSpecBytes::SpecByte1,
+					armor_component,
+					AvatarSpecBytes::SpecByte1,
+				);
+			}
+
+			// Add color sparks
+			if let Some((_, paint_flask)) = matching_sacrifices.iter().find(|(_, sacrifice)| {
+				let is_essence = AvatarUtils::has_attribute_with_value(
+					sacrifice,
+					AvatarAttributes::ItemType,
+					ItemType::Essence,
+				);
+				let is_paint_flask = AvatarUtils::has_attribute_with_value(
+					sacrifice,
+					AvatarAttributes::ItemSubType,
+					EssenceItemType::PaintFlask,
+				);
+
+				is_essence && is_paint_flask
+			}) {
+				AvatarUtils::add_spec_byte_from(
+					&mut input_leader,
+					AvatarSpecBytes::SpecByte1,
+					paint_flask,
+					AvatarSpecBytes::SpecByte1,
+				);
+			}
+
+			// Add force glows
+			if let Some((_, force_glow)) = matching_sacrifices.iter().find(|(_, sacrifice)| {
+				let is_essence = AvatarUtils::has_attribute_with_value(
+					sacrifice,
+					AvatarAttributes::ItemType,
+					ItemType::Essence,
+				);
+				let is_force_glow = AvatarUtils::has_attribute_with_value(
+					sacrifice,
+					AvatarAttributes::ItemSubType,
+					EssenceItemType::ForceGlow,
+				);
+
+				is_essence && is_force_glow
+			}) {
+				AvatarUtils::add_spec_byte_from(
+					&mut input_leader,
+					AvatarSpecBytes::SpecByte2,
+					force_glow,
+					AvatarSpecBytes::SpecByte1,
+				);
+			}
+		}
+
+		AvatarUtils::write_typed_attribute(
+			&mut input_leader,
+			AvatarAttributes::RarityType,
+			rarity_type,
+		);
+
+		let output_vec: Vec<ForgeOutput<T>> = non_matching_sacrifices
+			.into_iter()
+			.map(|sacrifice| ForgeOutput::Forged(sacrifice, 0))
+			.chain(
+				consumed_sacrifices
+					.into_iter()
+					.map(|(sacrifice_id, _)| ForgeOutput::Consumed(sacrifice_id)),
+			)
+			.chain(
+				matching_sacrifices
+					.into_iter()
+					.map(|(sacrifice_id, _)| ForgeOutput::Consumed(sacrifice_id)),
+			)
+			.collect();
+
+		Ok((LeaderForgeOutput::Forged((leader_id, input_leader), 0), output_vec))
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::*;
+
+	#[test]
+	fn test_assemble_single_base() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x3F, 0x83, 0x25, 0x3B, 0xA9, 0x24, 0xF2, 0xF6, 0xB5, 0xA9, 0x37, 0x15, 0x25, 0x2C,
+				0x04, 0xFC, 0xEC, 0x45, 0xC1, 0x4D, 0x86, 0xE7, 0x96, 0xE5, 0x20, 0x5D, 0x8B, 0x39,
+				0xB0, 0x54, 0xFB, 0x62,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let hash_base: [[u8; 32]; 5] = [
+				[
+					0xE7, 0x46, 0x00, 0xE4, 0xE8, 0x78, 0x12, 0xC4, 0xCA, 0x86, 0x53, 0x7F, 0x36,
+					0x1B, 0x64, 0xA0, 0xC3, 0x6B, 0x5C, 0x5F, 0x13, 0x40, 0xBC, 0xC6, 0x97, 0x12,
+					0x25, 0x48, 0xC5, 0xD9, 0x05, 0xC3,
+				],
+				[
+					0x3B, 0x06, 0x56, 0x4C, 0x0C, 0x96, 0x6F, 0x41, 0x28, 0x85, 0x40, 0xEC, 0x53,
+					0xAB, 0xF4, 0xCE, 0xCE, 0x6C, 0x60, 0x81, 0xBE, 0xBC, 0xCF, 0x82, 0xBD, 0x70,
+					0x61, 0x14, 0xA2, 0x5E, 0x1A, 0x13,
+				],
+				[
+					0x81, 0xA7, 0xCD, 0x5A, 0x36, 0x51, 0xB8, 0xB6, 0xE8, 0x9F, 0x6C, 0xE4, 0xE3,
+					0x52, 0x15, 0xD0, 0xEB, 0xF5, 0x25, 0x97, 0xA7, 0xD2, 0xE4, 0xC0, 0xDC, 0x7C,
+					0xF3, 0x6F, 0xE0, 0xB3, 0x88, 0x76,
+				],
+				[
+					0x1A, 0x1C, 0x41, 0x48, 0x0B, 0x96, 0xF9, 0xDC, 0xDA, 0x7A, 0x40, 0x28, 0x99,
+					0x86, 0x58, 0xC3, 0x6A, 0xD4, 0x7C, 0x66, 0x58, 0xD1, 0x9C, 0x8E, 0x81, 0xCF,
+					0xE5, 0x78, 0x70, 0x68, 0x12, 0x0D,
+				],
+				[
+					0x84, 0x78, 0x9A, 0x96, 0x77, 0xA2, 0xCE, 0xC3, 0x0E, 0x3C, 0x29, 0x20, 0x33,
+					0x01, 0x67, 0x9C, 0xF8, 0x4D, 0x03, 0x36, 0x80, 0xB5, 0x37, 0x43, 0x6C, 0x71,
+					0xAA, 0xA9, 0x3D, 0x9F, 0x8C, 0xB8,
+				],
+			];
+
+			let pet_type = PetType::FoxishDude;
+			let slot_type = SlotType::Head;
+			let equip_type = EquipableItemType::ArmorBase;
+			let rarity_type = RarityType::Common;
+			let color_pair = (ColorType::None, ColorType::None);
+			let force_type = ForceType::None;
+
+			let mut armor_component_set = (0..5)
+				.into_iter()
+				.map(|i| {
+					create_random_armor_component(
+						hash_base[i],
+						&ALICE,
+						pet_type,
+						slot_type,
+						rarity_type,
+						vec![equip_type],
+						color_pair,
+						force_type,
+						i as SoulCount,
+					)
+				})
+				.collect::<Vec<_>>();
+
+			let total_soul_points =
+				armor_component_set.iter().map(|(_, avatar)| avatar.souls).sum::<SoulCount>();
+			assert_eq!(total_soul_points, 10);
+
+			let armor_component_sacrifices = armor_component_set.split_off(1);
+			let leader_armor_component = armor_component_set.pop().unwrap();
+
+			let expected_progress_array =
+				[0x14, 0x12, 0x10, 0x11, 0x20, 0x21, 0x10, 0x15, 0x11, 0x25, 0x13];
+
+			assert_eq!(
+				AvatarUtils::read_progress_array(&leader_armor_component.1),
+				expected_progress_array
+			);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::assemble_avatars(
+				leader_armor_component,
+				armor_component_sacrifices,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 2);
+
+			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
+				assert_eq!(avatar.souls, 7);
+
+				let leader_progress_array = AvatarUtils::read_progress_array(&avatar);
+				let expected_leader_progress_array =
+					[0x14, 0x12, 0x10, 0x21, 0x20, 0x21, 0x20, 0x25, 0x11, 0x25, 0x23];
+				assert_eq!(leader_progress_array, expected_leader_progress_array);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_assemble_single_base_with_component() {
+		ExtBuilder::default().build().execute_with(|| {
+			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
+
+			let hash_base: [[u8; 32]; 5] = [
+				[
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xA1,
+				],
+				[
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xA2,
+				],
+				[
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xA3,
+				],
+				[
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xA4,
+				],
+				[
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+					0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xA5,
+				],
+			];
+
+			let progress_arrays: [[u8; 11]; 5] = [
+				[0x21, 0x10, 0x25, 0x23, 0x20, 0x23, 0x21, 0x22, 0x22, 0x22, 0x24],
+				[0x21, 0x15, 0x22, 0x15, 0x13, 0x12, 0x12, 0x10, 0x13, 0x10, 0x15],
+				[0x12, 0x13, 0x11, 0x12, 0x12, 0x20, 0x12, 0x13, 0x13, 0x12, 0x15],
+				[0x11, 0x11, 0x25, 0x24, 0x14, 0x23, 0x13, 0x12, 0x12, 0x12, 0x12],
+				[0x11, 0x11, 0x25, 0x24, 0x14, 0x23, 0x13, 0x12, 0x52, 0x12, 0x12],
+			];
+
+			let pet_type = PetType::FoxishDude;
+			let slot_type = SlotType::Head;
+			let equip_type: [EquipableItemType; 5] = [
+				EquipableItemType::ArmorBase,
+				EquipableItemType::ArmorBase,
+				EquipableItemType::ArmorBase,
+				EquipableItemType::ArmorBase,
+				EquipableItemType::ArmorComponent1,
+			];
+			let rarity_type = RarityType::Common;
+			let color_pair = (ColorType::None, ColorType::None);
+			let force_type = ForceType::None;
+
+			let mut armor_component_set = (0..5)
+				.into_iter()
+				.map(|i| {
+					let (id, mut avatar) = create_random_armor_component(
+						hash_base[i],
+						&ALICE,
+						pet_type,
+						slot_type,
+						rarity_type,
+						vec![equip_type[i]],
+						color_pair,
+						force_type,
+						i as SoulCount,
+					);
+					AvatarUtils::write_progress_array(&mut avatar, progress_arrays[i]);
+
+					(id, avatar)
+				})
+				.collect::<Vec<_>>();
+
+			let total_soul_points =
+				armor_component_set.iter().map(|(_, avatar)| avatar.souls).sum::<SoulCount>();
+			assert_eq!(total_soul_points, 10);
+
+			let armor_component_sacrifices = armor_component_set.split_off(1);
+			let leader_armor_component = armor_component_set.pop().unwrap();
+
+			let expected_progress_array =
+				[0x21, 0x10, 0x25, 0x23, 0x20, 0x23, 0x21, 0x22, 0x22, 0x22, 0x24];
+			assert_eq!(
+				AvatarUtils::read_progress_array(&leader_armor_component.1),
+				expected_progress_array
+			);
+
+			let pre_assemble = AvatarUtils::bits_to_enums::<EquipableItemType>(
+				AvatarUtils::read_spec_byte(&leader_armor_component.1, AvatarSpecBytes::SpecByte1)
+					as u32,
+			);
+			assert_eq!(pre_assemble.len(), 1);
+			assert_eq!(pre_assemble[0], EquipableItemType::ArmorBase);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::assemble_avatars(
+				leader_armor_component,
+				armor_component_sacrifices,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 2);
+
+			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
+				assert_eq!(avatar.souls, 7);
+
+				let post_assemble = AvatarUtils::bits_to_enums::<EquipableItemType>(
+					AvatarUtils::read_spec_byte(&avatar, AvatarSpecBytes::SpecByte1) as u32,
+				);
+				assert_eq!(post_assemble.len(), 2);
+				assert_eq!(post_assemble[0], EquipableItemType::ArmorBase);
+				assert_eq!(post_assemble[1], EquipableItemType::ArmorComponent1);
+
+				let leader_progress_array = AvatarUtils::read_progress_array(&avatar);
+				let expected_leader_progress_array =
+					[0x21, 0x20, 0x25, 0x23, 0x20, 0x23, 0x21, 0x22, 0x22, 0x22, 0x24];
+				assert_eq!(leader_progress_array, expected_leader_progress_array);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_assemble_failure() {
+		ExtBuilder::default().build().execute_with(|| {
+			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
+
+			let hash_base: [[u8; 32]; 5] = [
+				[
+					0xE7, 0x46, 0x00, 0xE4, 0xE8, 0x78, 0x12, 0xC4, 0xCA, 0x86, 0x53, 0x7F, 0x36,
+					0x1B, 0x64, 0xA0, 0xC3, 0x6B, 0x5C, 0x5F, 0x13, 0x40, 0xBC, 0xC6, 0x97, 0x12,
+					0x25, 0x48, 0xC5, 0xD9, 0x05, 0xC3,
+				],
+				[
+					0x3B, 0x06, 0x56, 0x4C, 0x0C, 0x96, 0x6F, 0x41, 0x28, 0x85, 0x40, 0xEC, 0x53,
+					0xAB, 0xF4, 0xCE, 0xCE, 0x6C, 0x60, 0x81, 0xBE, 0xBC, 0xCF, 0x82, 0xBD, 0x70,
+					0x61, 0x14, 0xA2, 0x5E, 0x1A, 0x13,
+				],
+				[
+					0x81, 0xA7, 0xCD, 0x5A, 0x36, 0x51, 0xB8, 0xB6, 0xE8, 0x9F, 0x6C, 0xE4, 0xE3,
+					0x52, 0x15, 0xD0, 0xEB, 0xF5, 0x25, 0x97, 0xA7, 0xD2, 0xE4, 0xC0, 0xDC, 0x7C,
+					0xF3, 0x6F, 0xE0, 0xB3, 0x88, 0x76,
+				],
+				[
+					0x1A, 0x1C, 0x41, 0x48, 0x0B, 0x96, 0xF9, 0xDC, 0xDA, 0x7A, 0x40, 0x28, 0x99,
+					0x86, 0x58, 0xC3, 0x6A, 0xD4, 0x7C, 0x66, 0x58, 0xD1, 0x9C, 0x8E, 0x81, 0xCF,
+					0xE5, 0x78, 0x70, 0x68, 0x12, 0x0D,
+				],
+				[
+					0x84, 0x78, 0x9A, 0x96, 0x77, 0xA2, 0xCE, 0xC3, 0x0E, 0x3C, 0x29, 0x20, 0x33,
+					0x01, 0x67, 0x9C, 0xF8, 0x4D, 0x03, 0x36, 0x80, 0xB5, 0x37, 0x43, 0x6C, 0x71,
+					0xAA, 0xA9, 0x3D, 0x9F, 0x8C, 0xB8,
+				],
+			];
+
+			let pet_type = PetType::FoxishDude;
+			let slot_types: [SlotType; 5] =
+				[SlotType::Head, SlotType::Head, SlotType::LegBack, SlotType::Head, SlotType::Head];
+			let equip_type = EquipableItemType::ArmorBase;
+			let rarity_type = RarityType::Common;
+			let color_pair = (ColorType::None, ColorType::None);
+			let force_type = ForceType::None;
+
+			let mut armor_component_set = (0..5)
+				.into_iter()
+				.map(|i| {
+					create_random_armor_component(
+						hash_base[i],
+						&ALICE,
+						pet_type,
+						slot_types[i],
+						rarity_type,
+						vec![equip_type],
+						color_pair,
+						force_type,
+						i as SoulCount,
+					)
+				})
+				.collect::<Vec<_>>();
+
+			let total_soul_points =
+				armor_component_set.iter().map(|(_, avatar)| avatar.souls).sum::<SoulCount>();
+			assert_eq!(total_soul_points, 10);
+
+			let armor_component_sacrifices = armor_component_set.split_off(1);
+			let leader_armor_component = armor_component_set.pop().unwrap();
+
+			let expected_progress_array =
+				[0x14, 0x12, 0x10, 0x11, 0x20, 0x21, 0x10, 0x15, 0x11, 0x25, 0x13];
+			assert_eq!(
+				AvatarUtils::read_progress_array(&leader_armor_component.1),
+				expected_progress_array
+			);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::assemble_avatars(
+				leader_armor_component,
+				armor_component_sacrifices,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 2);
+
+			assert!(is_leader_forged(&leader_output));
+		});
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/breed.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/breed.rs
@@ -1,9 +1,6 @@
 use super::*;
 
-impl<'a, T> AvatarCombinator<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarCombinator<T> {
 	pub(super) fn breed_avatars(
 		input_leader: ForgeItem<T>,
 		input_sacrifices: Vec<ForgeItem<T>>,
@@ -14,7 +11,7 @@ where
 
 		let rarity_type = RarityType::from_byte(AvatarUtils::read_lowest_progress_byte(
 			&AvatarUtils::read_progress_array(&input_leader.1),
-			ByteType::High,
+			&ByteType::High,
 		));
 
 		let is_leader_legendary = rarity_type == RarityType::Legendary;
@@ -26,29 +23,29 @@ where
 			],
 		);
 		let pet_variation =
-			AvatarUtils::read_attribute(&input_leader.1, AvatarAttributes::CustomType2);
+			AvatarUtils::read_attribute(&input_leader.1, &AvatarAttributes::CustomType2);
 
 		if is_leader_legendary && is_leader_egg && pet_variation > 0 {
 			let pet_type_list = AvatarUtils::bits_to_enums::<PetType>(pet_variation as u32);
-			let pet_type = pet_type_list[hash_provider.hash[0] as usize % pet_type_list.len()];
+			let pet_type = &pet_type_list[hash_provider.hash[0] as usize % pet_type_list.len()];
 
 			AvatarUtils::write_typed_attribute(
 				&mut input_leader.1,
-				AvatarAttributes::ClassType2,
+				&AvatarAttributes::ClassType2,
 				pet_type,
 			);
 
 			AvatarUtils::write_typed_attribute(
 				&mut input_leader.1,
-				AvatarAttributes::ItemSubType,
-				PetItemType::Pet,
+				&AvatarAttributes::ItemSubType,
+				&PetItemType::Pet,
 			);
 		}
 
 		AvatarUtils::write_typed_attribute(
 			&mut input_leader.1,
-			AvatarAttributes::RarityType,
-			rarity_type,
+			&AvatarAttributes::RarityType,
+			&rarity_type,
 		);
 
 		let output_vec: Vec<ForgeOutput<T>> = non_matching_sacrifices
@@ -85,7 +82,7 @@ mod test {
 			];
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
-			let hash_base: [[u8; 32]; 5] = [
+			let hash_base = [
 				[
 					0x13, 0x00, 0x04, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x42, 0x40, 0x40, 0x44, 0x43,
@@ -134,7 +131,7 @@ mod test {
 			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 1);
 
 			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
-				let expected_dna: [u8; 32] = [
+				let expected_dna = [
 					0x13, 0x00, 0x04, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x52, 0x40, 0x40, 0x44, 0x53,
 					0x42, 0x51, 0x54, 0x44, 0x42, 0x45,
@@ -156,15 +153,13 @@ mod test {
 			];
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
-			let progress_arrays: [[u8; 11]; 5] = [
+			let progress_arrays = [
 				[0x43, 0x44, 0x41, 0x43, 0x45, 0x44, 0x44, 0x41, 0x43, 0x41, 0x43],
 				[0x53, 0x40, 0x41, 0x41, 0x43, 0x44, 0x50, 0x42, 0x45, 0x40, 0x41],
 				[0x45, 0x44, 0x50, 0x45, 0x43, 0x43, 0x45, 0x43, 0x43, 0x41, 0x40],
 				[0x43, 0x43, 0x40, 0x41, 0x52, 0x45, 0x41, 0x40, 0x53, 0x42, 0x44],
 				[0x43, 0x40, 0x44, 0x43, 0x41, 0x45, 0x44, 0x44, 0x44, 0x45, 0x42],
 			];
-
-			let rarity_type = RarityType::Epic;
 
 			let mut egg_set = (0..5)
 				.into_iter()
@@ -174,7 +169,7 @@ mod test {
 					create_random_egg(
 						None,
 						&ALICE,
-						rarity_type,
+						&RarityType::Epic,
 						0b0000_1111,
 						soul_points as SoulCount,
 						progress_arrays[i],
@@ -194,7 +189,7 @@ mod test {
 			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 2);
 
 			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
-				let expected_progress_array: [u8; 11] =
+				let expected_progress_array =
 					[0x43, 0x44, 0x51, 0x43, 0x45, 0x44, 0x44, 0x51, 0x43, 0x41, 0x43];
 				assert_eq!(AvatarUtils::read_progress_array(&avatar), expected_progress_array);
 			} else {
@@ -208,15 +203,13 @@ mod test {
 		ExtBuilder::default().build().execute_with(|| {
 			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
 
-			let progress_arrays: [[u8; 11]; 5] = [
+			let progress_arrays = [
 				[0x54, 0x55, 0x43, 0x50, 0x50, 0x41, 0x41, 0x54, 0x54, 0x43, 0x52],
 				[0x42, 0x55, 0x42, 0x50, 0x43, 0x43, 0x45, 0x45, 0x44, 0x50, 0x42],
 				[0x44, 0x40, 0x44, 0x44, 0x53, 0x41, 0x40, 0x40, 0x54, 0x43, 0x45],
 				[0x42, 0x41, 0x44, 0x40, 0x53, 0x41, 0x43, 0x44, 0x42, 0x42, 0x42],
 				[0x54, 0x43, 0x44, 0x42, 0x45, 0x42, 0x41, 0x44, 0x40, 0x51, 0x41],
 			];
-
-			let rarity_type = RarityType::Epic;
 
 			let mut egg_set = (0..5)
 				.into_iter()
@@ -226,7 +219,7 @@ mod test {
 					create_random_egg(
 						None,
 						&ALICE,
-						rarity_type,
+						&RarityType::Epic,
 						0b0000_1111,
 						soul_points as SoulCount,
 						progress_arrays[i],
@@ -246,7 +239,7 @@ mod test {
 			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 0);
 
 			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
-				let expected_progress_array: [u8; 11] =
+				let expected_progress_array =
 					[0x54, 0x55, 0x53, 0x50, 0x50, 0x51, 0x51, 0x54, 0x54, 0x53, 0x52];
 				assert_eq!(AvatarUtils::read_progress_array(&avatar), expected_progress_array);
 			} else {
@@ -270,7 +263,7 @@ mod test {
 					let pet_type =
 						SlotRoller::<Test>::roll_on(&PET_TYPE_PROBABILITIES, &mut hash_provider);
 					let progress_array = AvatarUtils::generate_progress_bytes(
-						rarity_type,
+						&rarity_type,
 						SCALING_FACTOR_PERC,
 						PROGRESS_PROBABILITY_PERC,
 						[i; 11],
@@ -294,8 +287,8 @@ mod test {
 			let sacrifices = egg_set.split_off(1);
 			let leader = egg_set.pop().unwrap();
 
-			assert_eq!(AvatarUtils::read_attribute(&leader.1, AvatarAttributes::CustomType2), 2);
-			let expected_progress_array: [u8; 11] =
+			assert_eq!(AvatarUtils::read_attribute(&leader.1, &AvatarAttributes::CustomType2), 2);
+			let expected_progress_array =
 				[0x41, 0x40, 0x45, 0x43, 0x40, 0x53, 0x41, 0x42, 0x42, 0x52, 0x44];
 			assert_eq!(AvatarUtils::read_progress_array(&leader.1), expected_progress_array);
 
@@ -313,7 +306,7 @@ mod test {
 			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
 				assert_eq!(total_soul_points, avatar.souls);
 
-				let expected_progress_array: [u8; 11] =
+				let expected_progress_array =
 					[0x41, 0x40, 0x45, 0x43, 0x40, 0x53, 0x41, 0x42, 0x42, 0x52, 0x44];
 				assert_eq!(AvatarUtils::read_progress_array(&avatar), expected_progress_array);
 			} else {

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/breed.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/breed.rs
@@ -1,0 +1,326 @@
+use super::*;
+
+impl<'a, T> AvatarCombinator<'a, T>
+where
+	T: Config,
+{
+	pub(super) fn breed_avatars(
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		let (mut input_leader, matching_sacrifices, consumed_sacrifices, non_matching_sacrifices) =
+			Self::match_avatars(input_leader, input_sacrifices, hash_provider);
+
+		let rarity_type = RarityType::from_byte(AvatarUtils::read_lowest_progress_byte(
+			&AvatarUtils::read_progress_array(&input_leader.1),
+			ByteType::High,
+		));
+
+		let is_leader_legendary = rarity_type == RarityType::Legendary;
+		let is_leader_egg = AvatarUtils::has_attribute_set_with_values(
+			&input_leader.1,
+			&[
+				(AvatarAttributes::ItemType, ItemType::Pet.as_byte()),
+				(AvatarAttributes::ItemSubType, PetItemType::Egg.as_byte()),
+			],
+		);
+		let pet_variation =
+			AvatarUtils::read_attribute(&input_leader.1, AvatarAttributes::CustomType2);
+
+		if is_leader_legendary && is_leader_egg && pet_variation > 0 {
+			let pet_type_list = AvatarUtils::bits_to_enums::<PetType>(pet_variation as u32);
+			let pet_type = pet_type_list[hash_provider.hash[0] as usize % pet_type_list.len()];
+
+			AvatarUtils::write_typed_attribute(
+				&mut input_leader.1,
+				AvatarAttributes::ClassType2,
+				pet_type,
+			);
+
+			AvatarUtils::write_typed_attribute(
+				&mut input_leader.1,
+				AvatarAttributes::ItemSubType,
+				PetItemType::Pet,
+			);
+		}
+
+		AvatarUtils::write_typed_attribute(
+			&mut input_leader.1,
+			AvatarAttributes::RarityType,
+			rarity_type,
+		);
+
+		let output_vec: Vec<ForgeOutput<T>> = non_matching_sacrifices
+			.into_iter()
+			.map(|sacrifice| ForgeOutput::Forged(sacrifice, 0))
+			.chain(
+				consumed_sacrifices
+					.into_iter()
+					.map(|(sacrifice_id, _)| ForgeOutput::Consumed(sacrifice_id)),
+			)
+			.chain(
+				matching_sacrifices
+					.into_iter()
+					.map(|(sacrifice_id, _)| ForgeOutput::Consumed(sacrifice_id)),
+			)
+			.collect();
+
+		Ok((LeaderForgeOutput::Forged(input_leader, 0), output_vec))
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::*;
+
+	#[test]
+	fn test_breed_egg_prep_1() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x28, 0xD2, 0x1C, 0xCA, 0xEE, 0x3F, 0x80, 0xD9, 0x83, 0x21, 0x5D, 0xF9, 0xAC, 0x5E,
+				0x29, 0x74, 0x6A, 0xD9, 0x6C, 0xB0, 0x20, 0x16, 0xB5, 0xAD, 0xEA, 0x86, 0xFD, 0xE0,
+				0xCC, 0xFD, 0x01, 0xB4,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let hash_base: [[u8; 32]; 5] = [
+				[
+					0x13, 0x00, 0x04, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x42, 0x40, 0x40, 0x44, 0x43,
+					0x42, 0x41, 0x44, 0x44, 0x42, 0x45,
+				],
+				[
+					0x13, 0x00, 0x04, 0x01, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x41, 0x51, 0x52, 0x53, 0x44,
+					0x52, 0x45, 0x41, 0x40, 0x41, 0x43,
+				],
+				[
+					0x13, 0x00, 0x04, 0x01, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x52, 0x41, 0x43, 0x41, 0x53,
+					0x45, 0x43, 0x44, 0x52, 0x43, 0x43,
+				],
+				[
+					0x13, 0x00, 0x04, 0x01, 0x0D, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x42, 0x43, 0x43, 0x44, 0x42,
+					0x44, 0x54, 0x45, 0x41, 0x45, 0x40,
+				],
+				[
+					0x13, 0x00, 0x04, 0x01, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x43, 0x43, 0x52, 0x41, 0x42,
+					0x42, 0x40, 0x45, 0x43, 0x52, 0x44,
+				],
+			];
+
+			let unit_closure = |avatar| avatar;
+
+			let mut avatar_set = (0..5)
+				.into_iter()
+				.map(|i| {
+					create_random_avatar::<Test, _>(&ALICE, Some(hash_base[i]), Some(unit_closure))
+				})
+				.collect::<Vec<_>>();
+
+			let sacrifices = avatar_set.split_off(1);
+			let leader = avatar_set.pop().unwrap();
+
+			let (leader_output, sacrifice_output) =
+				AvatarCombinator::<Test>::breed_avatars(leader, sacrifices, &mut hash_provider)
+					.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 3);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 1);
+
+			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
+				let expected_dna: [u8; 32] = [
+					0x13, 0x00, 0x04, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x52, 0x40, 0x40, 0x44, 0x53,
+					0x42, 0x51, 0x54, 0x44, 0x42, 0x45,
+				];
+				assert_eq!(avatar.dna.as_slice(), &expected_dna);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_breed_egg_prep_2() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x9A, 0x6D, 0x5D, 0x62, 0x1B, 0x32, 0xFF, 0x42, 0x32, 0x46, 0x62, 0x15, 0xBB, 0x51,
+				0xE9, 0x37, 0xDB, 0xB0, 0xBC, 0x0F, 0xB0, 0x4C, 0xFF, 0x14, 0x40, 0x99, 0xEF, 0x6C,
+				0x23, 0xAF, 0xCF, 0x4E,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let progress_arrays: [[u8; 11]; 5] = [
+				[0x43, 0x44, 0x41, 0x43, 0x45, 0x44, 0x44, 0x41, 0x43, 0x41, 0x43],
+				[0x53, 0x40, 0x41, 0x41, 0x43, 0x44, 0x50, 0x42, 0x45, 0x40, 0x41],
+				[0x45, 0x44, 0x50, 0x45, 0x43, 0x43, 0x45, 0x43, 0x43, 0x41, 0x40],
+				[0x43, 0x43, 0x40, 0x41, 0x52, 0x45, 0x41, 0x40, 0x53, 0x42, 0x44],
+				[0x43, 0x40, 0x44, 0x43, 0x41, 0x45, 0x44, 0x44, 0x44, 0x45, 0x42],
+			];
+
+			let rarity_type = RarityType::Epic;
+
+			let mut egg_set = (0..5)
+				.into_iter()
+				.map(|i| {
+					let soul_points = ((progress_arrays[i][2] | progress_arrays[i][6]) % 99) + 1;
+
+					create_random_egg(
+						None,
+						&ALICE,
+						rarity_type,
+						0b0000_1111,
+						soul_points as SoulCount,
+						progress_arrays[i],
+					)
+				})
+				.collect::<Vec<_>>();
+
+			let sacrifices = egg_set.split_off(1);
+			let leader = egg_set.pop().unwrap();
+
+			let (leader_output, sacrifice_output) =
+				AvatarCombinator::<Test>::breed_avatars(leader, sacrifices, &mut hash_provider)
+					.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 2);
+
+			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
+				let expected_progress_array: [u8; 11] =
+					[0x43, 0x44, 0x51, 0x43, 0x45, 0x44, 0x44, 0x51, 0x43, 0x41, 0x43];
+				assert_eq!(AvatarUtils::read_progress_array(&avatar), expected_progress_array);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_breed_egg_prep_3() {
+		ExtBuilder::default().build().execute_with(|| {
+			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
+
+			let progress_arrays: [[u8; 11]; 5] = [
+				[0x54, 0x55, 0x43, 0x50, 0x50, 0x41, 0x41, 0x54, 0x54, 0x43, 0x52],
+				[0x42, 0x55, 0x42, 0x50, 0x43, 0x43, 0x45, 0x45, 0x44, 0x50, 0x42],
+				[0x44, 0x40, 0x44, 0x44, 0x53, 0x41, 0x40, 0x40, 0x54, 0x43, 0x45],
+				[0x42, 0x41, 0x44, 0x40, 0x53, 0x41, 0x43, 0x44, 0x42, 0x42, 0x42],
+				[0x54, 0x43, 0x44, 0x42, 0x45, 0x42, 0x41, 0x44, 0x40, 0x51, 0x41],
+			];
+
+			let rarity_type = RarityType::Epic;
+
+			let mut egg_set = (0..5)
+				.into_iter()
+				.map(|i| {
+					let soul_points = ((progress_arrays[i][2] | progress_arrays[i][6]) % 99) + 1;
+
+					create_random_egg(
+						None,
+						&ALICE,
+						rarity_type,
+						0b0000_1111,
+						soul_points as SoulCount,
+						progress_arrays[i],
+					)
+				})
+				.collect::<Vec<_>>();
+
+			let sacrifices = egg_set.split_off(1);
+			let leader = egg_set.pop().unwrap();
+
+			let (leader_output, sacrifice_output) =
+				AvatarCombinator::<Test>::breed_avatars(leader, sacrifices, &mut hash_provider)
+					.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 0);
+
+			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
+				let expected_progress_array: [u8; 11] =
+					[0x54, 0x55, 0x53, 0x50, 0x50, 0x51, 0x51, 0x54, 0x54, 0x53, 0x52];
+				assert_eq!(AvatarUtils::read_progress_array(&avatar), expected_progress_array);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	// TODO: Need original test rewrite
+	/*#[test]
+	fn test_breed_egg() {
+		ExtBuilder::default().build().execute_with(|| {
+			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
+
+			let rarity_type = RarityType::Epic;
+
+			let mut egg_set = (0..5)
+				.into_iter()
+				.map(|i| {
+					let soul_points = (i + 1) * 10;
+					let pet_type =
+						SlotRoller::<Test>::roll_on(&PET_TYPE_PROBABILITIES, &mut hash_provider);
+					let progress_array = AvatarUtils::generate_progress_bytes(
+						rarity_type,
+						SCALING_FACTOR_PERC,
+						PROGRESS_PROBABILITY_PERC,
+						[i; 11],
+					);
+
+					create_random_egg(
+						None,
+						&ALICE,
+						rarity_type,
+						pet_type,
+						soul_points as SoulCount,
+						progress_array,
+					)
+				})
+				.collect::<Vec<_>>();
+
+			let total_soul_points =
+				egg_set.iter().map(|(_, avatar)| avatar.souls).sum::<SoulCount>();
+			assert_eq!(total_soul_points, 150);
+
+			let sacrifices = egg_set.split_off(1);
+			let leader = egg_set.pop().unwrap();
+
+			assert_eq!(AvatarUtils::read_attribute(&leader.1, AvatarAttributes::CustomType2), 2);
+			let expected_progress_array: [u8; 11] =
+				[0x41, 0x40, 0x45, 0x43, 0x40, 0x53, 0x41, 0x42, 0x42, 0x52, 0x44];
+			assert_eq!(AvatarUtils::read_progress_array(&leader.1), expected_progress_array);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::breed_avatars(
+				leader,
+				sacrifices,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 0);
+
+			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
+				assert_eq!(total_soul_points, avatar.souls);
+
+				let expected_progress_array: [u8; 11] =
+					[0x41, 0x40, 0x45, 0x43, 0x40, 0x53, 0x41, 0x42, 0x42, 0x52, 0x44];
+				assert_eq!(AvatarUtils::read_progress_array(&avatar), expected_progress_array);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+
+			// MORE
+		});
+	}*/
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/build.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/build.rs
@@ -1,0 +1,724 @@
+use super::*;
+
+impl<'a, T> AvatarCombinator<'a, T>
+where
+	T: Config,
+{
+	pub(super) fn build_avatars(
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+		season_id: SeasonId,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		let mut output_sacrifices = Vec::with_capacity(input_sacrifices.len());
+
+		let leader_spec_bytes = AvatarUtils::read_full_spec_bytes(&input_leader.1);
+
+		let unord_1 = AvatarUtils::bits_to_enums::<MaterialItemType>(leader_spec_bytes[0] as u32);
+		let pat_1 = AvatarUtils::bits_order_to_enum(leader_spec_bytes[1] as u32, 4, unord_1);
+
+		let quantities = [
+			leader_spec_bytes[3],
+			leader_spec_bytes[4],
+			leader_spec_bytes[5],
+			leader_spec_bytes[6],
+		];
+
+		let sacrifice_pattern = input_sacrifices
+			.iter()
+			.map(|(_, sacrifice)| {
+				AvatarUtils::read_attribute_as::<MaterialItemType>(
+					sacrifice,
+					AvatarAttributes::ItemSubType,
+				)
+			})
+			.collect::<Vec<MaterialItemType>>();
+
+		let level = {
+			let mut lvl = 0;
+			for i in 1..6 {
+				if input_sacrifices.iter().enumerate().all(|(index, (_, sacrifice))| {
+					AvatarUtils::can_use_avatar(sacrifice, quantities[index] * i)
+				}) {
+					lvl = i;
+				}
+			}
+			lvl
+		};
+
+		let mut soul_points = 0 as SoulCount;
+
+		let can_use_leader = AvatarUtils::can_use_avatar(&input_leader.1, 1);
+
+		if sacrifice_pattern == pat_1 && can_use_leader && level > 0 {
+			for (i, (sacrifice_id, mut sacrifice)) in input_sacrifices.into_iter().enumerate() {
+				let (_, avatar_consumed, out_soul_points) =
+					AvatarUtils::use_avatar(&mut sacrifice, quantities[i] * level);
+				soul_points += out_soul_points;
+
+				let sacrifice_output = if avatar_consumed {
+					ForgeOutput::Consumed(sacrifice_id)
+				} else {
+					ForgeOutput::Forged((sacrifice_id, sacrifice), 0)
+				};
+
+				output_sacrifices.push(sacrifice_output);
+			}
+
+			let max_build = 6_usize;
+			let mut build_prop = SCALING_FACTOR_PERC;
+
+			let mut generated_equipables = Vec::with_capacity(3);
+
+			for i in 0..=max_build {
+				if soul_points > 0 &&
+					(build_prop * MAX_BYTE >= hash_provider.hash[i] as u32 * SCALING_FACTOR_PERC)
+				{
+					let pet_type = AvatarUtils::read_attribute_as::<PetType>(
+						&input_leader.1,
+						AvatarAttributes::ClassType2,
+					);
+
+					let slot_type = AvatarUtils::read_attribute_as::<SlotType>(
+						&input_leader.1,
+						AvatarAttributes::ClassType1,
+					);
+
+					let equipable_item_type = AvatarUtils::read_spec_byte_as::<EquipableItemType>(
+						&input_leader.1,
+						AvatarSpecBytes::SpecByte3,
+					);
+
+					let rarity_value = {
+						let rarity_val = hash_provider.hash[i] % 8 + 1;
+						if rarity_val < level {
+							if rarity_val > RarityType::Rare.as_byte() {
+								RarityType::Rare
+							} else {
+								RarityType::from_byte(rarity_val)
+							}
+						} else {
+							RarityType::from_byte(1)
+						}
+					};
+
+					let dna = AvatarMinterV2::<T>(PhantomData)
+						.generate_base_avatar_dna(hash_provider, 9)?;
+					let generated_equipable = AvatarBuilder::with_dna(season_id, dna)
+						.try_into_armor_and_component(
+							pet_type,
+							slot_type,
+							vec![equipable_item_type],
+							rarity_value,
+							(ColorType::None, ColorType::None),
+							ForceType::None,
+							1,
+						)
+						.map_err(|_| Error::<T>::InvalidForgeComponents)?
+						.build();
+
+					generated_equipables.push(generated_equipable);
+
+					soul_points -= 1;
+				}
+
+				build_prop = build_prop.saturating_sub(15 - (level as u32 * 3));
+			}
+
+			for _ in 0..soul_points as usize {
+				let sacrifice_index =
+					hash_provider.get_hash_byte() as usize % generated_equipables.len();
+				generated_equipables[sacrifice_index].souls.saturating_inc();
+			}
+
+			output_sacrifices
+				.extend(generated_equipables.into_iter().map(|gen| ForgeOutput::Minted(gen)));
+		} else {
+			// TODO: Incomplete
+			output_sacrifices.extend(
+				input_sacrifices.into_iter().map(|sacrifice| ForgeOutput::Forged(sacrifice, 0)),
+			);
+		}
+
+		Ok((LeaderForgeOutput::Forged(input_leader, 0), output_sacrifices))
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::*;
+
+	#[test]
+	fn test_build_successfully_no_materials_left() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let forge_hash = [
+				0x4C, 0x0B, 0xF6, 0x8A, 0xFF, 0x3D, 0xAD, 0xB0, 0x01, 0x15, 0xE1, 0x7B, 0x90, 0x36,
+				0x38, 0x60, 0x55, 0x91, 0x25, 0x4D, 0x57, 0xFA, 0x57, 0x1D, 0x38, 0xB9, 0xC9, 0x99,
+				0x42, 0xEA, 0x20, 0x37,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let pet_type = PetType::FoxishDude;
+			let slot_type = SlotType::Head;
+			let equip_type = EquipableItemType::ArmorBase;
+
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				equip_type.as_byte() as usize,
+			);
+
+			assert_eq!(
+				pattern,
+				vec![
+					MaterialItemType::Optics,
+					MaterialItemType::Superconductors,
+					MaterialItemType::Ceramics,
+					MaterialItemType::PowerCells
+				]
+			);
+
+			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, pattern[1], 1);
+			let material_input_3 = create_random_material(&ALICE, pattern[2], 1);
+			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+
+			let blueprint_input_1 =
+				create_random_blueprint(&ALICE, pet_type, slot_type, equip_type, pattern, 5);
+
+			let total_soul_points = blueprint_input_1.1.souls +
+				material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+			assert_eq!(total_soul_points, 9);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::build_avatars(
+				blueprint_input_1,
+				vec![material_input_1, material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 8);
+			// All materials have been consumed
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 4);
+			// We minted equipment pieces for each material
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 4);
+
+			// All minted items are ArmorBase equipables
+			assert_eq!(
+				sacrifice_output
+					.iter()
+					.filter(|output| {
+						is_minted_with_attributes(
+							output,
+							&[
+								(AvatarAttributes::ItemType, ItemType::Equipable.as_byte()),
+								(
+									AvatarAttributes::ItemSubType,
+									EquipableItemType::ArmorBase.as_byte(),
+								),
+							],
+						)
+					})
+					.count(),
+				4
+			);
+
+			assert!(is_leader_forged_with_attributes(
+				&leader_output,
+				&[(AvatarAttributes::ItemType, ItemType::Blueprint.as_byte())]
+			));
+		});
+	}
+
+	#[test]
+	fn test_build_successfully_some_materials_left() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let forge_hash = [
+				0x4C, 0x0B, 0xF6, 0x8A, 0xFF, 0x3D, 0xAD, 0xB0, 0x01, 0x15, 0xE1, 0x7B, 0x90, 0x36,
+				0x38, 0x60, 0x55, 0x91, 0x25, 0x4D, 0x57, 0xFA, 0x57, 0x1D, 0x38, 0xB9, 0xC9, 0x99,
+				0x42, 0xEA, 0x20, 0x37,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let pet_type = PetType::FoxishDude;
+			let slot_type = SlotType::Head;
+			let equip_type = EquipableItemType::ArmorBase;
+
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				equip_type.as_byte() as usize,
+			);
+
+			assert_eq!(
+				pattern,
+				vec![
+					MaterialItemType::Optics,
+					MaterialItemType::Superconductors,
+					MaterialItemType::Ceramics,
+					MaterialItemType::PowerCells
+				]
+			);
+
+			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, pattern[1], 2);
+			let material_input_3 = create_random_material(&ALICE, pattern[2], 1);
+			let material_input_4 = create_random_material(&ALICE, pattern[3], 2);
+
+			let blueprint_input_1 =
+				create_random_blueprint(&ALICE, pet_type, slot_type, equip_type, pattern, 5);
+
+			let total_soul_points = blueprint_input_1.1.souls +
+				material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+			assert_eq!(total_soul_points, 11);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::build_avatars(
+				blueprint_input_1,
+				vec![material_input_1, material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 8);
+			// All materials that had only 1 item have been consumed
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 2);
+			// All materials that had more than 1 item have been forged
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 2);
+			// We minted equipment pieces for each material
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 4);
+			// All minted items are ArmorBase equipables
+			assert_eq!(
+				sacrifice_output
+					.iter()
+					.filter(|output| {
+						is_minted_with_attributes(
+							output,
+							&[
+								(AvatarAttributes::ItemType, ItemType::Equipable.as_byte()),
+								(
+									AvatarAttributes::ItemSubType,
+									EquipableItemType::ArmorBase.as_byte(),
+								),
+							],
+						)
+					})
+					.count(),
+				4
+			);
+
+			for material in [MaterialItemType::PowerCells, MaterialItemType::Superconductors] {
+				assert_eq!(
+					sacrifice_output
+						.iter()
+						.filter(|output| is_forged_with_attributes(
+							output,
+							&[
+								(AvatarAttributes::ItemType, ItemType::Material.as_byte()),
+								(AvatarAttributes::ItemSubType, material.as_byte()),
+							]
+						))
+						.count(),
+					1
+				);
+			}
+
+			assert!(is_leader_forged_with_attributes(
+				&leader_output,
+				&[(AvatarAttributes::ItemType, ItemType::Blueprint.as_byte())]
+			));
+		});
+	}
+
+	#[test]
+	fn test_build_successfully_all_materials_left() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let forge_hash = [
+				0x4C, 0x0B, 0xF6, 0x8A, 0xFF, 0x3D, 0xAD, 0xB0, 0x01, 0x15, 0xE1, 0x7B, 0x90, 0x36,
+				0x38, 0x60, 0x55, 0x91, 0x25, 0x4D, 0x57, 0xFA, 0x57, 0x1D, 0x38, 0xB9, 0xC9, 0x99,
+				0x42, 0xEA, 0x20, 0x37,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let pet_type = PetType::FoxishDude;
+			let slot_type = SlotType::Head;
+			let equip_type = EquipableItemType::ArmorBase;
+
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				equip_type.as_byte() as usize,
+			);
+
+			assert_eq!(
+				pattern,
+				vec![
+					MaterialItemType::Optics,
+					MaterialItemType::Superconductors,
+					MaterialItemType::Ceramics,
+					MaterialItemType::PowerCells
+				]
+			);
+
+			let material_input_1 = create_random_material(&ALICE, pattern[0], 10);
+			let material_input_2 = create_random_material(&ALICE, pattern[1], 10);
+			let material_input_3 = create_random_material(&ALICE, pattern[2], 10);
+			let material_input_4 = create_random_material(&ALICE, pattern[3], 10);
+
+			let blueprint_input_1 = create_random_blueprint(
+				&ALICE,
+				pet_type,
+				slot_type,
+				equip_type,
+				pattern.clone(),
+				5,
+			);
+
+			let total_soul_points = blueprint_input_1.1.souls +
+				material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+			assert_eq!(total_soul_points, 45);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::build_avatars(
+				blueprint_input_1,
+				vec![material_input_1, material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 11);
+			// All materials that had only 1 item have been consumed
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 0);
+			// All materials that had more than 1 item have been forged
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 4);
+			// We minted equipment pieces for each material
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 7);
+			// All minted items are ArmorBase equipables
+			assert_eq!(
+				sacrifice_output
+					.iter()
+					.filter(|output| {
+						is_minted_with_attributes(
+							output,
+							&[
+								(AvatarAttributes::ItemType, ItemType::Equipable.as_byte()),
+								(
+									AvatarAttributes::ItemSubType,
+									EquipableItemType::ArmorBase.as_byte(),
+								),
+							],
+						)
+					})
+					.count(),
+				7
+			);
+
+			for material in pattern {
+				assert_eq!(
+					sacrifice_output
+						.iter()
+						.filter(|output| is_forged_with_attributes(
+							output,
+							&[
+								(AvatarAttributes::ItemType, ItemType::Material.as_byte()),
+								(AvatarAttributes::ItemSubType, material.as_byte()),
+							]
+						))
+						.count(),
+					1
+				);
+			}
+
+			assert!(is_leader_forged_with_attributes(
+				&leader_output,
+				&[(AvatarAttributes::ItemType, ItemType::Blueprint.as_byte())]
+			));
+		});
+	}
+
+	#[test]
+	fn test_build_failure_wrong_material_order() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let forge_hash = [
+				0x4C, 0x0B, 0xF6, 0x8A, 0xFF, 0x3D, 0xAD, 0xB0, 0x01, 0x15, 0xE1, 0x7B, 0x90, 0x36,
+				0x38, 0x60, 0x55, 0x91, 0x25, 0x4D, 0x57, 0xFA, 0x57, 0x1D, 0x38, 0xB9, 0xC9, 0x99,
+				0x42, 0xEA, 0x20, 0x37,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let pet_type = PetType::FoxishDude;
+			let slot_type = SlotType::Head;
+			let equip_type = EquipableItemType::ArmorBase;
+
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				equip_type.as_byte() as usize,
+			);
+
+			assert_eq!(
+				pattern,
+				vec![
+					MaterialItemType::Optics,
+					MaterialItemType::Superconductors,
+					MaterialItemType::Ceramics,
+					MaterialItemType::PowerCells
+				]
+			);
+
+			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, pattern[2], 1);
+			let material_input_3 = create_random_material(&ALICE, pattern[1], 1);
+			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+
+			let blueprint_input_1 = create_random_blueprint(
+				&ALICE,
+				pet_type,
+				slot_type,
+				equip_type,
+				pattern.clone(),
+				5,
+			);
+
+			let total_soul_points = blueprint_input_1.1.souls +
+				material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+			assert_eq!(total_soul_points, 9);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::build_avatars(
+				blueprint_input_1,
+				vec![material_input_1, material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			// All materials that had only 1 item have been consumed
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 0);
+			// All materials that had more than 1 item have been forged
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 4);
+			// We minted equipment pieces for each material
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 0);
+
+			for material in pattern {
+				assert_eq!(
+					sacrifice_output
+						.iter()
+						.filter(|output| is_forged_with_attributes(
+							output,
+							&[
+								(AvatarAttributes::ItemType, ItemType::Material.as_byte()),
+								(AvatarAttributes::ItemSubType, material.as_byte()),
+							]
+						))
+						.count(),
+					1
+				);
+			}
+
+			assert!(is_leader_forged_with_attributes(
+				&leader_output,
+				&[(AvatarAttributes::ItemType, ItemType::Blueprint.as_byte())]
+			));
+		});
+	}
+
+	#[test]
+	fn test_build_failure_wrong_material() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let forge_hash = [
+				0x4C, 0x0B, 0xF6, 0x8A, 0xFF, 0x3D, 0xAD, 0xB0, 0x01, 0x15, 0xE1, 0x7B, 0x90, 0x36,
+				0x38, 0x60, 0x55, 0x91, 0x25, 0x4D, 0x57, 0xFA, 0x57, 0x1D, 0x38, 0xB9, 0xC9, 0x99,
+				0x42, 0xEA, 0x20, 0x37,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let pet_type = PetType::FoxishDude;
+			let slot_type = SlotType::Head;
+			let equip_type = EquipableItemType::ArmorBase;
+
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				equip_type.as_byte() as usize,
+			);
+
+			assert_eq!(
+				pattern,
+				vec![
+					MaterialItemType::Optics,
+					MaterialItemType::Superconductors,
+					MaterialItemType::Ceramics,
+					MaterialItemType::PowerCells
+				]
+			);
+
+			// We change the materials from the original pattern
+			// in order to cause a mismatch with the Blueprint specs
+			let mutated_pattern = {
+				let mut mutated = pattern.clone();
+				mutated[2] = MaterialItemType::Metals;
+				mutated
+			};
+
+			let material_input_1 = create_random_material(&ALICE, mutated_pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, mutated_pattern[1], 1);
+			let material_input_3 = create_random_material(&ALICE, mutated_pattern[2], 1);
+			let material_input_4 = create_random_material(&ALICE, mutated_pattern[3], 1);
+
+			// Here we use the original pattern
+			let blueprint_input_1 =
+				create_random_blueprint(&ALICE, pet_type, slot_type, equip_type, pattern, 5);
+
+			let total_soul_points = blueprint_input_1.1.souls +
+				material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+			assert_eq!(total_soul_points, 9);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::build_avatars(
+				blueprint_input_1,
+				vec![material_input_1, material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			// All materials that had only 1 item have been consumed
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 0);
+			// All materials that had more than 1 item have been forged
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 4);
+			// We minted equipment pieces for each material
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 0);
+
+			for material in mutated_pattern {
+				assert_eq!(
+					sacrifice_output
+						.iter()
+						.filter(|output| is_forged_with_attributes(
+							output,
+							&[
+								(AvatarAttributes::ItemType, ItemType::Material.as_byte()),
+								(AvatarAttributes::ItemSubType, material.as_byte()),
+							]
+						))
+						.count(),
+					1
+				);
+			}
+
+			assert!(is_leader_forged_with_attributes(
+				&leader_output,
+				&[(AvatarAttributes::ItemType, ItemType::Blueprint.as_byte())]
+			));
+		});
+	}
+
+	#[test]
+	fn test_build_success_on_other_pattern() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let forge_hash = [
+				0x4C, 0x0B, 0xF6, 0x8A, 0xFF, 0x3D, 0xAD, 0xB0, 0x01, 0x15, 0xE1, 0x7B, 0x90, 0x36,
+				0x38, 0x60, 0x55, 0x91, 0x25, 0x4D, 0x57, 0xFA, 0x57, 0x1D, 0x38, 0xB9, 0xC9, 0x99,
+				0x42, 0xEA, 0x20, 0x37,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let pet_type = PetType::TankyBullwog;
+			let slot_type = SlotType::ArmBack;
+			let equip_type = EquipableItemType::ArmorComponent2;
+
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				equip_type.as_byte() as usize,
+			);
+
+			assert_eq!(
+				pattern,
+				vec![
+					MaterialItemType::Nanomaterials,
+					MaterialItemType::Metals,
+					MaterialItemType::PowerCells,
+					MaterialItemType::Electronics
+				]
+			);
+
+			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, pattern[1], 1);
+			let material_input_3 = create_random_material(&ALICE, pattern[2], 1);
+			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+
+			let blueprint_input_1 =
+				create_random_blueprint(&ALICE, pet_type, slot_type, equip_type, pattern, 5);
+
+			let total_soul_points = blueprint_input_1.1.souls +
+				material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+			assert_eq!(total_soul_points, 9);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::build_avatars(
+				blueprint_input_1,
+				vec![material_input_1, material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 8);
+			// All materials have been consumed
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 4);
+			// We minted equipment pieces for each material
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 4);
+
+			// All minted items are ArmorBase equipables
+			assert_eq!(
+				sacrifice_output
+					.iter()
+					.filter(|output| {
+						is_minted_with_attributes(
+							output,
+							&[
+								(AvatarAttributes::ItemType, ItemType::Equipable.as_byte()),
+								(
+									AvatarAttributes::ItemSubType,
+									EquipableItemType::ArmorComponent2.as_byte(),
+								),
+							],
+						)
+					})
+					.count(),
+				4
+			);
+
+			assert!(is_leader_forged_with_attributes(
+				&leader_output,
+				&[(AvatarAttributes::ItemType, ItemType::Blueprint.as_byte())]
+			));
+		});
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/build.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/build.rs
@@ -1,9 +1,6 @@
 use super::*;
 
-impl<'a, T> AvatarCombinator<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarCombinator<T> {
 	pub(super) fn build_avatars(
 		input_leader: ForgeItem<T>,
 		input_sacrifices: Vec<ForgeItem<T>>,
@@ -29,7 +26,7 @@ where
 			.map(|(_, sacrifice)| {
 				AvatarUtils::read_attribute_as::<MaterialItemType>(
 					sacrifice,
-					AvatarAttributes::ItemSubType,
+					&AvatarAttributes::ItemSubType,
 				)
 			})
 			.collect::<Vec<MaterialItemType>>();
@@ -76,17 +73,17 @@ where
 				{
 					let pet_type = AvatarUtils::read_attribute_as::<PetType>(
 						&input_leader.1,
-						AvatarAttributes::ClassType2,
+						&AvatarAttributes::ClassType2,
 					);
 
 					let slot_type = AvatarUtils::read_attribute_as::<SlotType>(
 						&input_leader.1,
-						AvatarAttributes::ClassType1,
+						&AvatarAttributes::ClassType1,
 					);
 
 					let equipable_item_type = AvatarUtils::read_spec_byte_as::<EquipableItemType>(
 						&input_leader.1,
-						AvatarSpecBytes::SpecByte3,
+						&AvatarSpecBytes::SpecByte3,
 					);
 
 					let rarity_value = {
@@ -106,15 +103,15 @@ where
 						.generate_base_avatar_dna(hash_provider, 9)?;
 					let generated_equipable = AvatarBuilder::with_dna(season_id, dna)
 						.try_into_armor_and_component(
-							pet_type,
-							slot_type,
-							vec![equipable_item_type],
-							rarity_value,
-							(ColorType::None, ColorType::None),
-							ForceType::None,
+							&pet_type,
+							&slot_type,
+							&[equipable_item_type],
+							&rarity_value,
+							&(ColorType::None, ColorType::None),
+							&ForceType::None,
 							1,
 						)
-						.map_err(|_| Error::<T>::InvalidForgeComponents)?
+						.map_err(|_| Error::<T>::IncompatibleForgeComponents)?
 						.build();
 
 					generated_equipables.push(generated_equipable);
@@ -180,13 +177,13 @@ mod test {
 				]
 			);
 
-			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
-			let material_input_2 = create_random_material(&ALICE, pattern[1], 1);
-			let material_input_3 = create_random_material(&ALICE, pattern[2], 1);
-			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+			let material_input_1 = create_random_material(&ALICE, &pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, &pattern[1], 1);
+			let material_input_3 = create_random_material(&ALICE, &pattern[2], 1);
+			let material_input_4 = create_random_material(&ALICE, &pattern[3], 1);
 
 			let blueprint_input_1 =
-				create_random_blueprint(&ALICE, pet_type, slot_type, equip_type, pattern, 5);
+				create_random_blueprint(&ALICE, &pet_type, &slot_type, &equip_type, &pattern, 5);
 
 			let total_soul_points = blueprint_input_1.1.souls +
 				material_input_1.1.souls +
@@ -267,13 +264,13 @@ mod test {
 				]
 			);
 
-			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
-			let material_input_2 = create_random_material(&ALICE, pattern[1], 2);
-			let material_input_3 = create_random_material(&ALICE, pattern[2], 1);
-			let material_input_4 = create_random_material(&ALICE, pattern[3], 2);
+			let material_input_1 = create_random_material(&ALICE, &pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, &pattern[1], 2);
+			let material_input_3 = create_random_material(&ALICE, &pattern[2], 1);
+			let material_input_4 = create_random_material(&ALICE, &pattern[3], 2);
 
 			let blueprint_input_1 =
-				create_random_blueprint(&ALICE, pet_type, slot_type, equip_type, pattern, 5);
+				create_random_blueprint(&ALICE, &pet_type, &slot_type, &equip_type, &pattern, 5);
 
 			let total_soul_points = blueprint_input_1.1.souls +
 				material_input_1.1.souls +
@@ -371,19 +368,13 @@ mod test {
 				]
 			);
 
-			let material_input_1 = create_random_material(&ALICE, pattern[0], 10);
-			let material_input_2 = create_random_material(&ALICE, pattern[1], 10);
-			let material_input_3 = create_random_material(&ALICE, pattern[2], 10);
-			let material_input_4 = create_random_material(&ALICE, pattern[3], 10);
+			let material_input_1 = create_random_material(&ALICE, &pattern[0], 10);
+			let material_input_2 = create_random_material(&ALICE, &pattern[1], 10);
+			let material_input_3 = create_random_material(&ALICE, &pattern[2], 10);
+			let material_input_4 = create_random_material(&ALICE, &pattern[3], 10);
 
-			let blueprint_input_1 = create_random_blueprint(
-				&ALICE,
-				pet_type,
-				slot_type,
-				equip_type,
-				pattern.clone(),
-				5,
-			);
+			let blueprint_input_1 =
+				create_random_blueprint(&ALICE, &pet_type, &slot_type, &equip_type, &pattern, 5);
 
 			let total_soul_points = blueprint_input_1.1.souls +
 				material_input_1.1.souls +
@@ -481,19 +472,13 @@ mod test {
 				]
 			);
 
-			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
-			let material_input_2 = create_random_material(&ALICE, pattern[2], 1);
-			let material_input_3 = create_random_material(&ALICE, pattern[1], 1);
-			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+			let material_input_1 = create_random_material(&ALICE, &pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, &pattern[2], 1);
+			let material_input_3 = create_random_material(&ALICE, &pattern[1], 1);
+			let material_input_4 = create_random_material(&ALICE, &pattern[3], 1);
 
-			let blueprint_input_1 = create_random_blueprint(
-				&ALICE,
-				pet_type,
-				slot_type,
-				equip_type,
-				pattern.clone(),
-				5,
-			);
+			let blueprint_input_1 =
+				create_random_blueprint(&ALICE, &pet_type, &slot_type, &equip_type, &pattern, 5);
 
 			let total_soul_points = blueprint_input_1.1.souls +
 				material_input_1.1.souls +
@@ -580,14 +565,14 @@ mod test {
 				mutated
 			};
 
-			let material_input_1 = create_random_material(&ALICE, mutated_pattern[0], 1);
-			let material_input_2 = create_random_material(&ALICE, mutated_pattern[1], 1);
-			let material_input_3 = create_random_material(&ALICE, mutated_pattern[2], 1);
-			let material_input_4 = create_random_material(&ALICE, mutated_pattern[3], 1);
+			let material_input_1 = create_random_material(&ALICE, &mutated_pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, &mutated_pattern[1], 1);
+			let material_input_3 = create_random_material(&ALICE, &mutated_pattern[2], 1);
+			let material_input_4 = create_random_material(&ALICE, &mutated_pattern[3], 1);
 
 			// Here we use the original pattern
 			let blueprint_input_1 =
-				create_random_blueprint(&ALICE, pet_type, slot_type, equip_type, pattern, 5);
+				create_random_blueprint(&ALICE, &pet_type, &slot_type, &equip_type, &pattern, 5);
 
 			let total_soul_points = blueprint_input_1.1.souls +
 				material_input_1.1.souls +
@@ -666,13 +651,13 @@ mod test {
 				]
 			);
 
-			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
-			let material_input_2 = create_random_material(&ALICE, pattern[1], 1);
-			let material_input_3 = create_random_material(&ALICE, pattern[2], 1);
-			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+			let material_input_1 = create_random_material(&ALICE, &pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, &pattern[1], 1);
+			let material_input_3 = create_random_material(&ALICE, &pattern[2], 1);
+			let material_input_4 = create_random_material(&ALICE, &pattern[3], 1);
 
 			let blueprint_input_1 =
-				create_random_blueprint(&ALICE, pet_type, slot_type, equip_type, pattern, 5);
+				create_random_blueprint(&ALICE, &pet_type, &slot_type, &equip_type, &pattern, 5);
 
 			let total_soul_points = blueprint_input_1.1.souls +
 				material_input_1.1.souls +

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/equip.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/equip.rs
@@ -1,9 +1,6 @@
 use super::*;
 
-impl<'a, T> AvatarCombinator<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarCombinator<T> {
 	pub(super) fn equip_avatars(
 		input_leader: ForgeItem<T>,
 		input_sacrifices: Vec<ForgeItem<T>>,
@@ -26,16 +23,16 @@ where
 			new_souls += sacrifice.souls;
 
 			let slot_type =
-				AvatarUtils::read_attribute(sacrifice, AvatarAttributes::ClassType1) as usize - 1;
+				AvatarUtils::read_attribute(sacrifice, &AvatarAttributes::ClassType1) as usize - 1;
 
 			if are_slots_maxed && equipment_slots_state[slot_type] {
 				continue
 			}
 
 			let sacrifice_spec_byte_1 =
-				AvatarUtils::read_spec_byte(sacrifice, AvatarSpecBytes::SpecByte1);
+				AvatarUtils::read_spec_byte(sacrifice, &AvatarSpecBytes::SpecByte1);
 			let sacrifice_spec_byte_2 =
-				AvatarUtils::read_spec_byte(sacrifice, AvatarSpecBytes::SpecByte2);
+				AvatarUtils::read_spec_byte(sacrifice, &AvatarSpecBytes::SpecByte2);
 			let slot_type_mod = slot_type % 2;
 			let slot_index = ((slot_type - slot_type_mod) * 3) / 2;
 
@@ -74,7 +71,7 @@ mod test {
 	fn test_equip_success() {
 		ExtBuilder::default().build().execute_with(|| {
 			let leader =
-				create_random_pet(&ALICE, PetType::FoxishDude, 0x0F, [0; 16], [0; 11], 100);
+				create_random_pet(&ALICE, &PetType::FoxishDude, 0x0F, [0; 16], [0; 11], 100);
 
 			let armor_progress = vec![
 				EquipableItemType::ArmorBase,
@@ -82,7 +79,7 @@ mod test {
 				EquipableItemType::ArmorComponent2,
 			];
 
-			let sacrifice_hash_base: [[u8; 32]; 4] = [
+			let sacrifice_hash_base = [
 				[
 					0x80, 0x31, 0x6D, 0x62, 0xA2, 0x5B, 0xB9, 0x7F, 0x15, 0xEA, 0xAF, 0xE2, 0xB1,
 					0xAC, 0x32, 0x61, 0x39, 0x92, 0x97, 0xE3, 0x30, 0x9C, 0xB3, 0x42, 0xB4, 0xC6,
@@ -106,23 +103,23 @@ mod test {
 			];
 
 			let armor_slots = [SlotType::Head, SlotType::Breast, SlotType::ArmFront];
-
 			let pet_type = PetType::FoxishDude;
-			let rarity_type = RarityType::Legendary;
 			let force_type = ForceType::Astral;
 			let color_pair = (ColorType::ColorC, ColorType::ColorB);
 
-			let mut armor_sacrifices = (0..3)
-				.map(|i| {
+			let mut armor_sacrifices = sacrifice_hash_base
+				.into_iter()
+				.zip(armor_slots)
+				.map(|(hash, armor_slot)| {
 					create_random_armor_component(
-						sacrifice_hash_base[i],
+						hash,
 						&ALICE,
-						pet_type,
-						armor_slots[i],
-						rarity_type,
-						armor_progress.clone(),
-						color_pair,
-						force_type,
+						&pet_type,
+						&armor_slot,
+						&RarityType::Legendary,
+						&armor_progress,
+						&color_pair,
+						&force_type,
 						100,
 					)
 				})
@@ -131,11 +128,11 @@ mod test {
 			let weapon_sacrifice = create_random_weapon(
 				sacrifice_hash_base[3],
 				&ALICE,
-				pet_type,
-				SlotType::WeaponBack,
-				EquipableItemType::WeaponVersion2,
-				color_pair,
-				force_type,
+				&pet_type,
+				&SlotType::WeaponBack,
+				&EquipableItemType::WeaponVersion2,
+				&color_pair,
+				&force_type,
 				100,
 			);
 
@@ -178,11 +175,11 @@ mod test {
 				let weapon_sacrifice_2 = create_random_weapon(
 					weapon_2_dna,
 					&ALICE,
-					pet_type,
-					SlotType::WeaponFront,
-					EquipableItemType::WeaponVersion3,
-					color_pair,
-					force_type,
+					&pet_type,
+					&SlotType::WeaponFront,
+					&EquipableItemType::WeaponVersion3,
+					&color_pair,
+					&force_type,
 					100,
 				);
 
@@ -225,33 +222,31 @@ mod test {
 			];
 			let leader = create_random_pet(
 				&ALICE,
-				PetType::FoxishDude,
+				&PetType::FoxishDude,
 				0x0F,
 				leader_spec_bytes,
 				[0; 11],
 				100,
 			);
 
-			let armor_progress = vec![
-				EquipableItemType::ArmorBase,
-				EquipableItemType::ArmorComponent1,
-				EquipableItemType::ArmorComponent2,
-			];
 			let sacrifice_base_hash = [
 				0xFB, 0x0E, 0x54, 0x01, 0x1C, 0x36, 0xA8, 0xBA, 0xED, 0x77, 0x45, 0x2A, 0x45, 0xD7,
 				0xC8, 0xA1, 0x08, 0xE4, 0x97, 0x29, 0x44, 0x1F, 0xBA, 0xE7, 0x22, 0x2E, 0x90, 0x20,
 				0x71, 0xFD, 0xA3, 0x68,
 			];
-			let color_pair = (ColorType::ColorC, ColorType::ColorB);
 			let sacrifice = create_random_armor_component(
 				sacrifice_base_hash,
 				&ALICE,
-				PetType::FoxishDude,
-				SlotType::ArmFront,
-				RarityType::Legendary,
-				armor_progress,
-				color_pair,
-				ForceType::Astral,
+				&PetType::FoxishDude,
+				&SlotType::ArmFront,
+				&RarityType::Legendary,
+				&[
+					EquipableItemType::ArmorBase,
+					EquipableItemType::ArmorComponent1,
+					EquipableItemType::ArmorComponent2,
+				],
+				&(ColorType::ColorC, ColorType::ColorB),
+				&ForceType::Astral,
 				100,
 			);
 

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/equip.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/equip.rs
@@ -1,0 +1,283 @@
+use super::*;
+
+impl<'a, T> AvatarCombinator<'a, T>
+where
+	T: Config,
+{
+	pub(super) fn equip_avatars(
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		let (leader_id, mut leader) = input_leader;
+
+		let mut new_souls = SoulCount::MIN;
+
+		let mut leader_spec_bytes = AvatarUtils::read_full_spec_bytes(&leader);
+
+		let equipment_slots_state = AvatarUtils::spec_byte_split_ten(&leader)
+			.into_iter()
+			.map(|slot| slot.iter().sum::<u8>() == 0)
+			.collect::<Vec<_>>();
+
+		let are_slots_maxed =
+			equipment_slots_state.iter().filter(|slot| !**slot).count() >= MAX_EQUIPPED_SLOTS;
+
+		for (_, sacrifice) in input_sacrifices.iter() {
+			new_souls += sacrifice.souls;
+
+			let slot_type =
+				AvatarUtils::read_attribute(sacrifice, AvatarAttributes::ClassType1) as usize - 1;
+
+			if are_slots_maxed && equipment_slots_state[slot_type] {
+				continue
+			}
+
+			let sacrifice_spec_byte_1 =
+				AvatarUtils::read_spec_byte(sacrifice, AvatarSpecBytes::SpecByte1);
+			let sacrifice_spec_byte_2 =
+				AvatarUtils::read_spec_byte(sacrifice, AvatarSpecBytes::SpecByte2);
+			let slot_type_mod = slot_type % 2;
+			let slot_index = ((slot_type - slot_type_mod) * 3) / 2;
+
+			if slot_type_mod == 0 {
+				leader_spec_bytes[slot_index] = sacrifice_spec_byte_1;
+				leader_spec_bytes[slot_index + 1] &= 0x0F;
+				leader_spec_bytes[slot_index + 1] |= sacrifice_spec_byte_2 << 4;
+			} else {
+				leader_spec_bytes[slot_index + 1] &= 0xF0;
+				leader_spec_bytes[slot_index + 1] |= sacrifice_spec_byte_1 >> 4;
+				leader_spec_bytes[slot_index + 2] &= 0x00;
+				leader_spec_bytes[slot_index + 2] |= sacrifice_spec_byte_1 << 4;
+				leader_spec_bytes[slot_index + 2] |= sacrifice_spec_byte_2;
+			}
+		}
+
+		AvatarUtils::write_full_spec_bytes(&mut leader, leader_spec_bytes);
+
+		leader.souls += new_souls;
+
+		let output_vec: Vec<ForgeOutput<T>> = input_sacrifices
+			.into_iter()
+			.map(|(sacrifice_id, _)| ForgeOutput::Consumed(sacrifice_id))
+			.collect();
+
+		Ok((LeaderForgeOutput::Forged((leader_id, leader), 0), output_vec))
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::*;
+
+	#[test]
+	fn test_equip_success() {
+		ExtBuilder::default().build().execute_with(|| {
+			let leader =
+				create_random_pet(&ALICE, PetType::FoxishDude, 0x0F, [0; 16], [0; 11], 100);
+
+			let armor_progress = vec![
+				EquipableItemType::ArmorBase,
+				EquipableItemType::ArmorComponent1,
+				EquipableItemType::ArmorComponent2,
+			];
+
+			let sacrifice_hash_base: [[u8; 32]; 4] = [
+				[
+					0x80, 0x31, 0x6D, 0x62, 0xA2, 0x5B, 0xB9, 0x7F, 0x15, 0xEA, 0xAF, 0xE2, 0xB1,
+					0xAC, 0x32, 0x61, 0x39, 0x92, 0x97, 0xE3, 0x30, 0x9C, 0xB3, 0x42, 0xB4, 0xC6,
+					0xAB, 0xE7, 0x37, 0x71, 0xB8, 0x92,
+				],
+				[
+					0x30, 0x19, 0x6D, 0xFF, 0x7A, 0x27, 0x97, 0x0C, 0xF2, 0x5E, 0xFB, 0xD8, 0x44,
+					0x7C, 0xCF, 0x60, 0x68, 0x58, 0x57, 0x02, 0xB5, 0x56, 0x5E, 0x8A, 0xBD, 0x7C,
+					0x07, 0xEE, 0x12, 0xB0, 0xAF, 0x7F,
+				],
+				[
+					0xF4, 0xAA, 0x26, 0xC4, 0xE4, 0xC2, 0x12, 0xED, 0x41, 0x55, 0xC0, 0x58, 0xE6,
+					0xB2, 0x1A, 0xB4, 0x74, 0x40, 0x41, 0xA6, 0x4E, 0xA9, 0x65, 0x22, 0x83, 0x57,
+					0x3E, 0xCE, 0x56, 0x6E, 0xF0, 0xF2,
+				],
+				[
+					0xD6, 0x0D, 0xB8, 0x30, 0x11, 0x55, 0x07, 0x7D, 0x5E, 0x54, 0xFC, 0x6D, 0x26,
+					0x56, 0x4E, 0x2F, 0x99, 0xD2, 0x9E, 0x72, 0xDE, 0x28, 0xA2, 0xCB, 0x8B, 0xE8,
+					0xDC, 0x2E, 0xEB, 0x3F, 0x04, 0x19,
+				],
+			];
+
+			let armor_slots = [SlotType::Head, SlotType::Breast, SlotType::ArmFront];
+
+			let pet_type = PetType::FoxishDude;
+			let rarity_type = RarityType::Legendary;
+			let force_type = ForceType::Astral;
+			let color_pair = (ColorType::ColorC, ColorType::ColorB);
+
+			let mut armor_sacrifices = (0..3)
+				.map(|i| {
+					create_random_armor_component(
+						sacrifice_hash_base[i],
+						&ALICE,
+						pet_type,
+						armor_slots[i],
+						rarity_type,
+						armor_progress.clone(),
+						color_pair,
+						force_type,
+						100,
+					)
+				})
+				.collect::<Vec<_>>();
+
+			let weapon_sacrifice = create_random_weapon(
+				sacrifice_hash_base[3],
+				&ALICE,
+				pet_type,
+				SlotType::WeaponBack,
+				EquipableItemType::WeaponVersion2,
+				color_pair,
+				force_type,
+				100,
+			);
+
+			let total_soul_points = leader.1.souls +
+				armor_sacrifices.iter().map(|(_, avatar)| avatar.souls).sum::<SoulCount>() +
+				weapon_sacrifice.1.souls;
+			assert_eq!(total_soul_points, 500);
+
+			let expected_dna = [
+				0x11, 0x02, 0x05, 0x01, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00,
+			];
+			assert_eq!(leader.1.dna.as_slice(), &expected_dna);
+
+			armor_sacrifices.push(weapon_sacrifice);
+
+			let (leader_output, sacrifice_output) =
+				AvatarCombinator::<Test>::equip_avatars(leader, armor_sacrifices)
+					.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 0);
+
+			if let LeaderForgeOutput::Forged((avatar_id, avatar), _) = leader_output {
+				let expected_dna = [
+					0x11, 0x02, 0x05, 0x01, 0x0F, 0x97, 0x59, 0x75, 0x97, 0x50, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x92, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				];
+				assert_eq!(avatar.dna.as_slice(), &expected_dna);
+
+				let weapon_2_dna = [
+					0xC3, 0x06, 0x8D, 0x1D, 0x8D, 0xFB, 0x1C, 0xE6, 0x38, 0x23, 0x8F, 0x98, 0x9B,
+					0xC2, 0x26, 0x35, 0x6B, 0x49, 0xF2, 0x86, 0x4F, 0x31, 0x4F, 0xF8, 0xBE, 0xD4,
+					0xF4, 0x42, 0x11, 0xFD, 0x3F, 0x26,
+				];
+
+				let weapon_sacrifice_2 = create_random_weapon(
+					weapon_2_dna,
+					&ALICE,
+					pet_type,
+					SlotType::WeaponFront,
+					EquipableItemType::WeaponVersion3,
+					color_pair,
+					force_type,
+					100,
+				);
+
+				let (leader_output_2, sacrifice_output_2) =
+					AvatarCombinator::<Test>::equip_avatars(
+						(avatar_id, avatar),
+						vec![weapon_sacrifice_2],
+					)
+					.expect("Should succeed in forging");
+
+				assert_eq!(sacrifice_output_2.len(), 1);
+				assert_eq!(
+					sacrifice_output_2.iter().filter(|output| is_consumed(output)).count(),
+					1
+				);
+				assert_eq!(sacrifice_output_2.iter().filter(|output| is_forged(output)).count(), 0);
+
+				if let LeaderForgeOutput::Forged((_avatar_id, avatar), _) = leader_output_2 {
+					let expected_dna_2 = [
+						0x11, 0x02, 0x05, 0x01, 0x0F, 0x97, 0x59, 0x75, 0x97, 0x50, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x09, 0x45, 0x92, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					];
+					assert_eq!(avatar.dna.as_slice(), &expected_dna_2);
+				} else {
+					panic!("LeaderForgeOutput for second forge should have been Forged!")
+				}
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_equip_failure() {
+		ExtBuilder::default().build().execute_with(|| {
+			let leader_spec_bytes = [
+				0x97, 0x59, 0x75, 0x97, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x75, 0x97, 0x50,
+				0x00, 0x00,
+			];
+			let leader = create_random_pet(
+				&ALICE,
+				PetType::FoxishDude,
+				0x0F,
+				leader_spec_bytes,
+				[0; 11],
+				100,
+			);
+
+			let armor_progress = vec![
+				EquipableItemType::ArmorBase,
+				EquipableItemType::ArmorComponent1,
+				EquipableItemType::ArmorComponent2,
+			];
+			let sacrifice_base_hash = [
+				0xFB, 0x0E, 0x54, 0x01, 0x1C, 0x36, 0xA8, 0xBA, 0xED, 0x77, 0x45, 0x2A, 0x45, 0xD7,
+				0xC8, 0xA1, 0x08, 0xE4, 0x97, 0x29, 0x44, 0x1F, 0xBA, 0xE7, 0x22, 0x2E, 0x90, 0x20,
+				0x71, 0xFD, 0xA3, 0x68,
+			];
+			let color_pair = (ColorType::ColorC, ColorType::ColorB);
+			let sacrifice = create_random_armor_component(
+				sacrifice_base_hash,
+				&ALICE,
+				PetType::FoxishDude,
+				SlotType::ArmFront,
+				RarityType::Legendary,
+				armor_progress,
+				color_pair,
+				ForceType::Astral,
+				100,
+			);
+
+			let total_soul_points = leader.1.souls + sacrifice.1.souls;
+			assert_eq!(total_soul_points, 200);
+
+			let (leader_output, sacrifice_output) =
+				AvatarCombinator::<Test>::equip_avatars(leader, vec![sacrifice])
+					.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 1);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 1);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 0);
+
+			if let LeaderForgeOutput::Forged((_, avatar), _) = leader_output {
+				assert_eq!(avatar.souls, 200);
+
+				let expected_dna = [
+					0x11, 0x02, 0x05, 0x01, 0x0F, 0x97, 0x59, 0x75, 0x97, 0x50, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x09, 0x75, 0x97, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				];
+				assert_eq!(avatar.dna.as_slice(), expected_dna);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/feed.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/feed.rs
@@ -1,0 +1,75 @@
+use super::*;
+
+impl<'a, T> AvatarCombinator<'a, T>
+where
+	T: Config,
+{
+	pub(super) fn feed_avatars(
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		match input_sacrifices.len() {
+			0 => Ok((LeaderForgeOutput::Forged(input_leader, 0), Vec::with_capacity(0))),
+			sacrifice_count => {
+				let (sacrifice_souls, other_output) = input_sacrifices.into_iter().fold(
+					(0, Vec::with_capacity(sacrifice_count)),
+					|(souls, mut items), item| {
+						items.push(ForgeOutput::Consumed(item.0));
+						(souls + item.1.souls, items)
+					},
+				);
+
+				let (leader_id, mut leader) = input_leader;
+				leader.souls += sacrifice_souls;
+
+				Ok((LeaderForgeOutput::Forged((leader_id, leader), 0), other_output))
+			},
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::*;
+
+	#[test]
+	fn test_feed() {
+		ExtBuilder::default().build().execute_with(|| {
+			let leader_progress_array =
+				[0x53, 0x54, 0x51, 0x52, 0x55, 0x55, 0x54, 0x51, 0x53, 0x55, 0x53];
+			let leader_spec_bytes = [
+				0x97, 0x59, 0x75, 0x97, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x75, 0x97, 0x50,
+				0x00, 0x00,
+			];
+
+			let leader = create_random_pet(
+				&ALICE,
+				PetType::BigHybrid,
+				0b0001_1001,
+				leader_spec_bytes,
+				leader_progress_array,
+				1000,
+			);
+			let sacrifice_1 =
+				create_random_egg(None, &ALICE, RarityType::Epic, 0b0000_1111, 100, [0x00; 11]);
+			let sacrifice_2 =
+				create_random_egg(None, &ALICE, RarityType::Epic, 0b0000_1111, 100, [0x00; 11]);
+
+			let total_soul_points = leader.1.souls + sacrifice_1.1.souls + sacrifice_2.1.souls;
+
+			let (leader_output, sacrifice_output) =
+				AvatarCombinator::<Test>::feed_avatars(leader, vec![sacrifice_1, sacrifice_2])
+					.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 2);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				assert_eq!(leader_avatar.souls, total_soul_points);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/feed.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/feed.rs
@@ -1,9 +1,6 @@
 use super::*;
 
-impl<'a, T> AvatarCombinator<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarCombinator<T> {
 	pub(super) fn feed_avatars(
 		input_leader: ForgeItem<T>,
 		input_sacrifices: Vec<ForgeItem<T>>,
@@ -45,16 +42,16 @@ mod test {
 
 			let leader = create_random_pet(
 				&ALICE,
-				PetType::BigHybrid,
+				&PetType::BigHybrid,
 				0b0001_1001,
 				leader_spec_bytes,
 				leader_progress_array,
 				1000,
 			);
 			let sacrifice_1 =
-				create_random_egg(None, &ALICE, RarityType::Epic, 0b0000_1111, 100, [0x00; 11]);
+				create_random_egg(None, &ALICE, &RarityType::Epic, 0b0000_1111, 100, [0x00; 11]);
 			let sacrifice_2 =
-				create_random_egg(None, &ALICE, RarityType::Epic, 0b0000_1111, 100, [0x00; 11]);
+				create_random_egg(None, &ALICE, &RarityType::Epic, 0b0000_1111, 100, [0x00; 11]);
 
 			let total_soul_points = leader.1.souls + sacrifice_1.1.souls + sacrifice_2.1.souls;
 

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/glimmer.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/glimmer.rs
@@ -1,9 +1,6 @@
 use super::*;
 
-impl<'a, T> AvatarCombinator<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarCombinator<T> {
 	pub(super) fn glimmer_avatars(
 		input_leader: ForgeItem<T>,
 		input_sacrifices: Vec<ForgeItem<T>>,
@@ -26,9 +23,9 @@ where
 				continue
 			}
 
-			let leader_quantity = AvatarUtils::read_attribute(&leader, AvatarAttributes::Quantity);
+			let leader_quantity = AvatarUtils::read_attribute(&leader, &AvatarAttributes::Quantity);
 			let sacrifice_quantity =
-				AvatarUtils::read_attribute(&sacrifice, AvatarAttributes::Quantity);
+				AvatarUtils::read_attribute(&sacrifice, &AvatarAttributes::Quantity);
 
 			if leader_quantity < GLIMMER_FORGE_GLIMMER_USE ||
 				sacrifice_quantity < GLIMMER_FORGE_MATERIAL_USE
@@ -67,7 +64,7 @@ where
 				if rand_1 == rand_2 &&
 					AvatarUtils::high_nibble_of(rand_1) == AvatarUtils::low_nibble_of(rand_2)
 				{
-					gen_avatar = gen_avatar.into_egg(RarityType::Rare, 0x00, soul_points, None);
+					gen_avatar = gen_avatar.into_egg(&RarityType::Rare, 0x00, soul_points, None);
 				} else if rand_1 ==
 					(AvatarUtils::high_nibble_of(rand_1) + AvatarUtils::low_nibble_of(rand_2))
 				{
@@ -83,10 +80,10 @@ where
 						ColorType::from_byte(rand_2 % (color_types + 1)),
 						ColorType::from_byte(rand_3 % (color_types + 1)),
 					);
-					gen_avatar = gen_avatar.into_color_spark(color_pair, soul_points, None);
+					gen_avatar = gen_avatar.into_color_spark(&color_pair, soul_points, None);
 				} else {
 					let force_type = ForceType::from_byte((rand_2 % force_types) + 1);
-					gen_avatar = gen_avatar.into_glow_spark(force_type, soul_points, None);
+					gen_avatar = gen_avatar.into_glow_spark(&force_type, soul_points, None);
 				}
 			} else {
 				gen_avatar = gen_avatar.into_dust(soul_points);
@@ -121,9 +118,9 @@ mod test {
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
 			let leader = create_random_glimmer(&ALICE, 10);
-			let sacrifice = create_random_material(&ALICE, MaterialItemType::Polymers, 8);
+			let sacrifice = create_random_material(&ALICE, &MaterialItemType::Polymers, 8);
 
-			let expected_dna: [u8; 32] = [
+			let expected_dna = [
 				0x31, 0x00, 0x12, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00,
@@ -156,37 +153,37 @@ mod test {
 				assert_eq!(output_souls, total_soul_points);
 
 				assert_eq!(
-					AvatarUtils::read_attribute(&leader_avatar, AvatarAttributes::Quantity,),
+					AvatarUtils::read_attribute(&leader_avatar, &AvatarAttributes::Quantity),
 					9
 				);
 				assert_eq!(
 					AvatarUtils::read_attribute_as::<ItemType>(
 						&leader_avatar,
-						AvatarAttributes::ItemType,
+						&AvatarAttributes::ItemType,
 					),
 					ItemType::Essence
 				);
 				assert_eq!(
 					AvatarUtils::read_attribute_as::<EssenceItemType>(
 						&leader_avatar,
-						AvatarAttributes::ItemSubType,
+						&AvatarAttributes::ItemSubType,
 					),
 					EssenceItemType::Glimmer
 				);
 
 				if let ForgeOutput::Forged((_, avatar), _) = &sacrifice_output[0] {
-					assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 4);
+					assert_eq!(AvatarUtils::read_attribute(avatar, &AvatarAttributes::Quantity), 4);
 					assert_eq!(
 						AvatarUtils::read_attribute_as::<ItemType>(
 							avatar,
-							AvatarAttributes::ItemType,
+							&AvatarAttributes::ItemType,
 						),
 						ItemType::Material
 					);
 					assert_eq!(
 						AvatarUtils::read_attribute_as::<MaterialItemType>(
 							avatar,
-							AvatarAttributes::ItemSubType,
+							&AvatarAttributes::ItemSubType,
 						),
 						MaterialItemType::Polymers
 					);
@@ -195,23 +192,23 @@ mod test {
 				}
 
 				if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
-					assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 5);
+					assert_eq!(AvatarUtils::read_attribute(avatar, &AvatarAttributes::Quantity), 5);
 					assert_eq!(
 						AvatarUtils::read_attribute_as::<ItemType>(
 							avatar,
-							AvatarAttributes::ItemType,
+							&AvatarAttributes::ItemType,
 						),
 						ItemType::Special
 					);
 					assert_eq!(
 						AvatarUtils::read_attribute_as::<SpecialItemType>(
 							avatar,
-							AvatarAttributes::ItemSubType,
+							&AvatarAttributes::ItemSubType,
 						),
 						SpecialItemType::Dust
 					);
 
-					let expected_dna_head: [u8; 5] = [0x61, 0x00, 0x11, 0x05, 0x00];
+					let expected_dna_head = [0x61, 0x00, 0x11, 0x05, 0x00];
 					let avatar_dna_slice = &avatar.dna[0..5];
 
 					// We only need to check the 5 first bytes since the rest are not relevant for
@@ -237,10 +234,11 @@ mod test {
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
 			let leader = create_random_glimmer(&ALICE, 100);
-			let sacrifice_1 = create_random_material(&ALICE, MaterialItemType::Polymers, 20);
-			let sacrifice_2 = create_random_material(&ALICE, MaterialItemType::Superconductors, 20);
-			let sacrifice_3 = create_random_material(&ALICE, MaterialItemType::Ceramics, 20);
-			let sacrifice_4 = create_random_material(&ALICE, MaterialItemType::Metals, 20);
+			let sacrifice_1 = create_random_material(&ALICE, &MaterialItemType::Polymers, 20);
+			let sacrifice_2 =
+				create_random_material(&ALICE, &MaterialItemType::Superconductors, 20);
+			let sacrifice_3 = create_random_material(&ALICE, &MaterialItemType::Ceramics, 20);
+			let sacrifice_4 = create_random_material(&ALICE, &MaterialItemType::Metals, 20);
 
 			let total_soul_points =
 				leader.1.souls +
@@ -271,20 +269,20 @@ mod test {
 				assert_eq!(output_souls, total_soul_points);
 
 				assert_eq!(
-					AvatarUtils::read_attribute(&leader_avatar, AvatarAttributes::Quantity,),
+					AvatarUtils::read_attribute(&leader_avatar, &AvatarAttributes::Quantity),
 					96
 				);
 				assert_eq!(
 					AvatarUtils::read_attribute_as::<ItemType>(
 						&leader_avatar,
-						AvatarAttributes::ItemType,
+						&AvatarAttributes::ItemType,
 					),
 					ItemType::Essence
 				);
 				assert_eq!(
 					AvatarUtils::read_attribute_as::<EssenceItemType>(
 						&leader_avatar,
-						AvatarAttributes::ItemSubType,
+						&AvatarAttributes::ItemSubType,
 					),
 					EssenceItemType::Glimmer
 				);
@@ -299,20 +297,20 @@ mod test {
 				for (i, material) in material_set.into_iter().enumerate() {
 					if let ForgeOutput::Forged((_, avatar), _) = &sacrifice_output[i * 2] {
 						assert_eq!(
-							AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,),
+							AvatarUtils::read_attribute(avatar, &AvatarAttributes::Quantity),
 							16
 						);
 						assert_eq!(
 							AvatarUtils::read_attribute_as::<ItemType>(
 								avatar,
-								AvatarAttributes::ItemType,
+								&AvatarAttributes::ItemType,
 							),
 							ItemType::Material
 						);
 						assert_eq!(
 							AvatarUtils::read_attribute_as::<MaterialItemType>(
 								avatar,
-								AvatarAttributes::ItemSubType,
+								&AvatarAttributes::ItemSubType,
 							),
 							material
 						);
@@ -324,20 +322,20 @@ mod test {
 				for i in (1..8).step_by(2) {
 					if let ForgeOutput::Minted(avatar) = &sacrifice_output[i] {
 						assert_eq!(
-							AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,),
+							AvatarUtils::read_attribute(avatar, &AvatarAttributes::Quantity),
 							5
 						);
 						assert_eq!(
 							AvatarUtils::read_attribute_as::<ItemType>(
 								avatar,
-								AvatarAttributes::ItemType,
+								&AvatarAttributes::ItemType,
 							),
 							ItemType::Special
 						);
 						assert_eq!(
 							AvatarUtils::read_attribute_as::<SpecialItemType>(
 								avatar,
-								AvatarAttributes::ItemSubType,
+								&AvatarAttributes::ItemSubType,
 							),
 							SpecialItemType::Dust
 						);
@@ -362,7 +360,7 @@ mod test {
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
 			let leader = create_random_glimmer(&ALICE, 1);
-			let sacrifice = create_random_material(&ALICE, MaterialItemType::Polymers, 4);
+			let sacrifice = create_random_material(&ALICE, &MaterialItemType::Polymers, 4);
 
 			let total_soul_points = leader.1.souls + sacrifice.1.souls;
 
@@ -382,15 +380,15 @@ mod test {
 
 			if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
 				assert_eq!(avatar.souls, total_soul_points);
-				assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 5);
+				assert_eq!(AvatarUtils::read_attribute(avatar, &AvatarAttributes::Quantity), 5);
 				assert_eq!(
-					AvatarUtils::read_attribute_as::<ItemType>(avatar, AvatarAttributes::ItemType,),
+					AvatarUtils::read_attribute_as::<ItemType>(avatar, &AvatarAttributes::ItemType),
 					ItemType::Special
 				);
 				assert_eq!(
 					AvatarUtils::read_attribute_as::<SpecialItemType>(
 						avatar,
-						AvatarAttributes::ItemSubType,
+						&AvatarAttributes::ItemSubType,
 					),
 					SpecialItemType::Dust
 				);
@@ -411,7 +409,7 @@ mod test {
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
 			let leader = create_random_glimmer(&ALICE, 10);
-			let sacrifice = create_random_material(&ALICE, MaterialItemType::Polymers, 8);
+			let sacrifice = create_random_material(&ALICE, &MaterialItemType::Polymers, 8);
 
 			let total_soul_points = leader.1.souls + sacrifice.1.souls;
 
@@ -439,18 +437,18 @@ mod test {
 				assert_eq!(output_souls, total_soul_points);
 
 				if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
-					assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 1);
+					assert_eq!(AvatarUtils::read_attribute(avatar, &AvatarAttributes::Quantity), 1);
 					assert_eq!(
 						AvatarUtils::read_attribute_as::<ItemType>(
 							avatar,
-							AvatarAttributes::ItemType,
+							&AvatarAttributes::ItemType,
 						),
 						ItemType::Essence
 					);
 					assert_eq!(
 						AvatarUtils::read_attribute_as::<EssenceItemType>(
 							avatar,
-							AvatarAttributes::ItemSubType,
+							&AvatarAttributes::ItemSubType,
 						),
 						EssenceItemType::ColorSpark
 					);
@@ -474,7 +472,7 @@ mod test {
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
 			let leader = create_random_glimmer(&ALICE, 10);
-			let sacrifice = create_random_material(&ALICE, MaterialItemType::Polymers, 8);
+			let sacrifice = create_random_material(&ALICE, &MaterialItemType::Polymers, 8);
 
 			let total_soul_points = leader.1.souls + sacrifice.1.souls;
 
@@ -502,18 +500,18 @@ mod test {
 				assert_eq!(output_souls, total_soul_points);
 
 				if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
-					assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 1);
+					assert_eq!(AvatarUtils::read_attribute(avatar, &AvatarAttributes::Quantity), 1);
 					assert_eq!(
 						AvatarUtils::read_attribute_as::<ItemType>(
 							avatar,
-							AvatarAttributes::ItemType,
+							&AvatarAttributes::ItemType,
 						),
 						ItemType::Essence
 					);
 					assert_eq!(
 						AvatarUtils::read_attribute_as::<EssenceItemType>(
 							avatar,
-							AvatarAttributes::ItemSubType,
+							&AvatarAttributes::ItemSubType,
 						),
 						EssenceItemType::GlowSpark
 					);
@@ -537,7 +535,7 @@ mod test {
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
 			let leader = create_random_glimmer(&ALICE, 10);
-			let sacrifice = create_random_material(&ALICE, MaterialItemType::Polymers, 8);
+			let sacrifice = create_random_material(&ALICE, &MaterialItemType::Polymers, 8);
 
 			let total_soul_points = leader.1.souls + sacrifice.1.souls;
 
@@ -565,18 +563,18 @@ mod test {
 				assert_eq!(output_souls, total_soul_points);
 
 				if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
-					assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 1);
+					assert_eq!(AvatarUtils::read_attribute(avatar, &AvatarAttributes::Quantity), 1);
 					assert_eq!(
 						AvatarUtils::read_attribute_as::<ItemType>(
 							avatar,
-							AvatarAttributes::ItemType,
+							&AvatarAttributes::ItemType,
 						),
 						ItemType::Pet
 					);
 					assert_eq!(
 						AvatarUtils::read_attribute_as::<PetItemType>(
 							avatar,
-							AvatarAttributes::ItemSubType,
+							&AvatarAttributes::ItemSubType,
 						),
 						PetItemType::Egg
 					);
@@ -600,7 +598,7 @@ mod test {
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
 			let leader = create_random_glimmer(&ALICE, 10);
-			let sacrifice = create_random_material(&ALICE, MaterialItemType::Polymers, 8);
+			let sacrifice = create_random_material(&ALICE, &MaterialItemType::Polymers, 8);
 
 			let total_soul_points = leader.1.souls + sacrifice.1.souls;
 
@@ -628,18 +626,18 @@ mod test {
 				assert_eq!(output_souls, total_soul_points);
 
 				if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
-					assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 1);
+					assert_eq!(AvatarUtils::read_attribute(avatar, &AvatarAttributes::Quantity), 1);
 					assert_eq!(
 						AvatarUtils::read_attribute_as::<ItemType>(
 							avatar,
-							AvatarAttributes::ItemType,
+							&AvatarAttributes::ItemType,
 						),
 						ItemType::Special
 					);
 					assert_eq!(
 						AvatarUtils::read_attribute_as::<SpecialItemType>(
 							avatar,
-							AvatarAttributes::ItemSubType,
+							&AvatarAttributes::ItemSubType,
 						),
 						SpecialItemType::Unidentified
 					);
@@ -662,15 +660,15 @@ mod test {
 			];
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
-			let mut probability_array: [u32; 6] = [0; 6];
+			let mut probability_array = [0; 6];
 
 			for i in 0..10_000 {
 				let leader = create_random_glimmer(&ALICE, 20);
-				let sacrifice_1 = create_random_material(&ALICE, MaterialItemType::Polymers, 20);
+				let sacrifice_1 = create_random_material(&ALICE, &MaterialItemType::Polymers, 20);
 				let sacrifice_2 =
-					create_random_material(&ALICE, MaterialItemType::Superconductors, 20);
-				let sacrifice_3 = create_random_material(&ALICE, MaterialItemType::Ceramics, 20);
-				let sacrifice_4 = create_random_material(&ALICE, MaterialItemType::Metals, 20);
+					create_random_material(&ALICE, &MaterialItemType::Superconductors, 20);
+				let sacrifice_3 = create_random_material(&ALICE, &MaterialItemType::Ceramics, 20);
+				let sacrifice_4 = create_random_material(&ALICE, &MaterialItemType::Metals, 20);
 
 				let (_leader_output, sacrifice_output) = AvatarCombinator::<Test>::glimmer_avatars(
 					leader,
@@ -684,13 +682,13 @@ mod test {
 				if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
 					match AvatarUtils::read_attribute_as::<ItemType>(
 						avatar,
-						AvatarAttributes::ItemType,
+						&AvatarAttributes::ItemType,
 					) {
 						ItemType::Pet => probability_array[1] += 1,
 						ItemType::Essence =>
 							match AvatarUtils::read_attribute_as::<EssenceItemType>(
 								avatar,
-								AvatarAttributes::ItemSubType,
+								&AvatarAttributes::ItemSubType,
 							) {
 								EssenceItemType::ColorSpark => probability_array[2] += 1,
 								EssenceItemType::GlowSpark => probability_array[3] += 1,
@@ -699,7 +697,7 @@ mod test {
 						ItemType::Special =>
 							match AvatarUtils::read_attribute_as::<SpecialItemType>(
 								avatar,
-								AvatarAttributes::ItemSubType,
+								&AvatarAttributes::ItemSubType,
 							) {
 								SpecialItemType::Dust => probability_array[4] += 1,
 								SpecialItemType::Unidentified => probability_array[5] += 1,

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/glimmer.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/glimmer.rs
@@ -1,0 +1,723 @@
+use super::*;
+
+impl<'a, T> AvatarCombinator<'a, T>
+where
+	T: Config,
+{
+	pub(super) fn glimmer_avatars(
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+		season_id: SeasonId,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		let color_types = ColorType::range().len() as u8;
+		let force_types = ForceType::range().len() as u8;
+
+		let (leader_id, mut leader) = input_leader;
+		let mut leader_consumed = false;
+
+		let mut other_output = Vec::new();
+
+		for (i, (sacrifice_id, mut sacrifice)) in input_sacrifices.into_iter().enumerate() {
+			if leader_consumed {
+				// If we consumed the leader in a previous step, we collect all
+				// sacrifices and skip all future loops
+				other_output.push(ForgeOutput::Forged((sacrifice_id, sacrifice), 0));
+				continue
+			}
+
+			let leader_quantity = AvatarUtils::read_attribute(&leader, AvatarAttributes::Quantity);
+			let sacrifice_quantity =
+				AvatarUtils::read_attribute(&sacrifice, AvatarAttributes::Quantity);
+
+			if leader_quantity < GLIMMER_FORGE_GLIMMER_USE ||
+				sacrifice_quantity < GLIMMER_FORGE_MATERIAL_USE
+			{
+				// If we skip the loop then the sacrifice remains unused
+				other_output.push(ForgeOutput::Forged((sacrifice_id, sacrifice), 0));
+				continue
+			}
+
+			let (_, consumed, out_leader_souls) =
+				AvatarUtils::use_avatar(&mut leader, GLIMMER_FORGE_GLIMMER_USE);
+			leader_consumed = consumed;
+			let (_, consumed_sacrifice, out_sacrifice_souls) =
+				AvatarUtils::use_avatar(&mut sacrifice, GLIMMER_FORGE_MATERIAL_USE);
+
+			other_output.push(if consumed_sacrifice {
+				ForgeOutput::Consumed(sacrifice_id)
+			} else {
+				ForgeOutput::Forged((sacrifice_id, sacrifice), 0)
+			});
+
+			let soul_points = out_leader_souls + out_sacrifice_souls;
+
+			let index = i * 4;
+			let rand_0 = hash_provider.hash[index];
+			let rand_1 = hash_provider.hash[index + 1];
+			let rand_2 = hash_provider.hash[index + 2];
+			let rand_3 = hash_provider.hash[index + 3];
+
+			let dna =
+				AvatarMinterV2::<T>(PhantomData).generate_base_avatar_dna(hash_provider, index)?;
+
+			let mut gen_avatar = AvatarBuilder::with_dna(season_id, dna);
+
+			if rand_0 as u32 * SCALING_FACTOR_PERC < STACK_PROB_PERC * MAX_BYTE {
+				if rand_1 == rand_2 &&
+					AvatarUtils::high_nibble_of(rand_1) == AvatarUtils::low_nibble_of(rand_2)
+				{
+					gen_avatar = gen_avatar.into_egg(RarityType::Rare, 0x00, soul_points, None);
+				} else if rand_1 ==
+					(AvatarUtils::high_nibble_of(rand_1) + AvatarUtils::low_nibble_of(rand_2))
+				{
+					let color_pair = (
+						ColorType::from_byte(rand_1 % (color_types + 1)),
+						ColorType::from_byte(rand_2 % (color_types + 1)),
+					);
+					let force_type = ForceType::from_byte((rand_3 % force_types) + 1);
+
+					gen_avatar = gen_avatar.into_unidentified(color_pair, force_type, soul_points);
+				} else if rand_1 as u32 * SCALING_FACTOR_PERC < COLOR_GLOW_SPARK * MAX_BYTE {
+					let color_pair = (
+						ColorType::from_byte(rand_2 % (color_types + 1)),
+						ColorType::from_byte(rand_3 % (color_types + 1)),
+					);
+					gen_avatar = gen_avatar.into_color_spark(color_pair, soul_points, None);
+				} else {
+					let force_type = ForceType::from_byte((rand_2 % force_types) + 1);
+					gen_avatar = gen_avatar.into_glow_spark(force_type, soul_points, None);
+				}
+			} else {
+				gen_avatar = gen_avatar.into_dust(soul_points);
+			}
+
+			other_output.push(ForgeOutput::Minted(gen_avatar.build()));
+		}
+
+		let leader_output = if leader_consumed {
+			LeaderForgeOutput::Consumed(leader_id)
+		} else {
+			LeaderForgeOutput::Forged((leader_id, leader), 0)
+		};
+
+		Ok((leader_output, other_output))
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::*;
+
+	#[test]
+	fn test_glimmer_simple() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x32, 0x5e, 0x2e, 0xd2, 0xe0, 0x39, 0x8a, 0x1c, 0x4f, 0x54, 0x23, 0xe4, 0x19, 0x51,
+				0x4a, 0xc5, 0xa8, 0x29, 0x49, 0x5b, 0x54, 0x21, 0x72, 0x94, 0xfd, 0xcf, 0x78, 0xc9,
+				0xde, 0x0a, 0xaf, 0x2d,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let leader = create_random_glimmer(&ALICE, 10);
+			let sacrifice = create_random_material(&ALICE, MaterialItemType::Polymers, 8);
+
+			let expected_dna: [u8; 32] = [
+				0x31, 0x00, 0x12, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00,
+			];
+			assert_eq!(leader.1.dna.as_slice(), &expected_dna);
+
+			let total_soul_points = leader.1.souls + sacrifice.1.souls;
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::glimmer_avatars(
+				leader,
+				vec![sacrifice],
+				0,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 1);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				let output_souls = sacrifice_output
+					.iter()
+					.map(|sacrifice| match sacrifice {
+						ForgeOutput::Forged((_, avatar), _) => avatar.souls,
+						ForgeOutput::Minted(avatar) => avatar.souls,
+						_ => 0,
+					})
+					.sum::<SoulCount>() + leader_avatar.souls;
+				assert_eq!(output_souls, total_soul_points);
+
+				assert_eq!(
+					AvatarUtils::read_attribute(&leader_avatar, AvatarAttributes::Quantity,),
+					9
+				);
+				assert_eq!(
+					AvatarUtils::read_attribute_as::<ItemType>(
+						&leader_avatar,
+						AvatarAttributes::ItemType,
+					),
+					ItemType::Essence
+				);
+				assert_eq!(
+					AvatarUtils::read_attribute_as::<EssenceItemType>(
+						&leader_avatar,
+						AvatarAttributes::ItemSubType,
+					),
+					EssenceItemType::Glimmer
+				);
+
+				if let ForgeOutput::Forged((_, avatar), _) = &sacrifice_output[0] {
+					assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 4);
+					assert_eq!(
+						AvatarUtils::read_attribute_as::<ItemType>(
+							avatar,
+							AvatarAttributes::ItemType,
+						),
+						ItemType::Material
+					);
+					assert_eq!(
+						AvatarUtils::read_attribute_as::<MaterialItemType>(
+							avatar,
+							AvatarAttributes::ItemSubType,
+						),
+						MaterialItemType::Polymers
+					);
+				} else {
+					panic!("ForgeOutput for the first output should have been Forged!")
+				}
+
+				if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
+					assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 5);
+					assert_eq!(
+						AvatarUtils::read_attribute_as::<ItemType>(
+							avatar,
+							AvatarAttributes::ItemType,
+						),
+						ItemType::Special
+					);
+					assert_eq!(
+						AvatarUtils::read_attribute_as::<SpecialItemType>(
+							avatar,
+							AvatarAttributes::ItemSubType,
+						),
+						SpecialItemType::Dust
+					);
+
+					let expected_dna_head: [u8; 5] = [0x61, 0x00, 0x11, 0x05, 0x00];
+					let avatar_dna_slice = &avatar.dna[0..5];
+
+					// We only need to check the 5 first bytes since the rest are not relevant for
+					// Dust avatars
+					assert_eq!(avatar_dna_slice, &expected_dna_head);
+				} else {
+					panic!("ForgeOutput for the second output should have been Minted!")
+				}
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_glimmer_multiple() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x28, 0xD2, 0x1C, 0xCA, 0xEE, 0x3F, 0x80, 0xD9, 0x83, 0x21, 0x5D, 0xF9, 0xAC, 0x5E,
+				0x29, 0x74, 0x6A, 0xD9, 0x6C, 0xB0, 0x20, 0x16, 0xB5, 0xAD, 0xEA, 0x86, 0xFD, 0xE0,
+				0xCC, 0xFD, 0x01, 0xB4,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let leader = create_random_glimmer(&ALICE, 100);
+			let sacrifice_1 = create_random_material(&ALICE, MaterialItemType::Polymers, 20);
+			let sacrifice_2 = create_random_material(&ALICE, MaterialItemType::Superconductors, 20);
+			let sacrifice_3 = create_random_material(&ALICE, MaterialItemType::Ceramics, 20);
+			let sacrifice_4 = create_random_material(&ALICE, MaterialItemType::Metals, 20);
+
+			let total_soul_points =
+				leader.1.souls +
+					sacrifice_1.1.souls + sacrifice_2.1.souls +
+					sacrifice_3.1.souls + sacrifice_4.1.souls;
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::glimmer_avatars(
+				leader,
+				vec![sacrifice_1, sacrifice_2, sacrifice_3, sacrifice_4],
+				0,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 8);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 4);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				let output_souls = sacrifice_output
+					.iter()
+					.map(|sacrifice| match sacrifice {
+						ForgeOutput::Forged((_, avatar), _) => avatar.souls,
+						ForgeOutput::Minted(avatar) => avatar.souls,
+						_ => 0,
+					})
+					.sum::<SoulCount>() + leader_avatar.souls;
+				assert_eq!(output_souls, total_soul_points);
+
+				assert_eq!(
+					AvatarUtils::read_attribute(&leader_avatar, AvatarAttributes::Quantity,),
+					96
+				);
+				assert_eq!(
+					AvatarUtils::read_attribute_as::<ItemType>(
+						&leader_avatar,
+						AvatarAttributes::ItemType,
+					),
+					ItemType::Essence
+				);
+				assert_eq!(
+					AvatarUtils::read_attribute_as::<EssenceItemType>(
+						&leader_avatar,
+						AvatarAttributes::ItemSubType,
+					),
+					EssenceItemType::Glimmer
+				);
+
+				let material_set = [
+					MaterialItemType::Polymers,
+					MaterialItemType::Superconductors,
+					MaterialItemType::Ceramics,
+					MaterialItemType::Metals,
+				];
+
+				for (i, material) in material_set.into_iter().enumerate() {
+					if let ForgeOutput::Forged((_, avatar), _) = &sacrifice_output[i * 2] {
+						assert_eq!(
+							AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,),
+							16
+						);
+						assert_eq!(
+							AvatarUtils::read_attribute_as::<ItemType>(
+								avatar,
+								AvatarAttributes::ItemType,
+							),
+							ItemType::Material
+						);
+						assert_eq!(
+							AvatarUtils::read_attribute_as::<MaterialItemType>(
+								avatar,
+								AvatarAttributes::ItemSubType,
+							),
+							material
+						);
+					} else {
+						panic!("ForgeOutput should have been Forged!")
+					}
+				}
+
+				for i in (1..8).step_by(2) {
+					if let ForgeOutput::Minted(avatar) = &sacrifice_output[i] {
+						assert_eq!(
+							AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,),
+							5
+						);
+						assert_eq!(
+							AvatarUtils::read_attribute_as::<ItemType>(
+								avatar,
+								AvatarAttributes::ItemType,
+							),
+							ItemType::Special
+						);
+						assert_eq!(
+							AvatarUtils::read_attribute_as::<SpecialItemType>(
+								avatar,
+								AvatarAttributes::ItemSubType,
+							),
+							SpecialItemType::Dust
+						);
+					} else {
+						panic!("ForgeOutput should have been Minted!")
+					}
+				}
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_empty_spark() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x28, 0xD2, 0x1C, 0xCA, 0xEE, 0x3F, 0x80, 0xD9, 0x83, 0x21, 0x5D, 0xF9, 0xAC, 0x5E,
+				0x29, 0x74, 0x6A, 0xD9, 0x6C, 0xB0, 0x20, 0x16, 0xB5, 0xAD, 0xEA, 0x86, 0xFD, 0xE0,
+				0xCC, 0xFD, 0x01, 0xB4,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let leader = create_random_glimmer(&ALICE, 1);
+			let sacrifice = create_random_material(&ALICE, MaterialItemType::Polymers, 4);
+
+			let total_soul_points = leader.1.souls + sacrifice.1.souls;
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::glimmer_avatars(
+				leader,
+				vec![sacrifice],
+				0,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 1);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			assert!(is_leader_consumed(&leader_output));
+
+			if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
+				assert_eq!(avatar.souls, total_soul_points);
+				assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 5);
+				assert_eq!(
+					AvatarUtils::read_attribute_as::<ItemType>(avatar, AvatarAttributes::ItemType,),
+					ItemType::Special
+				);
+				assert_eq!(
+					AvatarUtils::read_attribute_as::<SpecialItemType>(
+						avatar,
+						AvatarAttributes::ItemSubType,
+					),
+					SpecialItemType::Dust
+				);
+			} else {
+				panic!("ForgeOutput should have been Minted!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_color_spark() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x0A, 0xA9, 0x45, 0x37, 0x78, 0x1C, 0x04, 0x39, 0x8E, 0x1C, 0xDC, 0x95, 0xE2, 0x75,
+				0xD5, 0xE7, 0x69, 0xB1, 0x27, 0xDC, 0xA4, 0x9B, 0x6E, 0xF0, 0x95, 0x6B, 0x89, 0xC5,
+				0xA5, 0x2E, 0xDF, 0x03,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let leader = create_random_glimmer(&ALICE, 10);
+			let sacrifice = create_random_material(&ALICE, MaterialItemType::Polymers, 8);
+
+			let total_soul_points = leader.1.souls + sacrifice.1.souls;
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::glimmer_avatars(
+				leader,
+				vec![sacrifice],
+				0,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 1);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				let output_souls = sacrifice_output
+					.iter()
+					.map(|sacrifice| match sacrifice {
+						ForgeOutput::Forged((_, avatar), _) => avatar.souls,
+						ForgeOutput::Minted(avatar) => avatar.souls,
+						_ => 0,
+					})
+					.sum::<SoulCount>() + leader_avatar.souls;
+				assert_eq!(output_souls, total_soul_points);
+
+				if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
+					assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 1);
+					assert_eq!(
+						AvatarUtils::read_attribute_as::<ItemType>(
+							avatar,
+							AvatarAttributes::ItemType,
+						),
+						ItemType::Essence
+					);
+					assert_eq!(
+						AvatarUtils::read_attribute_as::<EssenceItemType>(
+							avatar,
+							AvatarAttributes::ItemSubType,
+						),
+						EssenceItemType::ColorSpark
+					);
+				} else {
+					panic!("ForgeOutput should have been Minted!")
+				}
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_glow_spark() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x04, 0xE5, 0x5C, 0xED, 0x33, 0x80, 0x1E, 0x2B, 0x10, 0xEB, 0xD1, 0xB0, 0xC4, 0x09,
+				0x78, 0x0D, 0xF4, 0x33, 0x92, 0x6D, 0x1F, 0x8B, 0x53, 0xE0, 0x1B, 0x23, 0x84, 0x7B,
+				0x4A, 0xF0, 0xEA, 0x94,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let leader = create_random_glimmer(&ALICE, 10);
+			let sacrifice = create_random_material(&ALICE, MaterialItemType::Polymers, 8);
+
+			let total_soul_points = leader.1.souls + sacrifice.1.souls;
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::glimmer_avatars(
+				leader,
+				vec![sacrifice],
+				0,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 1);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				let output_souls = sacrifice_output
+					.iter()
+					.map(|sacrifice| match sacrifice {
+						ForgeOutput::Forged((_, avatar), _) => avatar.souls,
+						ForgeOutput::Minted(avatar) => avatar.souls,
+						_ => 0,
+					})
+					.sum::<SoulCount>() + leader_avatar.souls;
+				assert_eq!(output_souls, total_soul_points);
+
+				if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
+					assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 1);
+					assert_eq!(
+						AvatarUtils::read_attribute_as::<ItemType>(
+							avatar,
+							AvatarAttributes::ItemType,
+						),
+						ItemType::Essence
+					);
+					assert_eq!(
+						AvatarUtils::read_attribute_as::<EssenceItemType>(
+							avatar,
+							AvatarAttributes::ItemSubType,
+						),
+						EssenceItemType::GlowSpark
+					);
+				} else {
+					panic!("ForgeOutput should have been Minted!")
+				}
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_egg() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x04, 0xBB, 0xBB, 0x1E, 0x64, 0x4E, 0xEA, 0x73, 0x97, 0x0D, 0x1D, 0x68, 0xEB, 0xB3,
+				0x15, 0x85, 0xE4, 0xA0, 0x33, 0x6A, 0x0D, 0xDC, 0x0D, 0x88, 0xFD, 0x97, 0x87, 0x0B,
+				0x23, 0x3B, 0x46, 0x1F,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let leader = create_random_glimmer(&ALICE, 10);
+			let sacrifice = create_random_material(&ALICE, MaterialItemType::Polymers, 8);
+
+			let total_soul_points = leader.1.souls + sacrifice.1.souls;
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::glimmer_avatars(
+				leader,
+				vec![sacrifice],
+				0,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 1);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				let output_souls = sacrifice_output
+					.iter()
+					.map(|sacrifice| match sacrifice {
+						ForgeOutput::Forged((_, avatar), _) => avatar.souls,
+						ForgeOutput::Minted(avatar) => avatar.souls,
+						_ => 0,
+					})
+					.sum::<SoulCount>() + leader_avatar.souls;
+				assert_eq!(output_souls, total_soul_points);
+
+				if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
+					assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 1);
+					assert_eq!(
+						AvatarUtils::read_attribute_as::<ItemType>(
+							avatar,
+							AvatarAttributes::ItemType,
+						),
+						ItemType::Pet
+					);
+					assert_eq!(
+						AvatarUtils::read_attribute_as::<PetItemType>(
+							avatar,
+							AvatarAttributes::ItemSubType,
+						),
+						PetItemType::Egg
+					);
+				} else {
+					panic!("ForgeOutput should have been Minted!")
+				}
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_unidentified() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x0C, 0x0B, 0x1B, 0x95, 0x61, 0x50, 0xAF, 0xFB, 0xCD, 0x39, 0x9F, 0x55, 0x88, 0x2D,
+				0xAB, 0x46, 0xDF, 0x40, 0x9A, 0x32, 0x27, 0x33, 0xBB, 0x80, 0x5F, 0xD6, 0x45, 0xA0,
+				0xFB, 0xE4, 0xE0, 0x79,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let leader = create_random_glimmer(&ALICE, 10);
+			let sacrifice = create_random_material(&ALICE, MaterialItemType::Polymers, 8);
+
+			let total_soul_points = leader.1.souls + sacrifice.1.souls;
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::glimmer_avatars(
+				leader,
+				vec![sacrifice],
+				0,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 1);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				let output_souls = sacrifice_output
+					.iter()
+					.map(|sacrifice| match sacrifice {
+						ForgeOutput::Forged((_, avatar), _) => avatar.souls,
+						ForgeOutput::Minted(avatar) => avatar.souls,
+						_ => 0,
+					})
+					.sum::<SoulCount>() + leader_avatar.souls;
+				assert_eq!(output_souls, total_soul_points);
+
+				if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
+					assert_eq!(AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity,), 1);
+					assert_eq!(
+						AvatarUtils::read_attribute_as::<ItemType>(
+							avatar,
+							AvatarAttributes::ItemType,
+						),
+						ItemType::Special
+					);
+					assert_eq!(
+						AvatarUtils::read_attribute_as::<SpecialItemType>(
+							avatar,
+							AvatarAttributes::ItemSubType,
+						),
+						SpecialItemType::Unidentified
+					);
+				} else {
+					panic!("ForgeOutput should have been Minted!")
+				}
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_glimmer_probability_test() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x28, 0xD2, 0x1C, 0xCA, 0xEE, 0x3F, 0x80, 0xD9, 0x83, 0x21, 0x5D, 0xF9, 0xAC, 0x5E,
+				0x29, 0x74, 0x6A, 0xD9, 0x6C, 0xB0, 0x20, 0x16, 0xB5, 0xAD, 0xEA, 0x86, 0xFD, 0xE0,
+				0xCC, 0xFD, 0x01, 0xB4,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let mut probability_array: [u32; 6] = [0; 6];
+
+			for i in 0..10_000 {
+				let leader = create_random_glimmer(&ALICE, 20);
+				let sacrifice_1 = create_random_material(&ALICE, MaterialItemType::Polymers, 20);
+				let sacrifice_2 =
+					create_random_material(&ALICE, MaterialItemType::Superconductors, 20);
+				let sacrifice_3 = create_random_material(&ALICE, MaterialItemType::Ceramics, 20);
+				let sacrifice_4 = create_random_material(&ALICE, MaterialItemType::Metals, 20);
+
+				let (_leader_output, sacrifice_output) = AvatarCombinator::<Test>::glimmer_avatars(
+					leader,
+					vec![sacrifice_1, sacrifice_2, sacrifice_3, sacrifice_4],
+					0,
+					&mut hash_provider,
+				)
+				.expect("Should succeed in forging");
+
+				probability_array[0] += 1;
+				if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
+					match AvatarUtils::read_attribute_as::<ItemType>(
+						avatar,
+						AvatarAttributes::ItemType,
+					) {
+						ItemType::Pet => probability_array[1] += 1,
+						ItemType::Essence =>
+							match AvatarUtils::read_attribute_as::<EssenceItemType>(
+								avatar,
+								AvatarAttributes::ItemSubType,
+							) {
+								EssenceItemType::ColorSpark => probability_array[2] += 1,
+								EssenceItemType::GlowSpark => probability_array[3] += 1,
+								_ => panic!("Generated avatar EssenceItemType not valid!"),
+							},
+						ItemType::Special =>
+							match AvatarUtils::read_attribute_as::<SpecialItemType>(
+								avatar,
+								AvatarAttributes::ItemSubType,
+							) {
+								SpecialItemType::Dust => probability_array[4] += 1,
+								SpecialItemType::Unidentified => probability_array[5] += 1,
+							},
+						_ => panic!("Generated avatar ItemType not valid!"),
+					}
+				} else {
+					panic!("ForgeOutput should have been Minted!")
+				}
+				hash_provider = HashProvider::new(&hash_provider.full_hash((i * 13) % 31));
+			}
+
+			assert_eq!(probability_array[0], 10_000);
+			assert_eq!(probability_array[1], 0);
+			assert_eq!(probability_array[2], 370);
+			assert_eq!(probability_array[3], 116);
+			assert_eq!(probability_array[4], 9_512);
+			assert_eq!(probability_array[5], 2);
+		});
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/mate.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/mate.rs
@@ -1,9 +1,6 @@
 use super::*;
 
-impl<'a, T> AvatarCombinator<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarCombinator<T> {
 	pub(super) fn mate_avatars(
 		input_leader: ForgeItem<T>,
 		input_sacrifices: Vec<ForgeItem<T>>,
@@ -58,13 +55,13 @@ where
 		let leader_pet_type =
 			AvatarUtils::enums_to_bits(&[AvatarUtils::read_attribute_as::<PetType>(
 				&leader,
-				AvatarAttributes::ClassType2,
+				&AvatarAttributes::ClassType2,
 			)]) as u8;
 
 		let leader_pet_variation =
-			AvatarUtils::read_attribute(&leader, AvatarAttributes::CustomType2);
+			AvatarUtils::read_attribute(&leader, &AvatarAttributes::CustomType2);
 		let partner_pet_variation =
-			AvatarUtils::read_attribute(&partner, AvatarAttributes::CustomType2);
+			AvatarUtils::read_attribute(&partner, &AvatarAttributes::CustomType2);
 
 		let legendary_egg_flag = ((hash_provider.hash[0] | hash_provider.hash[1]) == 0x7F) &&
 			((leader_pet_variation | partner_pet_variation) == 0x7F);
@@ -114,7 +111,7 @@ where
 				let dna =
 					AvatarMinterV2::<T>(PhantomData).generate_base_avatar_dna(hash_provider, 10)?;
 				let generated_egg = AvatarBuilder::with_dna(season_id, dna)
-					.into_egg(RarityType::Rare, pet_variation, soul_points, None)
+					.into_egg(&RarityType::Rare, pet_variation, soul_points, None)
 					.build();
 				Ok::<_, DispatchError>(ForgeOutput::Minted(generated_egg))
 			})
@@ -155,7 +152,7 @@ mod test {
 
 			let leader = create_random_pet(
 				&ALICE,
-				PetType::BigHybrid,
+				&PetType::BigHybrid,
 				0b0001_1001,
 				leader_spec_bytes,
 				leader_progress_array,
@@ -163,14 +160,14 @@ mod test {
 			);
 			let partner = create_random_pet(
 				&ALICE,
-				PetType::CrazyDude,
+				&PetType::CrazyDude,
 				0b0101_0011,
 				partner_spec_bytes,
 				partner_progress_array,
 				1000,
 			);
 
-			let expected_dna: [u8; 32] = [
+			let expected_dna = [
 				0x11, 0x05, 0x05, 0x01, 0x19, 0x97, 0x59, 0x75, 0x97, 0x50, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x09, 0x75, 0x97, 0x50, 0x00, 0x00, 0x53, 0x54, 0x51, 0x52, 0x55, 0x55, 0x54,
 				0x51, 0x53, 0x55, 0x53,
@@ -206,12 +203,12 @@ mod test {
 				assert_eq!(
 					AvatarUtils::read_attribute_as::<PetItemType>(
 						avatar,
-						AvatarAttributes::ItemSubType
+						&AvatarAttributes::ItemSubType
 					),
 					PetItemType::Egg
 				);
 				assert_eq!(
-					AvatarUtils::read_attribute(avatar, AvatarAttributes::CustomType2),
+					AvatarUtils::read_attribute(avatar, &AvatarAttributes::CustomType2),
 					0b0101_1010
 				);
 			} else {

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/mate.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/mate.rs
@@ -1,0 +1,222 @@
+use super::*;
+
+impl<'a, T> AvatarCombinator<'a, T>
+where
+	T: Config,
+{
+	pub(super) fn mate_avatars(
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+		season_id: SeasonId,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		if input_sacrifices.len() != 1 {
+			return Ok((
+				LeaderForgeOutput::Forged(input_leader, 0),
+				input_sacrifices
+					.into_iter()
+					.map(|input| ForgeOutput::Forged(input, 0))
+					.collect(),
+			))
+		}
+
+		let (leader_id, mut leader) = input_leader;
+		let (partner_id, mut partner) = {
+			let mut input_sacrifices = input_sacrifices;
+			input_sacrifices.pop().unwrap()
+		};
+
+		if AvatarUtils::spec_byte_split_ten_count(&leader) < MAX_EQUIPPED_SLOTS {
+			return Ok((
+				LeaderForgeOutput::Forged((leader_id, leader), 0),
+				vec![ForgeOutput::Forged((partner_id, partner), 0)],
+			))
+		}
+		if AvatarUtils::spec_byte_split_ten_count(&partner) < MAX_EQUIPPED_SLOTS {
+			leader.souls += partner.souls;
+
+			return Ok((
+				LeaderForgeOutput::Forged((leader_id, leader), 0),
+				vec![ForgeOutput::Consumed(partner_id)],
+			))
+		}
+
+		let (mirrors, _) = AvatarUtils::match_progress_arrays(
+			AvatarUtils::read_progress_array(&leader),
+			AvatarUtils::read_progress_array(&partner),
+		);
+
+		if mirrors < 4 {
+			leader.souls += partner.souls;
+
+			return Ok((
+				LeaderForgeOutput::Forged((leader_id, leader), 0),
+				vec![ForgeOutput::Consumed(partner_id)],
+			))
+		}
+
+		let leader_pet_type =
+			AvatarUtils::enums_to_bits(&[AvatarUtils::read_attribute_as::<PetType>(
+				&leader,
+				AvatarAttributes::ClassType2,
+			)]) as u8;
+
+		let leader_pet_variation =
+			AvatarUtils::read_attribute(&leader, AvatarAttributes::CustomType2);
+		let partner_pet_variation =
+			AvatarUtils::read_attribute(&partner, AvatarAttributes::CustomType2);
+
+		let legendary_egg_flag = ((hash_provider.hash[0] | hash_provider.hash[1]) == 0x7F) &&
+			((leader_pet_variation | partner_pet_variation) == 0x7F);
+
+		let random_pet_variation = hash_provider.hash[0] & hash_provider.hash[1] & 0b0111_1111;
+
+		let pet_variation = if !legendary_egg_flag {
+			(leader_pet_variation ^ partner_pet_variation) | leader_pet_type | random_pet_variation
+		} else {
+			0x00
+		};
+
+		let soul_points = (hash_provider.hash[0] | hash_provider.hash[1] & 0x7F) as SoulCount;
+
+		let (leader_output, other_output, any_survived) = if partner.souls > soul_points {
+			partner.souls -= soul_points;
+			(
+				LeaderForgeOutput::Forged((leader_id, leader), 0),
+				vec![ForgeOutput::Forged((partner_id, partner), 0)],
+				true,
+			)
+		} else if leader.souls + partner.souls > soul_points {
+			leader.souls -= soul_points - partner.souls;
+			(
+				LeaderForgeOutput::Forged((leader_id, leader), 0),
+				vec![ForgeOutput::Consumed(partner_id)],
+				true,
+			)
+		} else {
+			let generated_dust = {
+				let dna =
+					AvatarMinterV2::<T>(PhantomData).generate_base_avatar_dna(hash_provider, 0)?;
+
+				AvatarBuilder::with_dna(season_id, dna)
+					.into_dust(leader.souls + partner.souls)
+					.build()
+			};
+			(
+				LeaderForgeOutput::Consumed(leader_id),
+				vec![ForgeOutput::Consumed(partner_id), ForgeOutput::Minted(generated_dust)],
+				false,
+			)
+		};
+
+		let additional_output = any_survived
+			.then(|| {
+				let dna =
+					AvatarMinterV2::<T>(PhantomData).generate_base_avatar_dna(hash_provider, 10)?;
+				let generated_egg = AvatarBuilder::with_dna(season_id, dna)
+					.into_egg(RarityType::Rare, pet_variation, soul_points, None)
+					.build();
+				Ok::<_, DispatchError>(ForgeOutput::Minted(generated_egg))
+			})
+			.transpose()?;
+
+		Ok((leader_output, other_output.into_iter().chain(additional_output.into_iter()).collect()))
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::*;
+
+	#[test]
+	fn test_mate() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x28, 0xD2, 0x1C, 0xCA, 0xEE, 0x3F, 0x80, 0xD9, 0x83, 0x21, 0x5D, 0xF9, 0xAC, 0x5E,
+				0x29, 0x74, 0x6A, 0xD9, 0x6C, 0xB0, 0x20, 0x16, 0xB5, 0xAD, 0xEA, 0x86, 0xFD, 0xE0,
+				0xCC, 0xFD, 0x01, 0xB4,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let leader_progress_array =
+				[0x53, 0x54, 0x51, 0x52, 0x55, 0x55, 0x54, 0x51, 0x53, 0x55, 0x53];
+			let leader_spec_bytes = [
+				0x97, 0x59, 0x75, 0x97, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x75, 0x97, 0x50,
+				0x00, 0x00,
+			];
+
+			let partner_progress_array =
+				[0x53, 0x54, 0x51, 0x52, 0x54, 0x50, 0x50, 0x53, 0x55, 0x53, 0x51];
+			let partner_spec_bytes = [
+				0x97, 0x59, 0x75, 0x97, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x75, 0x97, 0x50,
+				0x00, 0x00,
+			];
+
+			let leader = create_random_pet(
+				&ALICE,
+				PetType::BigHybrid,
+				0b0001_1001,
+				leader_spec_bytes,
+				leader_progress_array,
+				1000,
+			);
+			let partner = create_random_pet(
+				&ALICE,
+				PetType::CrazyDude,
+				0b0101_0011,
+				partner_spec_bytes,
+				partner_progress_array,
+				1000,
+			);
+
+			let expected_dna: [u8; 32] = [
+				0x11, 0x05, 0x05, 0x01, 0x19, 0x97, 0x59, 0x75, 0x97, 0x50, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x09, 0x75, 0x97, 0x50, 0x00, 0x00, 0x53, 0x54, 0x51, 0x52, 0x55, 0x55, 0x54,
+				0x51, 0x53, 0x55, 0x53,
+			];
+			assert_eq!(leader.1.dna.as_slice(), &expected_dna);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::mate_avatars(
+				leader,
+				vec![partner],
+				0,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 1);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				assert_eq!(leader_avatar.souls, 1000);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+
+			if let ForgeOutput::Forged((_, avatar), _) = &sacrifice_output[0] {
+				assert_eq!(avatar.souls, 878);
+			} else {
+				panic!("ForgeOutput for first output should have been Forged!")
+			}
+
+			if let ForgeOutput::Minted(avatar) = &sacrifice_output[1] {
+				assert_eq!(avatar.souls, 122);
+				assert_eq!(
+					AvatarUtils::read_attribute_as::<PetItemType>(
+						avatar,
+						AvatarAttributes::ItemSubType
+					),
+					PetItemType::Egg
+				);
+				assert_eq!(
+					AvatarUtils::read_attribute(avatar, AvatarAttributes::CustomType2),
+					0b0101_1010
+				);
+			} else {
+				panic!("ForgeOutput for second output should have been Minted!")
+			}
+		});
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/mod.rs
@@ -1,0 +1,298 @@
+mod assemble;
+mod breed;
+mod build;
+mod equip;
+mod feed;
+mod glimmer;
+mod mate;
+mod spark;
+mod stack;
+mod tinker;
+
+use super::*;
+use sp_std::collections::vec_deque::VecDeque;
+
+pub(super) struct AvatarCombinator<'a, T: Config>(pub PhantomData<&'a T>);
+
+impl<'a, T> AvatarCombinator<'a, T>
+where
+	T: Config,
+{
+	pub(super) fn combine_avatars_in(
+		forge_type: ForgeType,
+		_player: &T::AccountId,
+		season_id: SeasonId,
+		_season: &SeasonOf<T>,
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		match forge_type {
+			ForgeType::Stack =>
+				Self::stack_avatars(input_leader, input_sacrifices, season_id, hash_provider),
+			ForgeType::Tinker =>
+				Self::tinker_avatars(input_leader, input_sacrifices, season_id, hash_provider),
+			ForgeType::Build =>
+				Self::build_avatars(input_leader, input_sacrifices, season_id, hash_provider),
+			ForgeType::Assemble =>
+				Self::assemble_avatars(input_leader, input_sacrifices, hash_provider),
+			ForgeType::Breed => Self::breed_avatars(input_leader, input_sacrifices, hash_provider),
+			ForgeType::Equip => Self::equip_avatars(input_leader, input_sacrifices),
+			ForgeType::Mate =>
+				Self::mate_avatars(input_leader, input_sacrifices, season_id, hash_provider),
+			ForgeType::Feed => Self::feed_avatars(input_leader, input_sacrifices),
+			ForgeType::Glimmer =>
+				Self::glimmer_avatars(input_leader, input_sacrifices, season_id, hash_provider),
+			ForgeType::Spark => Self::spark_avatars(input_leader, input_sacrifices, hash_provider),
+			ForgeType::Special | ForgeType::None =>
+				Self::forge_none(input_leader, input_sacrifices),
+		}
+	}
+
+	fn forge_none(
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		Ok((
+			LeaderForgeOutput::Forged(input_leader, 0),
+			input_sacrifices
+				.into_iter()
+				.map(|sacrifice| ForgeOutput::Forged(sacrifice, 0))
+				.collect(),
+		))
+	}
+
+	fn match_avatars(
+		input_leader: ForgeItem<T>,
+		sacrifices: Vec<ForgeItem<T>>,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> (ForgeItem<T>, Vec<ForgeItem<T>>, Vec<ForgeItem<T>>, Vec<ForgeItem<T>>) {
+		let (leader_id, mut leader) = input_leader;
+		let mut matches: u8 = 0;
+		let mut no_fit: u8 = 0;
+
+		let mut matching_score = Vec::new();
+		let mut matching_sacrifices = Vec::new();
+		let mut consumed_sacrifices = Vec::new();
+		let mut non_matching_sacrifices = Vec::new();
+
+		let mut leader_progress_array = AvatarUtils::read_progress_array(&leader);
+
+		let mut sacrifice_deque = VecDeque::from(sacrifices);
+
+		while let Some((sacrifice_id, sacrifice)) = sacrifice_deque.pop_front() {
+			let sacrifice_progress_array = AvatarUtils::read_progress_array(&sacrifice);
+
+			if let Some(matched_indexes) =
+				AvatarUtils::is_array_match(leader_progress_array, sacrifice_progress_array)
+			{
+				if AvatarUtils::has_attribute_set_with_same_values_as(
+					&leader,
+					&sacrifice,
+					&[AvatarAttributes::ItemType, AvatarAttributes::ItemSubType],
+				) {
+					matching_score.extend(matched_indexes);
+					consumed_sacrifices.push((sacrifice_id, sacrifice));
+					matches += 1;
+				} else {
+					matching_sacrifices.push((sacrifice_id, sacrifice));
+				}
+			} else {
+				non_matching_sacrifices.push((sacrifice_id, sacrifice));
+				no_fit += 1;
+			}
+		}
+
+		if !matching_score.is_empty() {
+			let rolls = matches + no_fit;
+
+			let match_probability =
+				(SCALING_FACTOR_PERC - BASE_PROGRESS_PROB_PERC) / MAX_SACRIFICE as u32;
+			let probability_match = BASE_PROGRESS_PROB_PERC + (matches as u32 * match_probability);
+
+			for i in 0..rolls as usize {
+				let hash_index = hash_provider.hash[i] as usize;
+				let random_hash = hash_provider.hash[hash_index % 32];
+
+				if (random_hash as u32 * SCALING_FACTOR_PERC) <= (probability_match * MAX_BYTE) {
+					let pos = matching_score[hash_index % matching_score.len()];
+
+					leader_progress_array[pos as usize] += 0x10; // 16
+
+					matching_score.retain(|item| *item != pos);
+					if matching_score.is_empty() {
+						break
+					}
+				}
+			}
+
+			AvatarUtils::write_progress_array(&mut leader, leader_progress_array);
+		}
+
+		leader.souls += matching_sacrifices
+			.iter()
+			.chain(consumed_sacrifices.iter())
+			.map(|(_, sacrifice)| sacrifice.souls)
+			.sum::<SoulCount>();
+
+		((leader_id, leader), matching_sacrifices, consumed_sacrifices, non_matching_sacrifices)
+	}
+}
+
+#[cfg(test)]
+mod match_test {
+	use super::*;
+	use crate::mock::*;
+
+	#[test]
+	fn test_match_avatars() {
+		ExtBuilder::default().build().execute_with(|| {
+			let hash_bytes: [u8; 32] = [
+				0x28, 0xD2, 0x1C, 0xCA, 0xEE, 0x3F, 0x80, 0xD9, 0x83, 0x21, 0x5D, 0xF9, 0xAC, 0x5E,
+				0x29, 0x74, 0x6A, 0xD9, 0x6C, 0xB0, 0x20, 0x16, 0xB5, 0xAD, 0xEA, 0x86, 0xFD, 0xE0,
+				0xCC, 0xFD, 0x01, 0xB4,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(hash_bytes);
+			let unit_closure = |avatar| avatar;
+
+			let test_set: Vec<([u8; 32], [u8; 32], (usize, usize, usize), (usize, u8), [u8; 11])> = vec![
+				(
+					[
+						0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					],
+					[
+						0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					],
+					(0, 0, 1),
+					(0, 0x10),
+					[0_u8; 11],
+				),
+				(
+					[
+						0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x10, 0x10,
+						0x10, 0x10, 0x10, 0x10, 0x00, 0x00, 0x01, 0x00,
+					],
+					[
+						0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x11, 0x11,
+						0x11, 0x12, 0x13, 0x14, 0x01, 0x05, 0x00, 0x00,
+					],
+					(1, 0, 0),
+					(1, 0x20),
+					[0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x00, 0x00, 0x01, 0x00],
+				),
+				(
+					[
+						0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x10, 0x10,
+						0x10, 0x10, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00,
+					],
+					[
+						0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x10, 0x11,
+						0x12, 0x13, 0x14, 0x15, 0x01, 0x05, 0x00, 0x00,
+					],
+					(1, 0, 0),
+					(1, 0x20),
+					[0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00],
+				),
+				(
+					[
+						0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x10, 0x10,
+						0x10, 0x10, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00,
+					],
+					[
+						0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x10, 0x10,
+						0x10, 0x13, 0x14, 0x15, 0x01, 0x00, 0x00, 0x00,
+					],
+					(1, 0, 0),
+					(1, 0x20),
+					[0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00],
+				),
+				(
+					[
+						0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x10, 0x10,
+						0x10, 0x10, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00,
+					],
+					[
+						0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x11, 0x11,
+						0x11, 0x13, 0x14, 0x15, 0x01, 0x00, 0x00, 0x00,
+					],
+					(0, 0, 1),
+					(0, 0x10),
+					[0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00],
+				),
+			];
+
+			for (
+				i,
+				(
+					dna_1,
+					dna_2,
+					(match_len, consumed_len, non_match_len),
+					(top_bit_index, top_1_bit),
+					progress_array_1,
+				),
+			) in test_set.into_iter().enumerate()
+			{
+				let avatar_1 =
+					create_random_avatar::<Test, _>(&ALICE, Some(dna_1), Some(unit_closure));
+				let avatar_2 =
+					create_random_avatar::<Test, _>(&ALICE, Some(dna_2), Some(unit_closure));
+
+				let ((_, leader), matched_avatars, consumed_avatars, non_matched_avatars) =
+					AvatarCombinator::<Test>::match_avatars(
+						avatar_1,
+						vec![avatar_2],
+						&mut hash_provider,
+					);
+
+				assert_eq!(
+					matched_avatars.len(),
+					match_len,
+					"Test matched_avatars len for case {}",
+					i
+				);
+				assert_eq!(
+					consumed_avatars.len(),
+					consumed_len,
+					"Test consumed_avatars len for case {}",
+					i
+				);
+				assert_eq!(
+					non_matched_avatars.len(),
+					non_match_len,
+					"Test non_match_len len for case {}",
+					i
+				);
+
+				if top_bit_index == 0 {
+					assert_eq!(leader.dna[0], top_1_bit, "Test top_bit for case {}", i);
+				} else {
+					assert_eq!(
+						matched_avatars[top_bit_index - 1].1.dna[0],
+						top_1_bit,
+						"Test top_bit for case {}",
+						i
+					);
+				}
+
+				assert_eq!(
+					AvatarUtils::read_progress_array(&leader),
+					progress_array_1,
+					"Test progress_array for case {}",
+					i
+				);
+			}
+		});
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/mod.rs
@@ -12,9 +12,9 @@ mod tinker;
 use super::*;
 use sp_std::collections::vec_deque::VecDeque;
 
-pub(super) struct AvatarCombinator<'a, T: Config>(pub PhantomData<&'a T>);
+pub(super) struct AvatarCombinator<T: Config>(pub PhantomData<T>);
 
-impl<'a, T> AvatarCombinator<'a, T>
+impl<T> AvatarCombinator<T>
 where
 	T: Config,
 {
@@ -147,7 +147,7 @@ mod match_test {
 	#[test]
 	fn test_match_avatars() {
 		ExtBuilder::default().build().execute_with(|| {
-			let hash_bytes: [u8; 32] = [
+			let hash_bytes = [
 				0x28, 0xD2, 0x1C, 0xCA, 0xEE, 0x3F, 0x80, 0xD9, 0x83, 0x21, 0x5D, 0xF9, 0xAC, 0x5E,
 				0x29, 0x74, 0x6A, 0xD9, 0x6C, 0xB0, 0x20, 0x16, 0xB5, 0xAD, 0xEA, 0x86, 0xFD, 0xE0,
 				0xCC, 0xFD, 0x01, 0xB4,

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/spark.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/spark.rs
@@ -1,9 +1,6 @@
 use super::*;
 
-impl<'a, T> AvatarCombinator<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarCombinator<T> {
 	pub(super) fn spark_avatars(
 		input_leader: ForgeItem<T>,
 		input_sacrifices: Vec<ForgeItem<T>>,
@@ -20,11 +17,11 @@ where
 
 		let rarity_type = RarityType::from_byte(AvatarUtils::read_lowest_progress_byte(
 			&AvatarUtils::read_progress_array(&leader),
-			ByteType::High,
+			&ByteType::High,
 		));
 		let essence_type = AvatarUtils::read_attribute_as::<EssenceItemType>(
 			&leader,
-			AvatarAttributes::ItemSubType,
+			&AvatarAttributes::ItemSubType,
 		);
 
 		if essence_type == EssenceItemType::ColorSpark && rarity_type == RarityType::Rare {
@@ -41,35 +38,39 @@ where
 					};
 					AvatarUtils::write_spec_byte(
 						&mut leader,
-						spec_byte_index,
-						AvatarUtils::read_spec_byte(sacrifice, spec_byte_index),
+						&spec_byte_index,
+						AvatarUtils::read_spec_byte(sacrifice, &spec_byte_index),
 					);
 				}
 
 				let leader_spec_byte_1 =
-					AvatarUtils::read_spec_byte(&leader, AvatarSpecBytes::SpecByte1);
+					AvatarUtils::read_spec_byte(&leader, &AvatarSpecBytes::SpecByte1);
 				let leader_spec_byte_2 =
-					AvatarUtils::read_spec_byte(&leader, AvatarSpecBytes::SpecByte2);
+					AvatarUtils::read_spec_byte(&leader, &AvatarSpecBytes::SpecByte2);
 				let color_bits = ((leader_spec_byte_1 - 1) << 6) | (leader_spec_byte_2 - 1) << 4;
 
-				AvatarUtils::write_spec_byte(&mut leader, AvatarSpecBytes::SpecByte1, color_bits);
-				AvatarUtils::write_spec_byte(&mut leader, AvatarSpecBytes::SpecByte2, 0x00);
+				AvatarUtils::write_spec_byte(&mut leader, &AvatarSpecBytes::SpecByte1, color_bits);
+				AvatarUtils::write_spec_byte(&mut leader, &AvatarSpecBytes::SpecByte2, 0x00);
 
 				AvatarUtils::write_typed_attribute(
 					&mut leader,
-					AvatarAttributes::ItemSubType,
-					EssenceItemType::PaintFlask,
+					&AvatarAttributes::ItemSubType,
+					&EssenceItemType::PaintFlask,
 				);
 			}
 		} else if essence_type == EssenceItemType::GlowSpark && rarity_type == RarityType::Epic {
 			AvatarUtils::write_typed_attribute(
 				&mut leader,
-				AvatarAttributes::ItemSubType,
-				EssenceItemType::ForceGlow,
+				&AvatarAttributes::ItemSubType,
+				&EssenceItemType::ForceGlow,
 			);
 		}
 
-		AvatarUtils::write_typed_attribute(&mut leader, AvatarAttributes::RarityType, rarity_type);
+		AvatarUtils::write_typed_attribute(
+			&mut leader,
+			&AvatarAttributes::RarityType,
+			&rarity_type,
+		);
 
 		let output_vec: Vec<ForgeOutput<T>> = non_matching_sacrifices
 			.into_iter()
@@ -105,7 +106,7 @@ mod test {
 			];
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
-			let progress_arrays: [[u8; 11]; 5] = [
+			let progress_arrays = [
 				[0x34, 0x35, 0x23, 0x30, 0x30, 0x21, 0x21, 0x34, 0x34, 0x23, 0x32],
 				[0x22, 0x35, 0x22, 0x30, 0x23, 0x23, 0x25, 0x25, 0x24, 0x30, 0x22],
 				[0x24, 0x20, 0x24, 0x24, 0x33, 0x21, 0x20, 0x20, 0x34, 0x23, 0x25],
@@ -113,17 +114,18 @@ mod test {
 				[0x34, 0x23, 0x24, 0x22, 0x25, 0x22, 0x21, 0x24, 0x20, 0x31, 0x21],
 			];
 
-			let mut avatars = Vec::with_capacity(5);
-
-			for progress_array in progress_arrays {
-				avatars.push(create_random_color_spark(
-					None,
-					&ALICE,
-					(ColorType::ColorA, ColorType::ColorC),
-					5,
-					Some(progress_array),
-				));
-			}
+			let mut avatars = progress_arrays
+				.into_iter()
+				.map(|progress_array| {
+					create_random_color_spark(
+						None,
+						&ALICE,
+						&(ColorType::ColorA, ColorType::ColorC),
+						5,
+						Some(progress_array),
+					)
+				})
+				.collect::<Vec<_>>();
 
 			let total_soul_points = 25;
 
@@ -150,19 +152,19 @@ mod test {
 				assert_eq!(
 					AvatarUtils::read_attribute_as::<RarityType>(
 						&leader_avatar,
-						AvatarAttributes::RarityType
+						&AvatarAttributes::RarityType
 					),
 					RarityType::Rare
 				);
 				assert_eq!(
 					AvatarUtils::read_attribute_as::<EssenceItemType>(
 						&leader_avatar,
-						AvatarAttributes::ItemSubType
+						&AvatarAttributes::ItemSubType
 					),
 					EssenceItemType::PaintFlask
 				);
 				assert_eq!(
-					AvatarUtils::read_spec_byte(&leader_avatar, AvatarSpecBytes::SpecByte1),
+					AvatarUtils::read_spec_byte(&leader_avatar, &AvatarSpecBytes::SpecByte1),
 					0b0010_0000
 				);
 			} else {
@@ -181,7 +183,7 @@ mod test {
 			];
 			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
 
-			let progress_arrays: [[u8; 11]; 5] = [
+			let progress_arrays = [
 				[0x44, 0x45, 0x33, 0x40, 0x40, 0x31, 0x31, 0x44, 0x44, 0x33, 0x42],
 				[0x32, 0x45, 0x32, 0x40, 0x33, 0x33, 0x35, 0x35, 0x34, 0x40, 0x32],
 				[0x34, 0x30, 0x34, 0x34, 0x43, 0x31, 0x30, 0x30, 0x44, 0x33, 0x35],
@@ -197,17 +199,13 @@ mod test {
 				ForceType::Kinetic,
 			];
 
-			let mut avatars = Vec::with_capacity(5);
-
-			for i in 0..5 {
-				avatars.push(create_random_glow_spark(
-					None,
-					&ALICE,
-					force_types[i],
-					5,
-					Some(progress_arrays[i]),
-				));
-			}
+			let mut avatars = force_types
+				.into_iter()
+				.zip(progress_arrays)
+				.map(|(force_type, progress_array)| {
+					create_random_glow_spark(None, &ALICE, &force_type, 5, Some(progress_array))
+				})
+				.collect::<Vec<_>>();
 
 			let total_soul_points = 25;
 
@@ -234,21 +232,21 @@ mod test {
 				assert_eq!(
 					AvatarUtils::read_attribute_as::<RarityType>(
 						&leader_avatar,
-						AvatarAttributes::RarityType
+						&AvatarAttributes::RarityType
 					),
 					RarityType::Epic
 				);
 				assert_eq!(
 					AvatarUtils::read_attribute_as::<EssenceItemType>(
 						&leader_avatar,
-						AvatarAttributes::ItemSubType
+						&AvatarAttributes::ItemSubType
 					),
 					EssenceItemType::ForceGlow
 				);
 				assert_eq!(
 					ForceType::from_byte(AvatarUtils::read_spec_byte(
 						&leader_avatar,
-						AvatarSpecBytes::SpecByte1
+						&AvatarSpecBytes::SpecByte1
 					)),
 					ForceType::Kinetic
 				);

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/spark.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/spark.rs
@@ -1,0 +1,260 @@
+use super::*;
+
+impl<'a, T> AvatarCombinator<'a, T>
+where
+	T: Config,
+{
+	pub(super) fn spark_avatars(
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		let all_count = input_sacrifices.len();
+
+		let (
+			(leader_id, mut leader),
+			matching_sacrifices,
+			consumed_sacrifices,
+			non_matching_sacrifices,
+		) = Self::match_avatars(input_leader, input_sacrifices, hash_provider);
+
+		let rarity_type = RarityType::from_byte(AvatarUtils::read_lowest_progress_byte(
+			&AvatarUtils::read_progress_array(&leader),
+			ByteType::High,
+		));
+		let essence_type = AvatarUtils::read_attribute_as::<EssenceItemType>(
+			&leader,
+			AvatarAttributes::ItemSubType,
+		);
+
+		if essence_type == EssenceItemType::ColorSpark && rarity_type == RarityType::Rare {
+			let rolls = MAX_SACRIFICE - all_count + 1;
+
+			for _ in 0..rolls {
+				let rand = hash_provider.get_hash_byte() as usize;
+				if rand > 150 {
+					let (_, sacrifice) = &matching_sacrifices[rand % all_count];
+					let spec_byte_index = if rand > 200 {
+						AvatarSpecBytes::SpecByte1
+					} else {
+						AvatarSpecBytes::SpecByte2
+					};
+					AvatarUtils::write_spec_byte(
+						&mut leader,
+						spec_byte_index,
+						AvatarUtils::read_spec_byte(sacrifice, spec_byte_index),
+					);
+				}
+
+				let leader_spec_byte_1 =
+					AvatarUtils::read_spec_byte(&leader, AvatarSpecBytes::SpecByte1);
+				let leader_spec_byte_2 =
+					AvatarUtils::read_spec_byte(&leader, AvatarSpecBytes::SpecByte2);
+				let color_bits = ((leader_spec_byte_1 - 1) << 6) | (leader_spec_byte_2 - 1) << 4;
+
+				AvatarUtils::write_spec_byte(&mut leader, AvatarSpecBytes::SpecByte1, color_bits);
+				AvatarUtils::write_spec_byte(&mut leader, AvatarSpecBytes::SpecByte2, 0x00);
+
+				AvatarUtils::write_typed_attribute(
+					&mut leader,
+					AvatarAttributes::ItemSubType,
+					EssenceItemType::PaintFlask,
+				);
+			}
+		} else if essence_type == EssenceItemType::GlowSpark && rarity_type == RarityType::Epic {
+			AvatarUtils::write_typed_attribute(
+				&mut leader,
+				AvatarAttributes::ItemSubType,
+				EssenceItemType::ForceGlow,
+			);
+		}
+
+		AvatarUtils::write_typed_attribute(&mut leader, AvatarAttributes::RarityType, rarity_type);
+
+		let output_vec: Vec<ForgeOutput<T>> = non_matching_sacrifices
+			.into_iter()
+			.map(|sacrifice| ForgeOutput::Forged(sacrifice, 0))
+			.chain(
+				consumed_sacrifices
+					.into_iter()
+					.map(|(sacrifice_id, _)| ForgeOutput::Consumed(sacrifice_id)),
+			)
+			.chain(
+				matching_sacrifices
+					.into_iter()
+					.map(|(sacrifice_id, _)| ForgeOutput::Consumed(sacrifice_id)),
+			)
+			.collect();
+
+		Ok((LeaderForgeOutput::Forged((leader_id, leader), 0), output_vec))
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::*;
+
+	#[test]
+	fn test_spark_to_paint() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x28, 0xD2, 0x1C, 0xCA, 0xEE, 0x3F, 0x80, 0xD9, 0x83, 0x21, 0x5D, 0xF9, 0xAC, 0x5E,
+				0x29, 0x74, 0x6A, 0xD9, 0x6C, 0xB0, 0x20, 0x16, 0xB5, 0xAD, 0xEA, 0x86, 0xFD, 0xE0,
+				0xCC, 0xFD, 0x01, 0xB4,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let progress_arrays: [[u8; 11]; 5] = [
+				[0x34, 0x35, 0x23, 0x30, 0x30, 0x21, 0x21, 0x34, 0x34, 0x23, 0x32],
+				[0x22, 0x35, 0x22, 0x30, 0x23, 0x23, 0x25, 0x25, 0x24, 0x30, 0x22],
+				[0x24, 0x20, 0x24, 0x24, 0x33, 0x21, 0x20, 0x20, 0x34, 0x23, 0x25],
+				[0x22, 0x21, 0x24, 0x20, 0x33, 0x21, 0x23, 0x24, 0x22, 0x22, 0x22],
+				[0x34, 0x23, 0x24, 0x22, 0x25, 0x22, 0x21, 0x24, 0x20, 0x31, 0x21],
+			];
+
+			let mut avatars = Vec::with_capacity(5);
+
+			for progress_array in progress_arrays {
+				avatars.push(create_random_color_spark(
+					None,
+					&ALICE,
+					(ColorType::ColorA, ColorType::ColorC),
+					5,
+					Some(progress_array),
+				));
+			}
+
+			let total_soul_points = 25;
+
+			let sacrifices = avatars.split_off(1);
+			let leader = avatars.pop().unwrap();
+
+			let (leader_output, sacrifice_output) =
+				AvatarCombinator::<Test>::spark_avatars(leader, sacrifices, &mut hash_provider)
+					.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 4);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				assert_eq!(leader_avatar.souls, total_soul_points);
+
+				let expected_progress_array =
+					[0x34, 0x35, 0x33, 0x30, 0x30, 0x31, 0x31, 0x34, 0x34, 0x33, 0x32];
+				let _leader_progress_array = AvatarUtils::read_progress_array(&leader_avatar);
+				assert_eq!(
+					AvatarUtils::read_progress_array(&leader_avatar),
+					expected_progress_array
+				);
+				assert_eq!(
+					AvatarUtils::read_attribute_as::<RarityType>(
+						&leader_avatar,
+						AvatarAttributes::RarityType
+					),
+					RarityType::Rare
+				);
+				assert_eq!(
+					AvatarUtils::read_attribute_as::<EssenceItemType>(
+						&leader_avatar,
+						AvatarAttributes::ItemSubType
+					),
+					EssenceItemType::PaintFlask
+				);
+				assert_eq!(
+					AvatarUtils::read_spec_byte(&leader_avatar, AvatarSpecBytes::SpecByte1),
+					0b0010_0000
+				);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_spark_to_force() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forge_hash = [
+				0x28, 0xD2, 0x1C, 0xCA, 0xEE, 0x3F, 0x80, 0xD9, 0x83, 0x21, 0x5D, 0xF9, 0xAC, 0x5E,
+				0x29, 0x74, 0x6A, 0xD9, 0x6C, 0xB0, 0x20, 0x16, 0xB5, 0xAD, 0xEA, 0x86, 0xFD, 0xE0,
+				0xCC, 0xFD, 0x01, 0xB4,
+			];
+			let mut hash_provider = HashProvider::new_with_bytes(forge_hash);
+
+			let progress_arrays: [[u8; 11]; 5] = [
+				[0x44, 0x45, 0x33, 0x40, 0x40, 0x31, 0x31, 0x44, 0x44, 0x33, 0x42],
+				[0x32, 0x45, 0x32, 0x40, 0x33, 0x33, 0x35, 0x35, 0x34, 0x40, 0x32],
+				[0x34, 0x30, 0x34, 0x34, 0x43, 0x31, 0x30, 0x30, 0x44, 0x33, 0x35],
+				[0x32, 0x31, 0x34, 0x30, 0x43, 0x31, 0x33, 0x34, 0x32, 0x32, 0x32],
+				[0x44, 0x33, 0x34, 0x32, 0x35, 0x32, 0x31, 0x34, 0x30, 0x41, 0x31],
+			];
+
+			let force_types = [
+				ForceType::Kinetic,
+				ForceType::Thermal,
+				ForceType::Thermal,
+				ForceType::Thermal,
+				ForceType::Kinetic,
+			];
+
+			let mut avatars = Vec::with_capacity(5);
+
+			for i in 0..5 {
+				avatars.push(create_random_glow_spark(
+					None,
+					&ALICE,
+					force_types[i],
+					5,
+					Some(progress_arrays[i]),
+				));
+			}
+
+			let total_soul_points = 25;
+
+			let sacrifices = avatars.split_off(1);
+			let leader = avatars.pop().unwrap();
+
+			let (leader_output, sacrifice_output) =
+				AvatarCombinator::<Test>::spark_avatars(leader, sacrifices, &mut hash_provider)
+					.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 4);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				assert_eq!(leader_avatar.souls, total_soul_points);
+
+				let expected_progress_array =
+					[0x44, 0x45, 0x43, 0x40, 0x40, 0x41, 0x41, 0x44, 0x44, 0x43, 0x42];
+				let _leader_progress_array = AvatarUtils::read_progress_array(&leader_avatar);
+				assert_eq!(
+					AvatarUtils::read_progress_array(&leader_avatar),
+					expected_progress_array
+				);
+				assert_eq!(
+					AvatarUtils::read_attribute_as::<RarityType>(
+						&leader_avatar,
+						AvatarAttributes::RarityType
+					),
+					RarityType::Epic
+				);
+				assert_eq!(
+					AvatarUtils::read_attribute_as::<EssenceItemType>(
+						&leader_avatar,
+						AvatarAttributes::ItemSubType
+					),
+					EssenceItemType::ForceGlow
+				);
+				assert_eq!(
+					ForceType::from_byte(AvatarUtils::read_spec_byte(
+						&leader_avatar,
+						AvatarSpecBytes::SpecByte1
+					)),
+					ForceType::Kinetic
+				);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/stack.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/stack.rs
@@ -1,0 +1,157 @@
+use super::*;
+
+impl<'a, T> AvatarCombinator<'a, T>
+where
+	T: Config,
+{
+	pub(super) fn stack_avatars(
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+		season_id: SeasonId,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		let (leader_id, mut leader) = input_leader;
+
+		let (new_quantity, new_souls) = input_sacrifices
+			.iter()
+			.map(|sacrifice| {
+				(
+					AvatarUtils::read_attribute(&sacrifice.1, AvatarAttributes::Quantity),
+					sacrifice.1.souls,
+				)
+			})
+			.reduce(|(acc_qty, acc_souls), (qty, souls)| {
+				(acc_qty.saturating_add(qty), acc_souls.saturating_add(souls))
+			})
+			.unwrap_or_default();
+		let leader_quantity = AvatarUtils::read_attribute(&leader, AvatarAttributes::Quantity)
+			.saturating_add(new_quantity);
+		AvatarUtils::write_attribute(&mut leader, AvatarAttributes::Quantity, leader_quantity);
+
+		let mut glimmer_avatar: Option<Avatar> = None;
+		let mut glimmer_additional_qty = 0;
+
+		for i in 0..input_sacrifices.len() {
+			if hash_provider.hash[i] as u32 * SCALING_FACTOR_PERC < STACK_PROB_PERC * MAX_BYTE {
+				match glimmer_avatar {
+					None => {
+						let dna = AvatarMinterV2::<T>(PhantomData)
+							.generate_base_avatar_dna(hash_provider, i)?;
+						glimmer_avatar =
+							Some(AvatarBuilder::with_dna(season_id, dna).into_glimmer(1).build());
+					},
+					Some(_) => {
+						glimmer_additional_qty += 1;
+					},
+				}
+			}
+		}
+
+		if let Some(ref mut avatar) = glimmer_avatar {
+			AvatarUtils::write_attribute(
+				avatar,
+				AvatarAttributes::Quantity,
+				glimmer_additional_qty,
+			);
+		}
+
+		leader.souls += new_souls;
+
+		let output_vec: Vec<ForgeOutput<T>> = input_sacrifices
+			.into_iter()
+			.map(|(sacrifice_id, _)| ForgeOutput::Consumed(sacrifice_id))
+			.chain(glimmer_avatar.map(|minted_avatar| ForgeOutput::Minted(minted_avatar)))
+			.collect();
+
+		Ok((LeaderForgeOutput::Forged((leader_id, leader), 0), output_vec))
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::*;
+
+	#[test]
+	fn test_stack_material() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
+
+			let material_input_1 = create_random_material(&ALICE, MaterialItemType::Polymers, 1);
+			let material_input_2 = create_random_material(&ALICE, MaterialItemType::Polymers, 2);
+			let material_input_3 = create_random_material(&ALICE, MaterialItemType::Polymers, 5);
+			let material_input_4 = create_random_material(&ALICE, MaterialItemType::Polymers, 3);
+
+			let total_soul_points = material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::stack_avatars(
+				material_input_1,
+				vec![material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert!(sacrifice_output.iter().all(|output| !is_forged(output)));
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				assert_eq!(leader_avatar.souls, total_soul_points);
+				assert_eq!(
+					AvatarUtils::read_attribute(&leader_avatar, AvatarAttributes::Quantity),
+					11
+				);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+
+	#[test]
+	fn test_stack_pet_parts() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
+
+			let pet_part_input_1 =
+				create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::Head, 3);
+			let pet_part_input_2 =
+				create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::ArmBack, 4);
+			let pet_part_input_3 =
+				create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::LegBack, 5);
+			let pet_part_input_4 =
+				create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::LegFront, 5);
+
+			let total_soul_points = pet_part_input_1.1.souls +
+				pet_part_input_2.1.souls +
+				pet_part_input_3.1.souls +
+				pet_part_input_4.1.souls;
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::stack_avatars(
+				pet_part_input_1,
+				vec![pet_part_input_2, pet_part_input_3, pet_part_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert!(sacrifice_output.iter().all(|output| !is_forged(output)));
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				assert_eq!(leader_avatar.souls, total_soul_points);
+				assert_eq!(
+					AvatarUtils::read_attribute(&leader_avatar, AvatarAttributes::Quantity),
+					17
+				);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			}
+		});
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/stack.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/stack.rs
@@ -1,9 +1,6 @@
 use super::*;
 
-impl<'a, T> AvatarCombinator<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarCombinator<T> {
 	pub(super) fn stack_avatars(
 		input_leader: ForgeItem<T>,
 		input_sacrifices: Vec<ForgeItem<T>>,
@@ -16,7 +13,7 @@ where
 			.iter()
 			.map(|sacrifice| {
 				(
-					AvatarUtils::read_attribute(&sacrifice.1, AvatarAttributes::Quantity),
+					AvatarUtils::read_attribute(&sacrifice.1, &AvatarAttributes::Quantity),
 					sacrifice.1.souls,
 				)
 			})
@@ -24,9 +21,9 @@ where
 				(acc_qty.saturating_add(qty), acc_souls.saturating_add(souls))
 			})
 			.unwrap_or_default();
-		let leader_quantity = AvatarUtils::read_attribute(&leader, AvatarAttributes::Quantity)
+		let leader_quantity = AvatarUtils::read_attribute(&leader, &AvatarAttributes::Quantity)
 			.saturating_add(new_quantity);
-		AvatarUtils::write_attribute(&mut leader, AvatarAttributes::Quantity, leader_quantity);
+		AvatarUtils::write_attribute(&mut leader, &AvatarAttributes::Quantity, leader_quantity);
 
 		let mut glimmer_avatar: Option<Avatar> = None;
 		let mut glimmer_additional_qty = 0;
@@ -50,7 +47,7 @@ where
 		if let Some(ref mut avatar) = glimmer_avatar {
 			AvatarUtils::write_attribute(
 				avatar,
-				AvatarAttributes::Quantity,
+				&AvatarAttributes::Quantity,
 				glimmer_additional_qty,
 			);
 		}
@@ -78,10 +75,10 @@ mod test {
 			let season_id = 0 as SeasonId;
 			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
 
-			let material_input_1 = create_random_material(&ALICE, MaterialItemType::Polymers, 1);
-			let material_input_2 = create_random_material(&ALICE, MaterialItemType::Polymers, 2);
-			let material_input_3 = create_random_material(&ALICE, MaterialItemType::Polymers, 5);
-			let material_input_4 = create_random_material(&ALICE, MaterialItemType::Polymers, 3);
+			let material_input_1 = create_random_material(&ALICE, &MaterialItemType::Polymers, 1);
+			let material_input_2 = create_random_material(&ALICE, &MaterialItemType::Polymers, 2);
+			let material_input_3 = create_random_material(&ALICE, &MaterialItemType::Polymers, 5);
+			let material_input_4 = create_random_material(&ALICE, &MaterialItemType::Polymers, 3);
 
 			let total_soul_points = material_input_1.1.souls +
 				material_input_2.1.souls +
@@ -103,7 +100,7 @@ mod test {
 			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
 				assert_eq!(leader_avatar.souls, total_soul_points);
 				assert_eq!(
-					AvatarUtils::read_attribute(&leader_avatar, AvatarAttributes::Quantity),
+					AvatarUtils::read_attribute(&leader_avatar, &AvatarAttributes::Quantity),
 					11
 				);
 			} else {
@@ -119,13 +116,13 @@ mod test {
 			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
 
 			let pet_part_input_1 =
-				create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::Head, 3);
+				create_random_pet_part(&ALICE, &PetType::FoxishDude, &SlotType::Head, 3);
 			let pet_part_input_2 =
-				create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::ArmBack, 4);
+				create_random_pet_part(&ALICE, &PetType::FoxishDude, &SlotType::ArmBack, 4);
 			let pet_part_input_3 =
-				create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::LegBack, 5);
+				create_random_pet_part(&ALICE, &PetType::FoxishDude, &SlotType::LegBack, 5);
 			let pet_part_input_4 =
-				create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::LegFront, 5);
+				create_random_pet_part(&ALICE, &PetType::FoxishDude, &SlotType::LegFront, 5);
 
 			let total_soul_points = pet_part_input_1.1.souls +
 				pet_part_input_2.1.souls +
@@ -146,7 +143,7 @@ mod test {
 			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
 				assert_eq!(leader_avatar.souls, total_soul_points);
 				assert_eq!(
-					AvatarUtils::read_attribute(&leader_avatar, AvatarAttributes::Quantity),
+					AvatarUtils::read_attribute(&leader_avatar, &AvatarAttributes::Quantity),
 					17
 				);
 			} else {

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/tinker.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/tinker.rs
@@ -1,0 +1,629 @@
+use super::*;
+
+impl<'a, T> AvatarCombinator<'a, T>
+where
+	T: Config,
+{
+	pub(super) fn tinker_avatars(
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+		season_id: SeasonId,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		let (leader_id, mut leader) = input_leader;
+
+		let mut output_sacrifices = Vec::with_capacity(0);
+		let mut consumed_leader = false;
+
+		let sacrifice_pattern = input_sacrifices
+			.iter()
+			.map(|(_, sacrifice)| {
+				AvatarUtils::read_attribute_as::<MaterialItemType>(
+					sacrifice,
+					AvatarAttributes::ItemSubType,
+				)
+			})
+			.collect::<Vec<MaterialItemType>>();
+
+		let pattern_flags = AvatarUtils::read_full_spec_bytes(&leader)
+			.chunks_exact(2)
+			.take(4)
+			.map(|chunk| {
+				sacrifice_pattern ==
+					AvatarUtils::bits_order_to_enum(
+						chunk[1] as u32,
+						4,
+						AvatarUtils::bits_to_enums::<MaterialItemType>(chunk[0] as u32),
+					)
+			})
+			.collect::<Vec<_>>();
+
+		let mut soul_points = 0;
+
+		let all_patterns_match = pattern_flags.iter().any(|pattern| *pattern);
+		let can_use_leader = AvatarUtils::can_use_avatar(&leader, 1);
+		let can_use_all_sacrifices = input_sacrifices
+			.iter()
+			.all(|(_, sacrifice)| AvatarUtils::can_use_avatar(sacrifice, 1));
+
+		if all_patterns_match && can_use_leader && can_use_all_sacrifices {
+			let mut success = true;
+
+			let (use_result, consumed, out_soul_points) = AvatarUtils::use_avatar(&mut leader, 1);
+
+			success &= use_result;
+			consumed_leader = consumed;
+			soul_points += out_soul_points;
+
+			for (sacrifice_id, mut sacrifice) in input_sacrifices.into_iter() {
+				let (use_result, _, out_soul_points) = AvatarUtils::use_avatar(&mut sacrifice, 1);
+				success &= use_result;
+				soul_points += out_soul_points;
+
+				let sacrifice_output =
+					if AvatarUtils::read_attribute(&sacrifice, AvatarAttributes::Quantity) == 0 {
+						ForgeOutput::Consumed(sacrifice_id)
+					} else {
+						ForgeOutput::Forged((sacrifice_id, sacrifice), 0)
+					};
+
+				output_sacrifices.push(sacrifice_output);
+			}
+
+			if !success || soul_points > u8::MAX as SoulCount {
+				// https://github.com/ajuna-network/Ajuna.AAA.Season2/blob/master/Ajuna.AAA.Season2/Game.cs#L877
+				todo!()
+			}
+
+			let equipable_item_type = {
+				if pattern_flags[0] {
+					EquipableItemType::ArmorBase
+				} else if pattern_flags[1] {
+					EquipableItemType::ArmorComponent1
+				} else if pattern_flags[2] {
+					EquipableItemType::ArmorComponent2
+				} else if pattern_flags[3] {
+					EquipableItemType::ArmorComponent3
+				} else {
+					// https://github.com/ajuna-network/Ajuna.AAA.Season2/blob/master/Ajuna.AAA.Season2/Game.cs#L899
+					todo!()
+				}
+			};
+
+			let pet_type =
+				AvatarUtils::read_attribute_as::<PetType>(&leader, AvatarAttributes::ClassType2);
+
+			let slot_type =
+				AvatarUtils::read_attribute_as::<SlotType>(&leader, AvatarAttributes::ClassType1);
+
+			let dna =
+				AvatarMinterV2::<T>(PhantomData).generate_base_avatar_dna(hash_provider, 6)?;
+			let generated_blueprint = AvatarBuilder::with_dna(season_id, dna)
+				.into_blueprint(
+					BlueprintItemType::Blueprint,
+					pet_type,
+					slot_type,
+					equipable_item_type,
+					sacrifice_pattern,
+					soul_points as SoulCount,
+				)
+				.build();
+
+			output_sacrifices.push(ForgeOutput::Minted(generated_blueprint));
+		} else {
+			// TODO: Incomplete
+			output_sacrifices.extend(
+				input_sacrifices.into_iter().map(|sacrifice| ForgeOutput::Forged(sacrifice, 0)),
+			);
+		}
+
+		let leader_output = if consumed_leader {
+			LeaderForgeOutput::Consumed(leader_id)
+		} else {
+			LeaderForgeOutput::Forged((leader_id, leader), 0)
+		};
+
+		Ok((leader_output, output_sacrifices))
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::*;
+
+	#[test]
+	fn test_tinker_success_no_materials_left() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
+
+			let pet_type = PetType::FoxishDude;
+			let slot_type = SlotType::Head;
+
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				EquipableItemType::ArmorBase.as_byte() as usize,
+			);
+
+			assert_eq!(
+				pattern,
+				vec![
+					MaterialItemType::Optics,
+					MaterialItemType::Superconductors,
+					MaterialItemType::Ceramics,
+					MaterialItemType::PowerCells
+				]
+			);
+
+			let pet_part_input_1 = create_random_pet_part(&ALICE, pet_type, slot_type, 1);
+
+			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, pattern[1], 1);
+			let material_input_3 = create_random_material(&ALICE, pattern[2], 1);
+			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+
+			let total_soul_points = pet_part_input_1.1.souls +
+				material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+			assert_eq!(total_soul_points, 5);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::tinker_avatars(
+				pet_part_input_1,
+				vec![material_input_1, material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 5);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			if let LeaderForgeOutput::Consumed(_) = leader_output {
+				let minted_blueprint = sacrifice_output
+					.into_iter()
+					.filter(|output| is_minted(output))
+					.collect::<Vec<ForgeOutput<Test>>>()
+					.pop()
+					.expect("Should have 1 element!");
+
+				if let ForgeOutput::Minted(avatar) = minted_blueprint {
+					assert!(AvatarUtils::has_attribute_with_value(
+						&avatar,
+						AvatarAttributes::ItemType,
+						ItemType::Blueprint
+					));
+					assert_eq!(
+						AvatarUtils::read_spec_byte(&avatar, AvatarSpecBytes::SpecByte3),
+						EquipableItemType::ArmorBase.as_byte()
+					);
+					assert_eq!(
+						AvatarUtils::read_attribute(&avatar, AvatarAttributes::Quantity),
+						total_soul_points as u8
+					);
+					assert_eq!(avatar.souls, total_soul_points);
+				} else {
+					panic!("ForgeOutput of blueprint should have been Minted!");
+				}
+			} else {
+				panic!("LeaderForgeOutput should have been Consumed!");
+			}
+		})
+	}
+
+	#[test]
+	fn test_tinker_success_some_materials_left() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
+
+			let pet_type = PetType::FoxishDude;
+			let slot_type = SlotType::Head;
+
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				EquipableItemType::ArmorBase.as_byte() as usize,
+			);
+
+			assert_eq!(
+				pattern,
+				vec![
+					MaterialItemType::Optics,
+					MaterialItemType::Superconductors,
+					MaterialItemType::Ceramics,
+					MaterialItemType::PowerCells
+				]
+			);
+
+			let pet_part_input_1 = create_random_pet_part(&ALICE, pet_type, slot_type, 1);
+
+			let material_input_1 = create_random_material(&ALICE, pattern[0], 2);
+			let material_input_2 = create_random_material(&ALICE, pattern[1], 1);
+			let material_input_3 = create_random_material(&ALICE, pattern[2], 2);
+			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+
+			let total_soul_points = pet_part_input_1.1.souls +
+				material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+			assert_eq!(total_soul_points, 7);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::tinker_avatars(
+				pet_part_input_1,
+				vec![material_input_1, material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 5);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			assert_eq!(
+				sacrifice_output
+					.iter()
+					.map(|output| {
+						match output {
+							ForgeOutput::Forged((_, avatar), _) => avatar.souls,
+							ForgeOutput::Minted(avatar) => avatar.souls,
+							_ => 0,
+						}
+					})
+					.sum::<SoulCount>(),
+				total_soul_points
+			);
+
+			if let LeaderForgeOutput::Consumed(_) = leader_output {
+				let minted_blueprint = sacrifice_output
+					.into_iter()
+					.filter(|output| is_minted(output))
+					.collect::<Vec<ForgeOutput<Test>>>()
+					.pop()
+					.expect("Should have 1 element!");
+
+				if let ForgeOutput::Minted(avatar) = minted_blueprint {
+					assert!(AvatarUtils::has_attribute_with_value(
+						&avatar,
+						AvatarAttributes::ItemType,
+						ItemType::Blueprint
+					));
+				} else {
+					panic!("ForgeOutput of blueprint should have been Minted!");
+				}
+			} else {
+				panic!("LeaderForgeOutput should have been Consumed!");
+			}
+		})
+	}
+
+	#[test]
+	fn test_tinker_success_all_materials_left() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
+
+			let pet_type = PetType::FoxishDude;
+			let slot_type = SlotType::Head;
+
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				EquipableItemType::ArmorBase.as_byte() as usize,
+			);
+
+			assert_eq!(
+				pattern,
+				vec![
+					MaterialItemType::Optics,
+					MaterialItemType::Superconductors,
+					MaterialItemType::Ceramics,
+					MaterialItemType::PowerCells
+				]
+			);
+
+			let pet_part_input_1 = create_random_pet_part(&ALICE, pet_type, slot_type, 2);
+
+			let material_input_1 = create_random_material(&ALICE, pattern[0], 2);
+			let material_input_2 = create_random_material(&ALICE, pattern[1], 2);
+			let material_input_3 = create_random_material(&ALICE, pattern[2], 2);
+			let material_input_4 = create_random_material(&ALICE, pattern[3], 2);
+
+			let total_soul_points = pet_part_input_1.1.souls +
+				material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+			assert_eq!(total_soul_points, 10);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::tinker_avatars(
+				pet_part_input_1,
+				vec![material_input_1, material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 5);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 0);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			if let LeaderForgeOutput::Forged((_, leader), _) = leader_output {
+				assert_eq!(AvatarUtils::read_attribute(&leader, AvatarAttributes::Quantity), 1);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!");
+			}
+
+			let minted_blueprint = sacrifice_output
+				.into_iter()
+				.filter(|output| is_minted(output))
+				.collect::<Vec<ForgeOutput<Test>>>()
+				.pop()
+				.expect("Should have 1 element!");
+
+			if let ForgeOutput::Minted(avatar) = minted_blueprint {
+				assert!(AvatarUtils::has_attribute_with_value(
+					&avatar,
+					AvatarAttributes::ItemType,
+					ItemType::Blueprint
+				));
+
+				assert_eq!(AvatarUtils::read_attribute(&avatar, AvatarAttributes::Quantity), 5);
+			} else {
+				panic!("ForgeOutput of blueprint should have been Minted!");
+			}
+		})
+	}
+
+	#[test]
+	fn test_tinker_failure_wrong_material_order() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
+
+			let pet_type = PetType::FoxishDude;
+			let slot_type = SlotType::Head;
+
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				EquipableItemType::ArmorBase.as_byte() as usize,
+			);
+
+			assert_eq!(
+				pattern,
+				vec![
+					MaterialItemType::Optics,
+					MaterialItemType::Superconductors,
+					MaterialItemType::Ceramics,
+					MaterialItemType::PowerCells
+				]
+			);
+
+			let pet_part_input_1 = create_random_pet_part(&ALICE, pet_type, slot_type, 1);
+
+			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, pattern[2], 1);
+			let material_input_3 = create_random_material(&ALICE, pattern[1], 1);
+			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+
+			let total_soul_points = pet_part_input_1.1.souls +
+				material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+			assert_eq!(total_soul_points, 5);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::tinker_avatars(
+				pet_part_input_1,
+				vec![material_input_1, material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 0);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 0);
+
+			if let LeaderForgeOutput::Forged((_, leader), _) = leader_output {
+				let leader_quantity =
+					AvatarUtils::read_attribute(&leader, AvatarAttributes::Quantity) as u32;
+				assert_eq!(leader_quantity, 1);
+
+				assert_eq!(
+					sacrifice_output
+						.iter()
+						.map(|output| {
+							match output {
+								ForgeOutput::Forged((_, avatar), _) =>
+									AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity)
+										as u32,
+								_ => 0,
+							}
+						})
+						.sum::<u32>(),
+					(total_soul_points - leader_quantity)
+				);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!");
+			}
+		});
+	}
+
+	#[test]
+	fn test_tinker_failure_wrong_material() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
+
+			let pet_type = PetType::FoxishDude;
+			let slot_type = SlotType::Head;
+
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				EquipableItemType::ArmorBase.as_byte() as usize,
+			);
+
+			assert_eq!(
+				pattern,
+				vec![
+					MaterialItemType::Optics,
+					MaterialItemType::Superconductors,
+					MaterialItemType::Ceramics,
+					MaterialItemType::PowerCells
+				]
+			);
+
+			let pet_part_input_1 = create_random_pet_part(&ALICE, pet_type, slot_type, 1);
+
+			let material_input_1 = create_random_material(&ALICE, MaterialItemType::Metals, 1);
+			let material_input_2 = create_random_material(&ALICE, MaterialItemType::Ceramics, 1);
+			let material_input_3 =
+				create_random_material(&ALICE, MaterialItemType::Superconductors, 1);
+			let material_input_4 = create_random_material(&ALICE, MaterialItemType::Electronics, 1);
+
+			let total_soul_points = pet_part_input_1.1.souls +
+				material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+			assert_eq!(total_soul_points, 5);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::tinker_avatars(
+				pet_part_input_1,
+				vec![material_input_1, material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 0);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_forged(output)).count(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 0);
+
+			if let LeaderForgeOutput::Forged((_, leader), _) = leader_output {
+				let leader_quantity =
+					AvatarUtils::read_attribute(&leader, AvatarAttributes::Quantity) as u32;
+				assert_eq!(leader_quantity, 1);
+
+				assert_eq!(
+					sacrifice_output
+						.iter()
+						.map(|output| {
+							match output {
+								ForgeOutput::Forged((_, avatar), _) =>
+									AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity)
+										as u32,
+								_ => 0,
+							}
+						})
+						.sum::<u32>(),
+					(total_soul_points - leader_quantity)
+				);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!");
+			}
+		});
+	}
+
+	#[test]
+	fn test_tinker_success_on_other_pattern() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season_id = 0 as SeasonId;
+			let mut hash_provider = HashProvider::new_with_bytes(HASH_BYTES);
+
+			let pet_type = PetType::TankyBullwog;
+			let slot_type = SlotType::Breast;
+
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				EquipableItemType::ArmorComponent3.as_byte() as usize,
+			);
+
+			assert_eq!(
+				pattern,
+				vec![
+					MaterialItemType::PowerCells,
+					MaterialItemType::Ceramics,
+					MaterialItemType::Superconductors,
+					MaterialItemType::Electronics
+				]
+			);
+
+			let pet_part_input_1 = create_random_pet_part(&ALICE, pet_type, slot_type, 1);
+
+			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, pattern[1], 1);
+			let material_input_3 = create_random_material(&ALICE, pattern[2], 1);
+			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+
+			let total_soul_points = pet_part_input_1.1.souls +
+				material_input_1.1.souls +
+				material_input_2.1.souls +
+				material_input_3.1.souls +
+				material_input_4.1.souls;
+			assert_eq!(total_soul_points, 5);
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::tinker_avatars(
+				pet_part_input_1,
+				vec![material_input_1, material_input_2, material_input_3, material_input_4],
+				season_id,
+				&mut hash_provider,
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 5);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
+
+			if let LeaderForgeOutput::Consumed(_) = leader_output {
+				let minted_blueprint = sacrifice_output
+					.into_iter()
+					.filter(|output| is_minted(output))
+					.collect::<Vec<ForgeOutput<Test>>>()
+					.pop()
+					.expect("Should have 1 element!");
+
+				if let ForgeOutput::Minted(avatar) = minted_blueprint {
+					assert!(AvatarUtils::has_attribute_with_value(
+						&avatar,
+						AvatarAttributes::ItemType,
+						ItemType::Blueprint
+					));
+					assert_eq!(
+						AvatarUtils::read_spec_byte(&avatar, AvatarSpecBytes::SpecByte3),
+						EquipableItemType::ArmorComponent3.as_byte()
+					);
+					assert_eq!(
+						AvatarUtils::read_attribute(&avatar, AvatarAttributes::Quantity),
+						total_soul_points as u8
+					);
+					assert_eq!(avatar.souls, total_soul_points);
+
+					let avatar_dna = avatar.dna.as_slice();
+					let expected_dna: [u8; 12] =
+						[0x51, 0x21, 0x13, 0x05, 0x00, 0x66, 0x6C, 0x04, 0x01, 0x01, 0x01, 0x01];
+
+					assert_eq!(&avatar_dna[0..12], &expected_dna);
+				} else {
+					panic!("ForgeOutput of blueprint should have been Minted!");
+				}
+			} else {
+				panic!("LeaderForgeOutput should have been Consumed!");
+			}
+		});
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/tinker.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/combinator/tinker.rs
@@ -1,9 +1,6 @@
 use super::*;
 
-impl<'a, T> AvatarCombinator<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarCombinator<T> {
 	pub(super) fn tinker_avatars(
 		input_leader: ForgeItem<T>,
 		input_sacrifices: Vec<ForgeItem<T>>,
@@ -20,7 +17,7 @@ where
 			.map(|(_, sacrifice)| {
 				AvatarUtils::read_attribute_as::<MaterialItemType>(
 					sacrifice,
-					AvatarAttributes::ItemSubType,
+					&AvatarAttributes::ItemSubType,
 				)
 			})
 			.collect::<Vec<MaterialItemType>>();
@@ -61,7 +58,7 @@ where
 				soul_points += out_soul_points;
 
 				let sacrifice_output =
-					if AvatarUtils::read_attribute(&sacrifice, AvatarAttributes::Quantity) == 0 {
+					if AvatarUtils::read_attribute(&sacrifice, &AvatarAttributes::Quantity) == 0 {
 						ForgeOutput::Consumed(sacrifice_id)
 					} else {
 						ForgeOutput::Forged((sacrifice_id, sacrifice), 0)
@@ -91,20 +88,20 @@ where
 			};
 
 			let pet_type =
-				AvatarUtils::read_attribute_as::<PetType>(&leader, AvatarAttributes::ClassType2);
+				AvatarUtils::read_attribute_as::<PetType>(&leader, &AvatarAttributes::ClassType2);
 
 			let slot_type =
-				AvatarUtils::read_attribute_as::<SlotType>(&leader, AvatarAttributes::ClassType1);
+				AvatarUtils::read_attribute_as::<SlotType>(&leader, &AvatarAttributes::ClassType1);
 
 			let dna =
 				AvatarMinterV2::<T>(PhantomData).generate_base_avatar_dna(hash_provider, 6)?;
 			let generated_blueprint = AvatarBuilder::with_dna(season_id, dna)
 				.into_blueprint(
-					BlueprintItemType::Blueprint,
-					pet_type,
-					slot_type,
-					equipable_item_type,
-					sacrifice_pattern,
+					&BlueprintItemType::Blueprint,
+					&pet_type,
+					&slot_type,
+					&equipable_item_type,
+					&sacrifice_pattern,
 					soul_points as SoulCount,
 				)
 				.build();
@@ -157,12 +154,11 @@ mod test {
 				]
 			);
 
-			let pet_part_input_1 = create_random_pet_part(&ALICE, pet_type, slot_type, 1);
-
-			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
-			let material_input_2 = create_random_material(&ALICE, pattern[1], 1);
-			let material_input_3 = create_random_material(&ALICE, pattern[2], 1);
-			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+			let pet_part_input_1 = create_random_pet_part(&ALICE, &pet_type, &slot_type, 1);
+			let material_input_1 = create_random_material(&ALICE, &pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, &pattern[1], 1);
+			let material_input_3 = create_random_material(&ALICE, &pattern[2], 1);
+			let material_input_4 = create_random_material(&ALICE, &pattern[3], 1);
 
 			let total_soul_points = pet_part_input_1.1.souls +
 				material_input_1.1.souls +
@@ -194,15 +190,15 @@ mod test {
 				if let ForgeOutput::Minted(avatar) = minted_blueprint {
 					assert!(AvatarUtils::has_attribute_with_value(
 						&avatar,
-						AvatarAttributes::ItemType,
+						&AvatarAttributes::ItemType,
 						ItemType::Blueprint
 					));
 					assert_eq!(
-						AvatarUtils::read_spec_byte(&avatar, AvatarSpecBytes::SpecByte3),
+						AvatarUtils::read_spec_byte(&avatar, &AvatarSpecBytes::SpecByte3),
 						EquipableItemType::ArmorBase.as_byte()
 					);
 					assert_eq!(
-						AvatarUtils::read_attribute(&avatar, AvatarAttributes::Quantity),
+						AvatarUtils::read_attribute(&avatar, &AvatarAttributes::Quantity),
 						total_soul_points as u8
 					);
 					assert_eq!(avatar.souls, total_soul_points);
@@ -240,12 +236,11 @@ mod test {
 				]
 			);
 
-			let pet_part_input_1 = create_random_pet_part(&ALICE, pet_type, slot_type, 1);
-
-			let material_input_1 = create_random_material(&ALICE, pattern[0], 2);
-			let material_input_2 = create_random_material(&ALICE, pattern[1], 1);
-			let material_input_3 = create_random_material(&ALICE, pattern[2], 2);
-			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+			let pet_part_input_1 = create_random_pet_part(&ALICE, &pet_type, &slot_type, 1);
+			let material_input_1 = create_random_material(&ALICE, &pattern[0], 2);
+			let material_input_2 = create_random_material(&ALICE, &pattern[1], 1);
+			let material_input_3 = create_random_material(&ALICE, &pattern[2], 2);
+			let material_input_4 = create_random_material(&ALICE, &pattern[3], 1);
 
 			let total_soul_points = pet_part_input_1.1.souls +
 				material_input_1.1.souls +
@@ -292,7 +287,7 @@ mod test {
 				if let ForgeOutput::Minted(avatar) = minted_blueprint {
 					assert!(AvatarUtils::has_attribute_with_value(
 						&avatar,
-						AvatarAttributes::ItemType,
+						&AvatarAttributes::ItemType,
 						ItemType::Blueprint
 					));
 				} else {
@@ -329,12 +324,11 @@ mod test {
 				]
 			);
 
-			let pet_part_input_1 = create_random_pet_part(&ALICE, pet_type, slot_type, 2);
-
-			let material_input_1 = create_random_material(&ALICE, pattern[0], 2);
-			let material_input_2 = create_random_material(&ALICE, pattern[1], 2);
-			let material_input_3 = create_random_material(&ALICE, pattern[2], 2);
-			let material_input_4 = create_random_material(&ALICE, pattern[3], 2);
+			let pet_part_input_1 = create_random_pet_part(&ALICE, &pet_type, &slot_type, 2);
+			let material_input_1 = create_random_material(&ALICE, &pattern[0], 2);
+			let material_input_2 = create_random_material(&ALICE, &pattern[1], 2);
+			let material_input_3 = create_random_material(&ALICE, &pattern[2], 2);
+			let material_input_4 = create_random_material(&ALICE, &pattern[3], 2);
 
 			let total_soul_points = pet_part_input_1.1.souls +
 				material_input_1.1.souls +
@@ -357,7 +351,7 @@ mod test {
 			assert_eq!(sacrifice_output.iter().filter(|output| is_minted(output)).count(), 1);
 
 			if let LeaderForgeOutput::Forged((_, leader), _) = leader_output {
-				assert_eq!(AvatarUtils::read_attribute(&leader, AvatarAttributes::Quantity), 1);
+				assert_eq!(AvatarUtils::read_attribute(&leader, &AvatarAttributes::Quantity), 1);
 			} else {
 				panic!("LeaderForgeOutput should have been Forged!");
 			}
@@ -372,11 +366,11 @@ mod test {
 			if let ForgeOutput::Minted(avatar) = minted_blueprint {
 				assert!(AvatarUtils::has_attribute_with_value(
 					&avatar,
-					AvatarAttributes::ItemType,
+					&AvatarAttributes::ItemType,
 					ItemType::Blueprint
 				));
 
-				assert_eq!(AvatarUtils::read_attribute(&avatar, AvatarAttributes::Quantity), 5);
+				assert_eq!(AvatarUtils::read_attribute(&avatar, &AvatarAttributes::Quantity), 5);
 			} else {
 				panic!("ForgeOutput of blueprint should have been Minted!");
 			}
@@ -408,12 +402,11 @@ mod test {
 				]
 			);
 
-			let pet_part_input_1 = create_random_pet_part(&ALICE, pet_type, slot_type, 1);
-
-			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
-			let material_input_2 = create_random_material(&ALICE, pattern[2], 1);
-			let material_input_3 = create_random_material(&ALICE, pattern[1], 1);
-			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+			let pet_part_input_1 = create_random_pet_part(&ALICE, &pet_type, &slot_type, 1);
+			let material_input_1 = create_random_material(&ALICE, &pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, &pattern[2], 1);
+			let material_input_3 = create_random_material(&ALICE, &pattern[1], 1);
+			let material_input_4 = create_random_material(&ALICE, &pattern[3], 1);
 
 			let total_soul_points = pet_part_input_1.1.souls +
 				material_input_1.1.souls +
@@ -437,7 +430,7 @@ mod test {
 
 			if let LeaderForgeOutput::Forged((_, leader), _) = leader_output {
 				let leader_quantity =
-					AvatarUtils::read_attribute(&leader, AvatarAttributes::Quantity) as u32;
+					AvatarUtils::read_attribute(&leader, &AvatarAttributes::Quantity) as u32;
 				assert_eq!(leader_quantity, 1);
 
 				assert_eq!(
@@ -446,7 +439,7 @@ mod test {
 						.map(|output| {
 							match output {
 								ForgeOutput::Forged((_, avatar), _) =>
-									AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity)
+									AvatarUtils::read_attribute(avatar, &AvatarAttributes::Quantity)
 										as u32,
 								_ => 0,
 							}
@@ -485,13 +478,13 @@ mod test {
 				]
 			);
 
-			let pet_part_input_1 = create_random_pet_part(&ALICE, pet_type, slot_type, 1);
-
-			let material_input_1 = create_random_material(&ALICE, MaterialItemType::Metals, 1);
-			let material_input_2 = create_random_material(&ALICE, MaterialItemType::Ceramics, 1);
+			let pet_part_input_1 = create_random_pet_part(&ALICE, &pet_type, &slot_type, 1);
+			let material_input_1 = create_random_material(&ALICE, &MaterialItemType::Metals, 1);
+			let material_input_2 = create_random_material(&ALICE, &MaterialItemType::Ceramics, 1);
 			let material_input_3 =
-				create_random_material(&ALICE, MaterialItemType::Superconductors, 1);
-			let material_input_4 = create_random_material(&ALICE, MaterialItemType::Electronics, 1);
+				create_random_material(&ALICE, &MaterialItemType::Superconductors, 1);
+			let material_input_4 =
+				create_random_material(&ALICE, &MaterialItemType::Electronics, 1);
 
 			let total_soul_points = pet_part_input_1.1.souls +
 				material_input_1.1.souls +
@@ -515,7 +508,7 @@ mod test {
 
 			if let LeaderForgeOutput::Forged((_, leader), _) = leader_output {
 				let leader_quantity =
-					AvatarUtils::read_attribute(&leader, AvatarAttributes::Quantity) as u32;
+					AvatarUtils::read_attribute(&leader, &AvatarAttributes::Quantity) as u32;
 				assert_eq!(leader_quantity, 1);
 
 				assert_eq!(
@@ -524,7 +517,7 @@ mod test {
 						.map(|output| {
 							match output {
 								ForgeOutput::Forged((_, avatar), _) =>
-									AvatarUtils::read_attribute(avatar, AvatarAttributes::Quantity)
+									AvatarUtils::read_attribute(avatar, &AvatarAttributes::Quantity)
 										as u32,
 								_ => 0,
 							}
@@ -563,12 +556,11 @@ mod test {
 				]
 			);
 
-			let pet_part_input_1 = create_random_pet_part(&ALICE, pet_type, slot_type, 1);
-
-			let material_input_1 = create_random_material(&ALICE, pattern[0], 1);
-			let material_input_2 = create_random_material(&ALICE, pattern[1], 1);
-			let material_input_3 = create_random_material(&ALICE, pattern[2], 1);
-			let material_input_4 = create_random_material(&ALICE, pattern[3], 1);
+			let pet_part_input_1 = create_random_pet_part(&ALICE, &pet_type, &slot_type, 1);
+			let material_input_1 = create_random_material(&ALICE, &pattern[0], 1);
+			let material_input_2 = create_random_material(&ALICE, &pattern[1], 1);
+			let material_input_3 = create_random_material(&ALICE, &pattern[2], 1);
+			let material_input_4 = create_random_material(&ALICE, &pattern[3], 1);
 
 			let total_soul_points = pet_part_input_1.1.souls +
 				material_input_1.1.souls +
@@ -600,21 +592,21 @@ mod test {
 				if let ForgeOutput::Minted(avatar) = minted_blueprint {
 					assert!(AvatarUtils::has_attribute_with_value(
 						&avatar,
-						AvatarAttributes::ItemType,
+						&AvatarAttributes::ItemType,
 						ItemType::Blueprint
 					));
 					assert_eq!(
-						AvatarUtils::read_spec_byte(&avatar, AvatarSpecBytes::SpecByte3),
+						AvatarUtils::read_spec_byte(&avatar, &AvatarSpecBytes::SpecByte3),
 						EquipableItemType::ArmorComponent3.as_byte()
 					);
 					assert_eq!(
-						AvatarUtils::read_attribute(&avatar, AvatarAttributes::Quantity),
+						AvatarUtils::read_attribute(&avatar, &AvatarAttributes::Quantity),
 						total_soul_points as u8
 					);
 					assert_eq!(avatar.souls, total_soul_points);
 
 					let avatar_dna = avatar.dna.as_slice();
-					let expected_dna: [u8; 12] =
+					let expected_dna =
 						[0x51, 0x21, 0x13, 0x05, 0x00, 0x66, 0x6C, 0x04, 0x01, 0x01, 0x01, 0x01];
 
 					assert_eq!(&avatar_dna[0..12], &expected_dna);

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/constants.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/constants.rs
@@ -1,0 +1,236 @@
+use super::*;
+
+/*
+	   public const bool Obfuscate = false;
+	   public const byte ProgressComponents = 11;
+*/
+
+pub(crate) const MIN_SACRIFICE: usize = 1;
+pub(crate) const MAX_SACRIFICE: usize = 4;
+pub(crate) const MAX_QUANTITY: u8 = 8;
+pub(crate) const SCALING_FACTOR_PERC: u32 = 100;
+pub(crate) const MAX_EQUIPPED_SLOTS: usize = 5;
+pub(crate) const PROGRESS_VARIATIONS: u8 = 6;
+pub(crate) const STACK_PROB_PERC: u32 = 5;
+pub(crate) const PROGRESS_PROBABILITY_PERC: u32 = 15;
+pub(crate) const BASE_PROGRESS_PROB_PERC: u32 = 20;
+pub(crate) const COLOR_GLOW_SPARK: u32 = 75;
+pub(crate) const SPARK_PROGRESS_PROB_PERC: u32 = 75;
+pub(crate) const GLIMMER_FORGE_GLIMMER_USE: u8 = 1;
+pub(crate) const GLIMMER_FORGE_MATERIAL_USE: u8 = 4;
+pub(crate) const MAX_BYTE: u32 = u8::MAX as u32;
+
+/// Probabilities for all PackType::Material options
+pub(crate) const PACK_TYPE_MATERIAL_ITEM_PROBABILITIES: ProbabilitySlots<ItemType, 6> = [
+	(ItemType::Pet, 150),
+	(ItemType::Material, 700),
+	(ItemType::Essence, 50),
+	(ItemType::Equipable, 100),
+	(ItemType::Blueprint, 0),
+	(ItemType::Special, 0),
+];
+
+pub(crate) const PACK_TYPE_MATERIAL_PET_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<PetItemType, 3> =
+	[(PetItemType::Pet, 0), (PetItemType::PetPart, 980), (PetItemType::Egg, 20)];
+
+pub(crate) const PACK_TYPE_MATERIAL_MATERIAL_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	MaterialItemType,
+	8,
+> = [
+	(MaterialItemType::Polymers, 125),
+	(MaterialItemType::Electronics, 125),
+	(MaterialItemType::PowerCells, 125),
+	(MaterialItemType::Optics, 125),
+	(MaterialItemType::Metals, 125),
+	(MaterialItemType::Ceramics, 125),
+	(MaterialItemType::Superconductors, 125),
+	(MaterialItemType::Nanomaterials, 125),
+];
+
+pub(crate) const PACK_TYPE_MATERIAL_ESSENCE_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	EssenceItemType,
+	3,
+> = [
+	(EssenceItemType::Glimmer, 400),
+	(EssenceItemType::ColorSpark, 350),
+	(EssenceItemType::GlowSpark, 250),
+];
+
+pub(crate) const PACK_TYPE_MATERIAL_EQUIPABLE_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	EquipableItemType,
+	7,
+> = [
+	(EquipableItemType::ArmorBase, 820),
+	(EquipableItemType::ArmorComponent1, 50),
+	(EquipableItemType::ArmorComponent2, 50),
+	(EquipableItemType::ArmorComponent3, 50),
+	(EquipableItemType::WeaponVersion1, 10),
+	(EquipableItemType::WeaponVersion2, 10),
+	(EquipableItemType::WeaponVersion3, 10),
+];
+
+pub(crate) const PACK_TYPE_MATERIAL_BLUEPRINT_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	BlueprintItemType,
+	1,
+> = [(BlueprintItemType::Blueprint, 1000)];
+
+pub(crate) const PACK_TYPE_MATERIAL_SPECIAL_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	SpecialItemType,
+	1,
+> = [(SpecialItemType::Dust, 1000)];
+// -----------------------------------------------
+
+/// Probabilities for all PackType::Equipment options
+pub(crate) const PACK_TYPE_EQUIPMENT_ITEM_PROBABILITIES: ProbabilitySlots<ItemType, 6> = [
+	(ItemType::Pet, 90),
+	(ItemType::Material, 200),
+	(ItemType::Essence, 10),
+	(ItemType::Equipable, 700),
+	(ItemType::Blueprint, 0),
+	(ItemType::Special, 0),
+];
+
+pub(crate) const PACK_TYPE_EQUIPMENT_PET_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<PetItemType, 3> =
+	[(PetItemType::Pet, 0), (PetItemType::PetPart, 800), (PetItemType::Egg, 200)];
+
+pub(crate) const PACK_TYPE_EQUIPMENT_MATERIAL_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	MaterialItemType,
+	8,
+> = [
+	(MaterialItemType::Polymers, 125),
+	(MaterialItemType::Electronics, 125),
+	(MaterialItemType::PowerCells, 125),
+	(MaterialItemType::Optics, 125),
+	(MaterialItemType::Metals, 125),
+	(MaterialItemType::Ceramics, 125),
+	(MaterialItemType::Superconductors, 125),
+	(MaterialItemType::Nanomaterials, 125),
+];
+
+pub(crate) const PACK_TYPE_EQUIPMENT_ESSENCE_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	EssenceItemType,
+	3,
+> = [
+	(EssenceItemType::Glimmer, 400),
+	(EssenceItemType::ColorSpark, 350),
+	(EssenceItemType::GlowSpark, 250),
+];
+
+pub(crate) const PACK_TYPE_EQUIPMENT_EQUIPABLE_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	EquipableItemType,
+	7,
+> = [
+	(EquipableItemType::ArmorBase, 820),
+	(EquipableItemType::ArmorComponent1, 50),
+	(EquipableItemType::ArmorComponent2, 50),
+	(EquipableItemType::ArmorComponent3, 50),
+	(EquipableItemType::WeaponVersion1, 10),
+	(EquipableItemType::WeaponVersion2, 10),
+	(EquipableItemType::WeaponVersion3, 10),
+];
+
+pub(crate) const PACK_TYPE_EQUIPMENT_BLUEPRINT_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	BlueprintItemType,
+	1,
+> = [(BlueprintItemType::Blueprint, 1000)];
+
+pub(crate) const PACK_TYPE_EQUIPMENT_SPECIAL_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	SpecialItemType,
+	1,
+> = [(SpecialItemType::Dust, 1000)];
+// -----------------------------------------------
+
+/// Probabilities for all PackType::Special options
+pub(crate) const PACK_TYPE_SPECIAL_ITEM_PROBABILITIES: ProbabilitySlots<ItemType, 6> = [
+	(ItemType::Pet, 100),
+	(ItemType::Material, 150),
+	(ItemType::Essence, 50),
+	(ItemType::Equipable, 700),
+	(ItemType::Blueprint, 0),
+	(ItemType::Special, 0),
+];
+
+pub(crate) const PACK_TYPE_SPECIAL_PET_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<PetItemType, 3> =
+	[(PetItemType::Pet, 0), (PetItemType::PetPart, 0), (PetItemType::Egg, 1000)];
+
+pub(crate) const PACK_TYPE_SPECIAL_MATERIAL_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	MaterialItemType,
+	8,
+> = [
+	(MaterialItemType::Polymers, 125),
+	(MaterialItemType::Electronics, 125),
+	(MaterialItemType::PowerCells, 125),
+	(MaterialItemType::Optics, 125),
+	(MaterialItemType::Metals, 125),
+	(MaterialItemType::Ceramics, 125),
+	(MaterialItemType::Superconductors, 125),
+	(MaterialItemType::Nanomaterials, 125),
+];
+
+pub(crate) const PACK_TYPE_SPECIAL_ESSENCE_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	EssenceItemType,
+	3,
+> = [
+	(EssenceItemType::Glimmer, 400),
+	(EssenceItemType::ColorSpark, 350),
+	(EssenceItemType::GlowSpark, 250),
+];
+
+pub(crate) const PACK_TYPE_SPECIAL_EQUIPABLE_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	EquipableItemType,
+	7,
+> = [
+	(EquipableItemType::ArmorBase, 250),
+	(EquipableItemType::ArmorComponent1, 200),
+	(EquipableItemType::ArmorComponent2, 200),
+	(EquipableItemType::ArmorComponent3, 200),
+	(EquipableItemType::WeaponVersion1, 50),
+	(EquipableItemType::WeaponVersion2, 50),
+	(EquipableItemType::WeaponVersion3, 50),
+];
+
+pub(crate) const PACK_TYPE_SPECIAL_BLUEPRINT_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	BlueprintItemType,
+	1,
+> = [(BlueprintItemType::Blueprint, 1000)];
+
+pub(crate) const PACK_TYPE_SPECIAL_SPECIAL_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
+	SpecialItemType,
+	1,
+> = [(SpecialItemType::Dust, 1000)];
+// -----------------------------------------------
+
+/// Probabilities for equipment slots
+pub(crate) const ARMOR_SLOT_PROBABILITIES: ProbabilitySlots<SlotType, 6> = [
+	(SlotType::Head, 170),
+	(SlotType::Breast, 170),
+	(SlotType::ArmFront, 165),
+	(SlotType::ArmBack, 165),
+	(SlotType::LegFront, 165),
+	(SlotType::LegBack, 165),
+];
+
+pub(crate) const WEAPON_SLOT_PROBABILITIES: ProbabilitySlots<SlotType, 2> =
+	[(SlotType::WeaponFront, 500), (SlotType::WeaponBack, 500)];
+
+/// Probabilities for pet type
+pub(crate) const PET_TYPE_PROBABILITIES: ProbabilitySlots<PetType, 7> = [
+	(PetType::TankyBullwog, 150),
+	(PetType::FoxishDude, 150),
+	(PetType::WierdFerry, 150),
+	(PetType::FireDino, 150),
+	(PetType::BigHybrid, 150),
+	(PetType::GiantWoodStick, 150),
+	(PetType::CrazyDude, 100),
+];
+
+/// Probabilities for equipment type
+pub(crate) const EQUIPMENT_TYPE_PROBABILITIES: ProbabilitySlots<EquipableItemType, 7> = [
+	(EquipableItemType::ArmorBase, 250),
+	(EquipableItemType::ArmorComponent1, 150),
+	(EquipableItemType::ArmorComponent3, 150),
+	(EquipableItemType::ArmorComponent3, 150),
+	(EquipableItemType::WeaponVersion1, 100),
+	(EquipableItemType::WeaponVersion2, 100),
+	(EquipableItemType::WeaponVersion3, 100),
+];

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/constants.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/constants.rs
@@ -25,9 +25,9 @@ pub(crate) const PACK_TYPE_MATERIAL_ITEM_PROBABILITIES: ProbabilitySlots<ItemTyp
 	(ItemType::Pet, 150),
 	(ItemType::Material, 700),
 	(ItemType::Essence, 50),
-	(ItemType::Equipable, 100),
+	(ItemType::Equipable, 50),
 	(ItemType::Blueprint, 0),
-	(ItemType::Special, 0),
+	(ItemType::Special, 50),
 ];
 
 pub(crate) const PACK_TYPE_MATERIAL_PET_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<PetItemType, 3> =
@@ -49,21 +49,23 @@ pub(crate) const PACK_TYPE_MATERIAL_MATERIAL_ITEM_TYPE_PROBABILITIES: Probabilit
 
 pub(crate) const PACK_TYPE_MATERIAL_ESSENCE_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
 	EssenceItemType,
-	3,
+	5,
 > = [
-	(EssenceItemType::Glimmer, 400),
-	(EssenceItemType::ColorSpark, 350),
-	(EssenceItemType::GlowSpark, 250),
+	(EssenceItemType::Glimmer, 800),
+	(EssenceItemType::ColorSpark, 50),
+	(EssenceItemType::GlowSpark, 50),
+	(EssenceItemType::PaintFlask, 10),
+	(EssenceItemType::ForceGlow, 10),
 ];
 
 pub(crate) const PACK_TYPE_MATERIAL_EQUIPABLE_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
 	EquipableItemType,
 	7,
 > = [
-	(EquipableItemType::ArmorBase, 820),
-	(EquipableItemType::ArmorComponent1, 50),
-	(EquipableItemType::ArmorComponent2, 50),
-	(EquipableItemType::ArmorComponent3, 50),
+	(EquipableItemType::ArmorBase, 970),
+	(EquipableItemType::ArmorComponent1, 0),
+	(EquipableItemType::ArmorComponent2, 0),
+	(EquipableItemType::ArmorComponent3, 0),
 	(EquipableItemType::WeaponVersion1, 10),
 	(EquipableItemType::WeaponVersion2, 10),
 	(EquipableItemType::WeaponVersion3, 10),
@@ -76,22 +78,22 @@ pub(crate) const PACK_TYPE_MATERIAL_BLUEPRINT_ITEM_TYPE_PROBABILITIES: Probabili
 
 pub(crate) const PACK_TYPE_MATERIAL_SPECIAL_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
 	SpecialItemType,
-	1,
-> = [(SpecialItemType::Dust, 1000)];
+	2,
+> = [(SpecialItemType::Dust, 990), (SpecialItemType::Unidentified, 10)];
 // -----------------------------------------------
 
 /// Probabilities for all PackType::Equipment options
 pub(crate) const PACK_TYPE_EQUIPMENT_ITEM_PROBABILITIES: ProbabilitySlots<ItemType, 6> = [
-	(ItemType::Pet, 90),
-	(ItemType::Material, 200),
-	(ItemType::Essence, 10),
-	(ItemType::Equipable, 700),
+	(ItemType::Pet, 100),
+	(ItemType::Material, 350),
+	(ItemType::Essence, 300),
+	(ItemType::Equipable, 50),
 	(ItemType::Blueprint, 0),
-	(ItemType::Special, 0),
+	(ItemType::Special, 200),
 ];
 
 pub(crate) const PACK_TYPE_EQUIPMENT_PET_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<PetItemType, 3> =
-	[(PetItemType::Pet, 0), (PetItemType::PetPart, 800), (PetItemType::Egg, 200)];
+	[(PetItemType::Pet, 20), (PetItemType::PetPart, 800), (PetItemType::Egg, 180)];
 
 pub(crate) const PACK_TYPE_EQUIPMENT_MATERIAL_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
 	MaterialItemType,
@@ -109,24 +111,26 @@ pub(crate) const PACK_TYPE_EQUIPMENT_MATERIAL_ITEM_TYPE_PROBABILITIES: Probabili
 
 pub(crate) const PACK_TYPE_EQUIPMENT_ESSENCE_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
 	EssenceItemType,
-	3,
+	5,
 > = [
-	(EssenceItemType::Glimmer, 400),
-	(EssenceItemType::ColorSpark, 350),
-	(EssenceItemType::GlowSpark, 250),
+	(EssenceItemType::Glimmer, 550),
+	(EssenceItemType::ColorSpark, 175),
+	(EssenceItemType::GlowSpark, 175),
+	(EssenceItemType::PaintFlask, 50),
+	(EssenceItemType::ForceGlow, 50),
 ];
 
 pub(crate) const PACK_TYPE_EQUIPMENT_EQUIPABLE_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
 	EquipableItemType,
 	7,
 > = [
-	(EquipableItemType::ArmorBase, 820),
-	(EquipableItemType::ArmorComponent1, 50),
-	(EquipableItemType::ArmorComponent2, 50),
-	(EquipableItemType::ArmorComponent3, 50),
-	(EquipableItemType::WeaponVersion1, 10),
-	(EquipableItemType::WeaponVersion2, 10),
-	(EquipableItemType::WeaponVersion3, 10),
+	(EquipableItemType::ArmorBase, 10),
+	(EquipableItemType::ArmorComponent1, 250),
+	(EquipableItemType::ArmorComponent2, 250),
+	(EquipableItemType::ArmorComponent3, 250),
+	(EquipableItemType::WeaponVersion1, 80),
+	(EquipableItemType::WeaponVersion2, 80),
+	(EquipableItemType::WeaponVersion3, 80),
 ];
 
 pub(crate) const PACK_TYPE_EQUIPMENT_BLUEPRINT_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
@@ -136,22 +140,22 @@ pub(crate) const PACK_TYPE_EQUIPMENT_BLUEPRINT_ITEM_TYPE_PROBABILITIES: Probabil
 
 pub(crate) const PACK_TYPE_EQUIPMENT_SPECIAL_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
 	SpecialItemType,
-	1,
-> = [(SpecialItemType::Dust, 1000)];
+	2,
+> = [(SpecialItemType::Dust, 990), (SpecialItemType::Unidentified, 10)];
 // -----------------------------------------------
 
 /// Probabilities for all PackType::Special options
 pub(crate) const PACK_TYPE_SPECIAL_ITEM_PROBABILITIES: ProbabilitySlots<ItemType, 6> = [
-	(ItemType::Pet, 100),
-	(ItemType::Material, 150),
-	(ItemType::Essence, 50),
-	(ItemType::Equipable, 700),
+	(ItemType::Pet, 300),
+	(ItemType::Material, 350),
+	(ItemType::Essence, 100),
+	(ItemType::Equipable, 50),
 	(ItemType::Blueprint, 0),
-	(ItemType::Special, 0),
+	(ItemType::Special, 200),
 ];
 
 pub(crate) const PACK_TYPE_SPECIAL_PET_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<PetItemType, 3> =
-	[(PetItemType::Pet, 0), (PetItemType::PetPart, 0), (PetItemType::Egg, 1000)];
+	[(PetItemType::Pet, 10), (PetItemType::PetPart, 390), (PetItemType::Egg, 600)];
 
 pub(crate) const PACK_TYPE_SPECIAL_MATERIAL_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
 	MaterialItemType,
@@ -169,24 +173,26 @@ pub(crate) const PACK_TYPE_SPECIAL_MATERIAL_ITEM_TYPE_PROBABILITIES: Probability
 
 pub(crate) const PACK_TYPE_SPECIAL_ESSENCE_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
 	EssenceItemType,
-	3,
+	5,
 > = [
-	(EssenceItemType::Glimmer, 400),
-	(EssenceItemType::ColorSpark, 350),
-	(EssenceItemType::GlowSpark, 250),
+	(EssenceItemType::Glimmer, 800),
+	(EssenceItemType::ColorSpark, 75),
+	(EssenceItemType::GlowSpark, 75),
+	(EssenceItemType::PaintFlask, 25),
+	(EssenceItemType::ForceGlow, 25),
 ];
 
 pub(crate) const PACK_TYPE_SPECIAL_EQUIPABLE_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
 	EquipableItemType,
 	7,
 > = [
-	(EquipableItemType::ArmorBase, 250),
-	(EquipableItemType::ArmorComponent1, 200),
-	(EquipableItemType::ArmorComponent2, 200),
-	(EquipableItemType::ArmorComponent3, 200),
-	(EquipableItemType::WeaponVersion1, 50),
-	(EquipableItemType::WeaponVersion2, 50),
-	(EquipableItemType::WeaponVersion3, 50),
+	(EquipableItemType::ArmorBase, 10),
+	(EquipableItemType::ArmorComponent1, 250),
+	(EquipableItemType::ArmorComponent2, 250),
+	(EquipableItemType::ArmorComponent3, 250),
+	(EquipableItemType::WeaponVersion1, 80),
+	(EquipableItemType::WeaponVersion2, 80),
+	(EquipableItemType::WeaponVersion3, 80),
 ];
 
 pub(crate) const PACK_TYPE_SPECIAL_BLUEPRINT_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
@@ -196,8 +202,8 @@ pub(crate) const PACK_TYPE_SPECIAL_BLUEPRINT_ITEM_TYPE_PROBABILITIES: Probabilit
 
 pub(crate) const PACK_TYPE_SPECIAL_SPECIAL_ITEM_TYPE_PROBABILITIES: ProbabilitySlots<
 	SpecialItemType,
-	1,
-> = [(SpecialItemType::Dust, 1000)];
+	2,
+> = [(SpecialItemType::Dust, 990), (SpecialItemType::Unidentified, 10)];
 // -----------------------------------------------
 
 /// Probabilities for equipment slots

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/mod.rs
@@ -1,0 +1,932 @@
+mod avatar_utils;
+mod combinator;
+mod constants;
+mod mutator;
+mod slot_roller;
+#[cfg(test)]
+mod test_utils;
+mod types;
+
+pub(self) use avatar_utils::*;
+pub(self) use combinator::*;
+pub(self) use constants::*;
+pub(self) use mutator::*;
+pub(self) use slot_roller::*;
+#[cfg(test)]
+pub(self) use test_utils::*;
+pub(self) use types::*;
+
+use super::*;
+use crate::{
+	pallet::SeasonOf,
+	types::{MintOption, SeasonId},
+	Config,
+};
+use sp_runtime::DispatchError;
+use sp_std::prelude::*;
+
+pub(super) struct AttributeMapperV2;
+
+impl AttributeMapper for AttributeMapperV2 {
+	fn min_tier(&self, target: &Avatar) -> u8 {
+		AvatarUtils::read_attribute(target, AvatarAttributes::RarityType).saturating_sub(1)
+	}
+
+	fn last_variation(&self, target: &Avatar) -> u8 {
+		// TODO: Determine proper mapping
+		AvatarUtils::read_spec_byte(target, AvatarSpecBytes::SpecByte1).saturating_sub(1)
+	}
+}
+
+pub(super) struct AvatarMinterV2<'a, T: Config>(pub PhantomData<&'a T>);
+
+impl<'a, T> Minter<T> for AvatarMinterV2<'a, T>
+where
+	T: Config,
+{
+	fn mint_avatar_set(
+		&self,
+		player: &T::AccountId,
+		season_id: &SeasonId,
+		_season: &SeasonOf<T>,
+		mint_option: &MintOption,
+	) -> Result<Vec<MintOutput<T>>, DispatchError> {
+		self.mint_avatar_set_for(player, season_id, mint_option)
+	}
+}
+
+impl<'a, T> AvatarMinterV2<'a, T>
+where
+	T: Config,
+{
+	pub(super) fn generate_base_avatar_dna(
+		&self,
+		hash_provider: &mut HashProvider<T, 32>,
+		starting_index: usize,
+	) -> Result<Dna, DispatchError> {
+		let base_hash = hash_provider.full_hash(starting_index);
+
+		Dna::try_from(base_hash.as_ref()[0..32].to_vec())
+			.map_err(|_| Error::<T>::IncorrectDna.into())
+	}
+
+	fn get_mutator_from_item_type(
+		&self,
+		pack_type: PackType,
+		item_type: ItemType,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Box<dyn AvatarMutator<T>> {
+		match item_type {
+			ItemType::Pet => Box::new(SlotRoller::<T>::roll_on_pack_type(
+				pack_type,
+				&PACK_TYPE_MATERIAL_PET_ITEM_TYPE_PROBABILITIES,
+				&PACK_TYPE_EQUIPMENT_PET_ITEM_TYPE_PROBABILITIES,
+				&PACK_TYPE_SPECIAL_PET_ITEM_TYPE_PROBABILITIES,
+				hash_provider,
+			)),
+			ItemType::Material => Box::new(SlotRoller::<T>::roll_on_pack_type(
+				pack_type,
+				&PACK_TYPE_MATERIAL_MATERIAL_ITEM_TYPE_PROBABILITIES,
+				&PACK_TYPE_EQUIPMENT_MATERIAL_ITEM_TYPE_PROBABILITIES,
+				&PACK_TYPE_SPECIAL_MATERIAL_ITEM_TYPE_PROBABILITIES,
+				hash_provider,
+			)),
+			ItemType::Essence => Box::new(SlotRoller::<T>::roll_on_pack_type(
+				pack_type,
+				&PACK_TYPE_MATERIAL_ESSENCE_ITEM_TYPE_PROBABILITIES,
+				&PACK_TYPE_EQUIPMENT_ESSENCE_ITEM_TYPE_PROBABILITIES,
+				&PACK_TYPE_SPECIAL_ESSENCE_ITEM_TYPE_PROBABILITIES,
+				hash_provider,
+			)),
+			ItemType::Equipable => Box::new(SlotRoller::<T>::roll_on_pack_type(
+				pack_type,
+				&PACK_TYPE_MATERIAL_EQUIPABLE_ITEM_TYPE_PROBABILITIES,
+				&PACK_TYPE_EQUIPMENT_EQUIPABLE_ITEM_TYPE_PROBABILITIES,
+				&PACK_TYPE_SPECIAL_EQUIPABLE_ITEM_TYPE_PROBABILITIES,
+				hash_provider,
+			)),
+			ItemType::Blueprint => Box::new(SlotRoller::<T>::roll_on_pack_type(
+				pack_type,
+				&PACK_TYPE_MATERIAL_BLUEPRINT_ITEM_TYPE_PROBABILITIES,
+				&PACK_TYPE_EQUIPMENT_BLUEPRINT_ITEM_TYPE_PROBABILITIES,
+				&PACK_TYPE_SPECIAL_BLUEPRINT_ITEM_TYPE_PROBABILITIES,
+				hash_provider,
+			)),
+			ItemType::Special => Box::new(SlotRoller::<T>::roll_on_pack_type(
+				pack_type,
+				&PACK_TYPE_MATERIAL_SPECIAL_ITEM_TYPE_PROBABILITIES,
+				&PACK_TYPE_EQUIPMENT_SPECIAL_ITEM_TYPE_PROBABILITIES,
+				&PACK_TYPE_SPECIAL_SPECIAL_ITEM_TYPE_PROBABILITIES,
+				hash_provider,
+			)),
+		}
+	}
+
+	fn mint_avatar_set_for(
+		&self,
+		player: &T::AccountId,
+		season_id: &SeasonId,
+		mint_option: &MintOption,
+	) -> Result<Vec<MintOutput<T>>, DispatchError> {
+		let mut hash_provider =
+			HashProvider::<T, 32>::new(&Pallet::<T>::random_hash(b"avatar_minter_v2", player));
+
+		let roll_amount = mint_option.count as usize;
+		let mut minted_avatars = Vec::with_capacity(roll_amount);
+
+		for i in 0..roll_amount {
+			let rolled_item_type = SlotRoller::<T>::roll_on_pack_type(
+				mint_option.mint_pack,
+				&PACK_TYPE_MATERIAL_ITEM_PROBABILITIES,
+				&PACK_TYPE_EQUIPMENT_ITEM_PROBABILITIES,
+				&PACK_TYPE_SPECIAL_ITEM_PROBABILITIES,
+				&mut hash_provider,
+			);
+
+			let avatar_id = Pallet::<T>::random_hash(b"avatar_minter_v2", player);
+
+			let dna_mutation = (i * 13) % 31;
+			let base_dna = self.generate_base_avatar_dna(&mut hash_provider, dna_mutation)?;
+			let base_avatar = Avatar {
+				season_id: *season_id,
+				version: AvatarVersion::V2,
+				dna: base_dna,
+				souls: SoulCount::zero(),
+			};
+
+			let avatar = self
+				.get_mutator_from_item_type(
+					mint_option.mint_pack,
+					rolled_item_type,
+					&mut hash_provider,
+				)
+				.mutate_from_base(base_avatar, &mut hash_provider);
+
+			minted_avatars.push((avatar_id, avatar));
+		}
+
+		Ok(minted_avatars)
+	}
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum ForgeType {
+	None = 0,
+	Stack = 1,
+	Tinker = 2,
+	Build = 3,
+	Assemble = 4,
+	Breed = 5,
+	Equip = 6,
+	Mate = 7,
+	Feed = 8,
+	Glimmer = 9,
+	Spark = 10,
+	Special = 11,
+}
+
+pub(super) struct AvatarForgerV2<'a, T: Config>(pub PhantomData<&'a T>);
+
+impl<'a, T> Forger<T> for AvatarForgerV2<'a, T>
+where
+	T: Config,
+{
+	fn forge_with(
+		&self,
+		player: &T::AccountId,
+		season_id: SeasonId,
+		season: &SeasonOf<T>,
+		input_leader: ForgeItem<T>,
+		input_sacrifices: Vec<ForgeItem<T>>,
+	) -> Result<(LeaderForgeOutput<T>, Vec<ForgeOutput<T>>), DispatchError> {
+		let mut hash_provider =
+			HashProvider::<T, 32>::new(&Pallet::<T>::random_hash(b"avatar_forger_v2", player));
+
+		self.can_be_forged(season, &input_leader, &input_sacrifices)?;
+
+		let sacrifices =
+			input_sacrifices.iter().map(|(_, sacrifice)| sacrifice).collect::<Vec<_>>();
+
+		let forge_type = self.determine_forge_type(&input_leader.1, sacrifices.as_slice());
+
+		AvatarCombinator::<T>::combine_avatars_in(
+			forge_type,
+			player,
+			season_id,
+			season,
+			input_leader,
+			input_sacrifices,
+			&mut hash_provider,
+		)
+	}
+
+	fn can_be_forged(
+		&self,
+		_season: &SeasonOf<T>,
+		input_leader: &ForgeItem<T>,
+		input_sacrifices: &[ForgeItem<T>],
+	) -> Result<(), DispatchError> {
+		if (input_leader.1.version != AvatarVersion::V2) ||
+			(input_sacrifices.len() < MIN_SACRIFICE || input_sacrifices.len() > MAX_SACRIFICE) ||
+			(input_sacrifices.iter().any(|(_, avatar)| avatar.version != AvatarVersion::V2))
+		{
+			Err(Error::<T>::IncompatibleAvatarVersions.into())
+		} else {
+			Ok(())
+		}
+	}
+}
+
+impl<'a, T> AvatarForgerV2<'a, T>
+where
+	T: Config,
+{
+	fn determine_forge_type(
+		&self,
+		input_leader: &Avatar,
+		input_sacrifices: &[&Avatar],
+	) -> ForgeType {
+		let input_leader_item_type =
+			AvatarUtils::read_attribute_as::<ItemType>(input_leader, AvatarAttributes::ItemType);
+
+		match input_leader_item_type {
+			ItemType::Pet => {
+				let leader_rarity = AvatarUtils::read_attribute_as::<RarityType>(
+					input_leader,
+					AvatarAttributes::RarityType,
+				);
+
+				let leader_sub_type = AvatarUtils::read_attribute_as::<PetItemType>(
+					input_leader,
+					AvatarAttributes::ItemSubType,
+				);
+
+				match leader_rarity {
+					RarityType::Legendary => match leader_sub_type {
+						PetItemType::Pet => {
+							if input_sacrifices.iter().all(|sacrifice| {
+								let equipable_item = AvatarUtils::read_attribute_as(
+									sacrifice,
+									AvatarAttributes::ItemSubType,
+								);
+
+								AvatarUtils::has_attribute_set_with_same_values_as(
+									input_leader,
+									sacrifice,
+									&[AvatarAttributes::RarityType, AvatarAttributes::ClassType2],
+								) && AvatarUtils::has_attribute_with_value(
+									sacrifice,
+									AvatarAttributes::ItemType,
+									ItemType::Equipable,
+								) && (equipable_item == EquipableItemType::ArmorBase ||
+									EquipableItemType::is_weapon(equipable_item))
+							}) {
+								ForgeType::Equip
+							} else if input_sacrifices.iter().all(|sacrifice| {
+								AvatarUtils::has_attribute_set_with_same_values_as(
+									input_leader,
+									sacrifice,
+									&[
+										AvatarAttributes::ItemType,
+										AvatarAttributes::ItemSubType,
+										AvatarAttributes::RarityType,
+									],
+								)
+							}) {
+								ForgeType::Mate
+							} else if input_sacrifices.iter().all(|sacrifice| {
+								AvatarUtils::has_attribute_with_same_value_as(
+									input_leader,
+									sacrifice,
+									AvatarAttributes::ItemType,
+								) && AvatarUtils::has_attribute_with_value(
+									sacrifice,
+									AvatarAttributes::ItemSubType,
+									PetItemType::Egg,
+								) && AvatarUtils::read_attribute_as::<RarityType>(
+									sacrifice,
+									AvatarAttributes::RarityType,
+								) < RarityType::Legendary
+							}) {
+								ForgeType::Feed
+							} else {
+								ForgeType::None
+							}
+						},
+						PetItemType::PetPart => ForgeType::None,
+						PetItemType::Egg => ForgeType::None,
+					},
+					RarityType::Mythical => ForgeType::None,
+					_ => match leader_sub_type {
+						PetItemType::Pet => ForgeType::None,
+						PetItemType::PetPart => {
+							if input_sacrifices.iter().all(|sacrifice| {
+								AvatarUtils::has_attribute_with_value(
+									sacrifice,
+									AvatarAttributes::ItemSubType,
+									PetItemType::PetPart,
+								) && AvatarUtils::has_attribute_with_same_value_as(
+									sacrifice,
+									input_leader,
+									AvatarAttributes::ClassType2,
+								)
+							}) {
+								ForgeType::Stack
+							} else if input_sacrifices.iter().all(|sacrifice| {
+								AvatarUtils::has_attribute_with_value(
+									sacrifice,
+									AvatarAttributes::ItemType,
+									ItemType::Material,
+								)
+							}) {
+								ForgeType::Tinker
+							} else {
+								ForgeType::None
+							}
+						},
+						PetItemType::Egg => {
+							if input_sacrifices.iter().all(|sacrifice| {
+								AvatarUtils::has_attribute_with_value(
+									sacrifice,
+									AvatarAttributes::ItemType,
+									ItemType::Pet,
+								) && AvatarUtils::has_attribute_with_value(
+									sacrifice,
+									AvatarAttributes::ItemSubType,
+									PetItemType::Egg,
+								)
+							}) {
+								ForgeType::Breed
+							} else {
+								ForgeType::None
+							}
+						},
+					},
+				}
+			},
+			ItemType::Material => {
+				if input_sacrifices.iter().all(|sacrifice| {
+					AvatarUtils::has_attribute_with_same_value_as(
+						input_leader,
+						sacrifice,
+						AvatarAttributes::ItemSubType,
+					)
+				}) {
+					ForgeType::Stack
+				} else {
+					ForgeType::None
+				}
+			},
+			ItemType::Essence => {
+				let leader_sub_type = AvatarUtils::read_attribute_as::<EssenceItemType>(
+					input_leader,
+					AvatarAttributes::ItemSubType,
+				);
+
+				match leader_sub_type {
+					EssenceItemType::Glimmer => {
+						if input_sacrifices.iter().all(|sacrifice| {
+							AvatarUtils::has_attribute_with_value(
+								sacrifice,
+								AvatarAttributes::ItemType,
+								ItemType::Material,
+							) && AvatarUtils::read_attribute(sacrifice, AvatarAttributes::Quantity) >=
+								4
+						}) && AvatarUtils::read_attribute(
+							input_leader,
+							AvatarAttributes::Quantity,
+						) as usize >= input_sacrifices.len()
+						{
+							ForgeType::Glimmer
+						} else if input_sacrifices.iter().all(|sacrifice| {
+							AvatarUtils::has_attribute_set_with_same_values_as(
+								sacrifice,
+								input_leader,
+								&[AvatarAttributes::ItemType, AvatarAttributes::ItemSubType],
+							)
+						}) {
+							ForgeType::Stack
+						} else {
+							ForgeType::None
+						}
+					},
+					EssenceItemType::ColorSpark | EssenceItemType::GlowSpark => {
+						if input_sacrifices.iter().all(|sacrifice| {
+							AvatarUtils::has_attribute_set_with_same_values_as(
+								input_leader,
+								sacrifice,
+								&[AvatarAttributes::ItemType, AvatarAttributes::ItemSubType],
+							)
+						}) {
+							ForgeType::Spark
+						} else {
+							ForgeType::None
+						}
+					},
+					EssenceItemType::PaintFlask | EssenceItemType::ForceGlow => ForgeType::None,
+				}
+			},
+			ItemType::Equipable => {
+				let leader_rarity = AvatarUtils::read_attribute_as::<RarityType>(
+					input_leader,
+					AvatarAttributes::RarityType,
+				);
+
+				match leader_rarity {
+					RarityType::Legendary | RarityType::Mythical => ForgeType::None,
+					_ => {
+						let equipable_item = AvatarUtils::read_attribute_as::<EquipableItemType>(
+							input_leader,
+							AvatarAttributes::ItemSubType,
+						);
+
+						let any_sacrifice_full_match_leader =
+							input_sacrifices.iter().any(|sacrifice| {
+								AvatarUtils::has_attribute_set_with_same_values_as(
+									input_leader,
+									sacrifice,
+									&[
+										AvatarAttributes::ItemType,
+										AvatarAttributes::ItemSubType,
+										AvatarAttributes::ClassType1,
+										AvatarAttributes::ClassType2,
+									],
+								)
+							});
+
+						let all_sacrifice_are_armor_part_or_essence =
+							input_sacrifices.iter().all(|sacrifice| {
+								let equipable_sacrifice_item =
+									AvatarUtils::read_attribute_as::<EquipableItemType>(
+										input_leader,
+										AvatarAttributes::ItemSubType,
+									);
+
+								(AvatarUtils::has_attribute_set_with_same_values_as(
+									sacrifice,
+									input_leader,
+									&[
+										AvatarAttributes::ItemType,
+										AvatarAttributes::ClassType1,
+										AvatarAttributes::ClassType2,
+									],
+								) && EquipableItemType::is_armor(equipable_sacrifice_item)) ||
+									AvatarUtils::has_attribute_with_value(
+										sacrifice,
+										AvatarAttributes::ItemType,
+										ItemType::Essence,
+									)
+							});
+
+						if EquipableItemType::is_armor(equipable_item) &&
+							any_sacrifice_full_match_leader &&
+							all_sacrifice_are_armor_part_or_essence
+						{
+							ForgeType::Assemble
+						} else {
+							ForgeType::None
+						}
+					},
+				}
+			},
+			ItemType::Blueprint => {
+				if input_sacrifices.iter().all(|sacrifice| {
+					AvatarUtils::has_attribute_with_value(
+						sacrifice,
+						AvatarAttributes::ItemType,
+						ItemType::Material,
+					)
+				}) {
+					ForgeType::Build
+				} else {
+					ForgeType::None
+				}
+			},
+			ItemType::Special => {
+				let leader_sub_type = AvatarUtils::read_attribute_as::<SpecialItemType>(
+					input_leader,
+					AvatarAttributes::ItemSubType,
+				);
+
+				match leader_sub_type {
+					SpecialItemType::Dust =>
+						if input_sacrifices.iter().all(|sacrifice| {
+							AvatarUtils::has_attribute_set_with_same_values_as(
+								sacrifice,
+								input_leader,
+								&[AvatarAttributes::ItemType, AvatarAttributes::ItemSubType],
+							)
+						}) {
+							ForgeType::Stack
+						} else {
+							ForgeType::None
+						},
+					SpecialItemType::Unidentified => ForgeType::None,
+				}
+			},
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::mock::*;
+
+	#[test]
+	fn test_can_be_forged() {
+		ExtBuilder::default().build().execute_with(|| {
+			let season = Season::default();
+
+			let forger = AvatarForgerV2::<Test>(PhantomData);
+
+			let mut leader = create_random_material(&ALICE, MaterialItemType::Polymers, 10);
+			let sacrifices = [
+				create_random_material(&ALICE, MaterialItemType::Polymers, 10),
+				create_random_material(&ALICE, MaterialItemType::Polymers, 10),
+				create_random_material(&ALICE, MaterialItemType::Polymers, 10),
+				create_random_material(&ALICE, MaterialItemType::Polymers, 10),
+				create_random_material(&ALICE, MaterialItemType::Polymers, 10),
+				create_random_material(&ALICE, MaterialItemType::Polymers, 10),
+			];
+
+			// Can't forge non V2 avatar
+			leader.1.version = AvatarVersion::V1;
+			assert!(forger.can_be_forged(&season, &leader, &sacrifices[0..4]).is_err());
+			leader.1.version = AvatarVersion::V2;
+			// Can forge with V2 avatar and correct number of sacrifices
+			assert!(forger.can_be_forged(&season, &leader, &sacrifices[0..4]).is_ok());
+
+			// Can't forge with more than MAX_SACRIFICE amount
+			assert!(forger.can_be_forged(&season, &leader, &sacrifices).is_err());
+
+			// Can't forge with less than MIN_SACRIFICE amount
+			assert!(forger.can_be_forged(&season, &leader, &[]).is_err());
+		});
+	}
+
+	#[test]
+	fn test_determine_forge_types_assemble() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forger = AvatarForgerV2::<Test>(PhantomData);
+
+			// Assemble with armor and essence
+			let (_, leader) = create_random_armor_component(
+				[0xA2; 32],
+				&ALICE,
+				PetType::TankyBullwog,
+				SlotType::ArmBack,
+				RarityType::Uncommon,
+				vec![EquipableItemType::ArmorComponent2],
+				(ColorType::ColorA, ColorType::None),
+				ForceType::Thermal,
+				2,
+			);
+			let sacrifices = [
+				&create_random_armor_component(
+					[0x2A; 32],
+					&ALICE,
+					PetType::TankyBullwog,
+					SlotType::ArmBack,
+					RarityType::Common,
+					vec![EquipableItemType::ArmorComponent2],
+					(ColorType::None, ColorType::ColorD),
+					ForceType::Astral,
+					2,
+				)
+				.1,
+				&create_random_glimmer(&ALICE, 10).1,
+			];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Assemble);
+
+			// Assemble without armor-parts or essence fails
+			let sacrifices_err = [&create_random_material(&ALICE, MaterialItemType::Polymers, 4).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+
+			// Assemble with incompatible armor component fails
+			let sacrifices_err = [&create_random_armor_component(
+				[0x2A; 32],
+				&ALICE,
+				PetType::FoxishDude,
+				SlotType::ArmBack,
+				RarityType::Common,
+				vec![EquipableItemType::ArmorComponent2],
+				(ColorType::None, ColorType::ColorD),
+				ForceType::Astral,
+				2,
+			)
+			.1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+		});
+	}
+
+	#[test]
+	fn test_determine_forge_types_breed() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forger = AvatarForgerV2::<Test>(PhantomData);
+
+			// Breed
+			let (_, leader) =
+				create_random_egg(None, &ALICE, RarityType::Rare, 0b0001_1110, 10, [0; 11]);
+			let sacrifices =
+				[&create_random_egg(None, &ALICE, RarityType::Common, 0b0001_0010, 10, [2; 11]).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Breed);
+
+			// Breed with Legendary egg leader fails
+			let (_, leader_err) =
+				create_random_egg(None, &ALICE, RarityType::Legendary, 0b0101_0010, 10, [9; 11]);
+			assert_eq!(forger.determine_forge_type(&leader_err, &sacrifices), ForgeType::None);
+
+			// Breed with non-eggs fails
+			let sacrifices_err = [&create_random_material(&ALICE, MaterialItemType::Metals, 10).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+		});
+	}
+
+	#[test]
+	fn test_determine_forge_types_build() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forger = AvatarForgerV2::<Test>(PhantomData);
+
+			let pet_type = PetType::TankyBullwog;
+			let slot_type = SlotType::ArmBack;
+			let equip_type = EquipableItemType::ArmorComponent2;
+			let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+			let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+				base_seed,
+				equip_type.as_byte() as usize,
+			);
+
+			// Build
+			let (_, leader) = create_random_blueprint(
+				&ALICE,
+				pet_type,
+				slot_type,
+				equip_type,
+				pattern.clone(),
+				2,
+			);
+			let sacrifices = [&create_random_material(&ALICE, MaterialItemType::Ceramics, 10).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Build);
+
+			// Build with non-materials fails
+			let sacrifices_err =
+				[&create_random_blueprint(&ALICE, pet_type, slot_type, equip_type, pattern, 4).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+		});
+	}
+
+	#[test]
+	fn test_determine_forge_types_equip() {
+		ExtBuilder::default().build().execute_with(|| {
+			ExtBuilder::default().build().execute_with(|| {
+				let forger = AvatarForgerV2::<Test>(PhantomData);
+
+				// Equip
+				let (_, leader) = create_random_pet(
+					&ALICE,
+					PetType::TankyBullwog,
+					0b0001_0001,
+					[0; 16],
+					[0; 11],
+					2,
+				);
+				let sacrifices = [&create_random_armor_component(
+					[0x2A; 32],
+					&ALICE,
+					PetType::TankyBullwog,
+					SlotType::ArmBack,
+					RarityType::Legendary,
+					vec![EquipableItemType::ArmorBase],
+					(ColorType::None, ColorType::ColorD),
+					ForceType::Astral,
+					2,
+				)
+				.1];
+				assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Equip);
+
+				// Equip without armor-parts fails
+				let sacrifices_err =
+					[&create_random_material(&ALICE, MaterialItemType::Polymers, 4).1];
+				assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+
+				// Equip with incompatible armor component fails
+				let sacrifices_err = [&create_random_armor_component(
+					[0x2A; 32],
+					&ALICE,
+					PetType::FoxishDude,
+					SlotType::ArmBack,
+					RarityType::Common,
+					vec![EquipableItemType::ArmorComponent2],
+					(ColorType::None, ColorType::ColorD),
+					ForceType::Astral,
+					2,
+				)
+				.1];
+				assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+			});
+		});
+	}
+
+	#[test]
+	fn test_determine_forge_types_feed() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forger = AvatarForgerV2::<Test>(PhantomData);
+
+			// Feed
+			let (_, leader) =
+				create_random_pet(&ALICE, PetType::TankyBullwog, 0b0001_0001, [0; 16], [0; 11], 2);
+			let sacrifices =
+				[&create_random_egg(None, &ALICE, RarityType::Common, 0b0001_0010, 10, [2; 11]).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Feed);
+
+			// Feed with Legendary egg sacrifices fails
+			let sacrifices_err =
+				[&create_random_egg(None, &ALICE, RarityType::Legendary, 0b0001_0010, 10, [2; 11])
+					.1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+
+			// Feed with non-eggs fails
+			let sacrifices_err = [&create_random_material(&ALICE, MaterialItemType::Metals, 10).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+		});
+	}
+
+	#[test]
+	fn test_determine_forge_types_glimmer() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forger = AvatarForgerV2::<Test>(PhantomData);
+
+			// Glimmer
+			let (_, leader) = create_random_glimmer(&ALICE, 5);
+			let sacrifices = [
+				&create_random_material(&ALICE, MaterialItemType::Ceramics, 4).1,
+				&create_random_material(&ALICE, MaterialItemType::Nanomaterials, 5).1,
+			];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Glimmer);
+
+			// Glimmer without enough materials fails
+			let sacrifices_err = [
+				&create_random_material(&ALICE, MaterialItemType::Polymers, 2).1,
+				&create_random_material(&ALICE, MaterialItemType::Optics, 4).1,
+			];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+
+			// Glimmer without enough glimmer amount fails
+			let (_, leader_err) = create_random_glimmer(&ALICE, 1);
+			assert_eq!(forger.determine_forge_type(&leader_err, &sacrifices), ForgeType::None);
+
+			// Glimmer without material sacrifices fails
+			let sacrifices_err =
+				[&create_random_egg(None, &ALICE, RarityType::Legendary, 0b0001_0010, 10, [2; 11])
+					.1];
+			assert_eq!(forger.determine_forge_type(&leader_err, &sacrifices_err), ForgeType::None);
+		});
+	}
+
+	#[test]
+	fn test_determine_forge_types_mate() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forger = AvatarForgerV2::<Test>(PhantomData);
+
+			// Mate
+			let (_, leader) =
+				create_random_pet(&ALICE, PetType::TankyBullwog, 0b0001_0001, [0; 16], [0; 11], 2);
+			let sacrifices =
+				[&create_random_pet(&ALICE, PetType::CrazyDude, 0b0001_0001, [0; 16], [0; 11], 2)
+					.1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Mate);
+
+			// Mate with non-pet fails
+			let sacrifices_err =
+				[&create_random_egg(None, &ALICE, RarityType::Legendary, 0b0001_0010, 10, [2; 11])
+					.1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+		});
+	}
+
+	#[test]
+	fn test_determine_forge_types_spark() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forger = AvatarForgerV2::<Test>(PhantomData);
+
+			// Spark with ColorSpark
+			let (_, leader_color) = create_random_color_spark(
+				None,
+				&ALICE,
+				(ColorType::ColorA, ColorType::ColorC),
+				100,
+				None,
+			);
+			let sacrifices_color = [&create_random_color_spark(
+				None,
+				&ALICE,
+				(ColorType::ColorC, ColorType::ColorD),
+				3,
+				None,
+			)
+			.1];
+			assert_eq!(
+				forger.determine_forge_type(&leader_color, &sacrifices_color),
+				ForgeType::Spark
+			);
+
+			// Spark with GlowSpark
+			let (_, leader_glow) =
+				create_random_glow_spark(None, &ALICE, ForceType::Kinetic, 100, None);
+			let sacrifices_glow =
+				[&create_random_glow_spark(None, &ALICE, ForceType::Thermal, 100, None).1];
+			assert_eq!(
+				forger.determine_forge_type(&leader_glow, &sacrifices_glow),
+				ForgeType::Spark
+			);
+
+			// Spark with incompatible spark types fails
+			assert_eq!(
+				forger.determine_forge_type(&leader_glow, &sacrifices_color),
+				ForgeType::None
+			);
+			assert_eq!(
+				forger.determine_forge_type(&leader_color, &sacrifices_glow),
+				ForgeType::None
+			);
+
+			// Spark without GlowSpark or ColorSpark fails
+			let sacrifices_err =
+				[&create_random_egg(None, &ALICE, RarityType::Legendary, 0b0001_0010, 10, [2; 11])
+					.1];
+			assert_eq!(
+				forger.determine_forge_type(&leader_color, &sacrifices_err),
+				ForgeType::None
+			);
+			assert_eq!(forger.determine_forge_type(&leader_glow, &sacrifices_err), ForgeType::None);
+		});
+	}
+
+	#[test]
+	fn test_determine_forge_types_stack() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forger = AvatarForgerV2::<Test>(PhantomData);
+
+			// Stack Materials
+			let (_, leader) = create_random_material(&ALICE, MaterialItemType::Polymers, 10);
+			let sacrifices = [&create_random_material(&ALICE, MaterialItemType::Polymers, 10).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Stack);
+			// Stack different Materials fails
+			let sacrifices_err = [&create_random_material(&ALICE, MaterialItemType::Metals, 10).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+
+			// Stack Dust
+			let (_, leader) = create_random_dust(&ALICE, 10);
+			let sacrifices = [&create_random_dust(&ALICE, 10).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Stack);
+			// Stack dust with non-dust fails
+			let sacrifices_err = [&create_random_material(&ALICE, MaterialItemType::Metals, 10).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+
+			// Stack Glimmer
+			let (_, leader) = create_random_glimmer(&ALICE, 1);
+			let sacrifices = [&create_random_glimmer(&ALICE, 2).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Stack);
+			// Stack Glimmer with different non-glimmer fails
+			let sacrifices_err = [&create_random_dust(&ALICE, 10).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+
+			// Stack PetPart
+			let (_, leader) =
+				create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::Head, 1);
+			let sacrifices =
+				[&create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::Head, 1).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Stack);
+			// Stack PetPart with different PetType fails
+			let sacrifices_err =
+				[&create_random_pet_part(&ALICE, PetType::BigHybrid, SlotType::Head, 1).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+		});
+	}
+
+	#[test]
+	fn test_determine_forge_types_tinker() {
+		ExtBuilder::default().build().execute_with(|| {
+			let forger = AvatarForgerV2::<Test>(PhantomData);
+
+			// Tinker
+			let (_, leader) =
+				create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::Head, 1);
+			let sacrifices = [&create_random_material(&ALICE, MaterialItemType::Polymers, 10).1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Tinker);
+
+			// Tinker with non-materials fails
+			let sacrifices_err = [&create_random_color_spark(
+				None,
+				&ALICE,
+				(ColorType::ColorA, ColorType::ColorC),
+				10,
+				None,
+			)
+			.1];
+			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
+		});
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/mod.rs
@@ -29,21 +29,18 @@ pub(super) struct AttributeMapperV2;
 
 impl AttributeMapper for AttributeMapperV2 {
 	fn min_tier(&self, target: &Avatar) -> u8 {
-		AvatarUtils::read_attribute(target, AvatarAttributes::RarityType).saturating_sub(1)
+		AvatarUtils::read_attribute(target, &AvatarAttributes::RarityType).saturating_sub(1)
 	}
 
 	fn last_variation(&self, target: &Avatar) -> u8 {
 		// TODO: Determine proper mapping
-		AvatarUtils::read_spec_byte(target, AvatarSpecBytes::SpecByte1).saturating_sub(1)
+		AvatarUtils::read_spec_byte(target, &AvatarSpecBytes::SpecByte1).saturating_sub(1)
 	}
 }
 
-pub(super) struct AvatarMinterV2<'a, T: Config>(pub PhantomData<&'a T>);
+pub(super) struct AvatarMinterV2<T: Config>(pub PhantomData<T>);
 
-impl<'a, T> Minter<T> for AvatarMinterV2<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> Minter<T> for AvatarMinterV2<T> {
 	fn mint_avatar_set(
 		&self,
 		player: &T::AccountId,
@@ -55,10 +52,7 @@ where
 	}
 }
 
-impl<'a, T> AvatarMinterV2<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarMinterV2<T> {
 	pub(super) fn generate_base_avatar_dna(
 		&self,
 		hash_provider: &mut HashProvider<T, 32>,
@@ -131,12 +125,12 @@ where
 		let mut hash_provider =
 			HashProvider::<T, 32>::new(&Pallet::<T>::random_hash(b"avatar_minter_v2", player));
 
-		let roll_amount = mint_option.count as usize;
+		let roll_amount = mint_option.count.clone() as usize;
 		let mut minted_avatars = Vec::with_capacity(roll_amount);
 
 		for i in 0..roll_amount {
 			let rolled_item_type = SlotRoller::<T>::roll_on_pack_type(
-				mint_option.mint_pack,
+				mint_option.mint_pack.clone(),
 				&PACK_TYPE_MATERIAL_ITEM_PROBABILITIES,
 				&PACK_TYPE_EQUIPMENT_ITEM_PROBABILITIES,
 				&PACK_TYPE_SPECIAL_ITEM_PROBABILITIES,
@@ -156,7 +150,7 @@ where
 
 			let avatar = self
 				.get_mutator_from_item_type(
-					mint_option.mint_pack,
+					mint_option.mint_pack.clone(),
 					rolled_item_type,
 					&mut hash_provider,
 				)
@@ -186,9 +180,9 @@ pub(crate) enum ForgeType {
 	Special = 11,
 }
 
-pub(super) struct AvatarForgerV2<'a, T: Config>(pub PhantomData<&'a T>);
+pub(super) struct AvatarForgerV2<T: Config>(pub PhantomData<T>);
 
-impl<'a, T> Forger<T> for AvatarForgerV2<'a, T>
+impl<T> Forger<T> for AvatarForgerV2<T>
 where
 	T: Config,
 {
@@ -226,40 +220,37 @@ where
 		_season: &SeasonOf<T>,
 		input_leader: &ForgeItem<T>,
 		input_sacrifices: &[ForgeItem<T>],
-	) -> Result<(), DispatchError> {
-		if (input_leader.1.version != AvatarVersion::V2) ||
-			(input_sacrifices.len() < MIN_SACRIFICE || input_sacrifices.len() > MAX_SACRIFICE) ||
-			(input_sacrifices.iter().any(|(_, avatar)| avatar.version != AvatarVersion::V2))
-		{
-			Err(Error::<T>::IncompatibleAvatarVersions.into())
-		} else {
-			Ok(())
-		}
+	) -> DispatchResult {
+		ensure!(
+			(input_leader.1.version == AvatarVersion::V2) &&
+				(input_sacrifices.len() >= MIN_SACRIFICE &&
+					input_sacrifices.len() <= MAX_SACRIFICE) &&
+				(input_sacrifices.iter().all(|(_, avatar)| avatar.version == AvatarVersion::V2)),
+			Error::<T>::IncompatibleAvatarVersions
+		);
+		Ok(())
 	}
 }
 
-impl<'a, T> AvatarForgerV2<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> AvatarForgerV2<T> {
 	fn determine_forge_type(
 		&self,
 		input_leader: &Avatar,
 		input_sacrifices: &[&Avatar],
 	) -> ForgeType {
 		let input_leader_item_type =
-			AvatarUtils::read_attribute_as::<ItemType>(input_leader, AvatarAttributes::ItemType);
+			AvatarUtils::read_attribute_as::<ItemType>(input_leader, &AvatarAttributes::ItemType);
 
 		match input_leader_item_type {
 			ItemType::Pet => {
 				let leader_rarity = AvatarUtils::read_attribute_as::<RarityType>(
 					input_leader,
-					AvatarAttributes::RarityType,
+					&AvatarAttributes::RarityType,
 				);
 
 				let leader_sub_type = AvatarUtils::read_attribute_as::<PetItemType>(
 					input_leader,
-					AvatarAttributes::ItemSubType,
+					&AvatarAttributes::ItemSubType,
 				);
 
 				match leader_rarity {
@@ -268,7 +259,7 @@ where
 							if input_sacrifices.iter().all(|sacrifice| {
 								let equipable_item = AvatarUtils::read_attribute_as(
 									sacrifice,
-									AvatarAttributes::ItemSubType,
+									&AvatarAttributes::ItemSubType,
 								);
 
 								AvatarUtils::has_attribute_set_with_same_values_as(
@@ -277,7 +268,7 @@ where
 									&[AvatarAttributes::RarityType, AvatarAttributes::ClassType2],
 								) && AvatarUtils::has_attribute_with_value(
 									sacrifice,
-									AvatarAttributes::ItemType,
+									&AvatarAttributes::ItemType,
 									ItemType::Equipable,
 								) && (equipable_item == EquipableItemType::ArmorBase ||
 									EquipableItemType::is_weapon(equipable_item))
@@ -299,14 +290,14 @@ where
 								AvatarUtils::has_attribute_with_same_value_as(
 									input_leader,
 									sacrifice,
-									AvatarAttributes::ItemType,
+									&AvatarAttributes::ItemType,
 								) && AvatarUtils::has_attribute_with_value(
 									sacrifice,
-									AvatarAttributes::ItemSubType,
+									&AvatarAttributes::ItemSubType,
 									PetItemType::Egg,
 								) && AvatarUtils::read_attribute_as::<RarityType>(
 									sacrifice,
-									AvatarAttributes::RarityType,
+									&AvatarAttributes::RarityType,
 								) < RarityType::Legendary
 							}) {
 								ForgeType::Feed
@@ -324,19 +315,19 @@ where
 							if input_sacrifices.iter().all(|sacrifice| {
 								AvatarUtils::has_attribute_with_value(
 									sacrifice,
-									AvatarAttributes::ItemSubType,
+									&AvatarAttributes::ItemSubType,
 									PetItemType::PetPart,
 								) && AvatarUtils::has_attribute_with_same_value_as(
 									sacrifice,
 									input_leader,
-									AvatarAttributes::ClassType2,
+									&AvatarAttributes::ClassType2,
 								)
 							}) {
 								ForgeType::Stack
 							} else if input_sacrifices.iter().all(|sacrifice| {
 								AvatarUtils::has_attribute_with_value(
 									sacrifice,
-									AvatarAttributes::ItemType,
+									&AvatarAttributes::ItemType,
 									ItemType::Material,
 								)
 							}) {
@@ -349,11 +340,11 @@ where
 							if input_sacrifices.iter().all(|sacrifice| {
 								AvatarUtils::has_attribute_with_value(
 									sacrifice,
-									AvatarAttributes::ItemType,
+									&AvatarAttributes::ItemType,
 									ItemType::Pet,
 								) && AvatarUtils::has_attribute_with_value(
 									sacrifice,
-									AvatarAttributes::ItemSubType,
+									&AvatarAttributes::ItemSubType,
 									PetItemType::Egg,
 								)
 							}) {
@@ -370,7 +361,7 @@ where
 					AvatarUtils::has_attribute_with_same_value_as(
 						input_leader,
 						sacrifice,
-						AvatarAttributes::ItemSubType,
+						&AvatarAttributes::ItemSubType,
 					)
 				}) {
 					ForgeType::Stack
@@ -381,7 +372,7 @@ where
 			ItemType::Essence => {
 				let leader_sub_type = AvatarUtils::read_attribute_as::<EssenceItemType>(
 					input_leader,
-					AvatarAttributes::ItemSubType,
+					&AvatarAttributes::ItemSubType,
 				);
 
 				match leader_sub_type {
@@ -389,13 +380,13 @@ where
 						if input_sacrifices.iter().all(|sacrifice| {
 							AvatarUtils::has_attribute_with_value(
 								sacrifice,
-								AvatarAttributes::ItemType,
+								&AvatarAttributes::ItemType,
 								ItemType::Material,
-							) && AvatarUtils::read_attribute(sacrifice, AvatarAttributes::Quantity) >=
+							) && AvatarUtils::read_attribute(sacrifice, &AvatarAttributes::Quantity) >=
 								4
 						}) && AvatarUtils::read_attribute(
 							input_leader,
-							AvatarAttributes::Quantity,
+							&AvatarAttributes::Quantity,
 						) as usize >= input_sacrifices.len()
 						{
 							ForgeType::Glimmer
@@ -430,7 +421,7 @@ where
 			ItemType::Equipable => {
 				let leader_rarity = AvatarUtils::read_attribute_as::<RarityType>(
 					input_leader,
-					AvatarAttributes::RarityType,
+					&AvatarAttributes::RarityType,
 				);
 
 				match leader_rarity {
@@ -438,7 +429,7 @@ where
 					_ => {
 						let equipable_item = AvatarUtils::read_attribute_as::<EquipableItemType>(
 							input_leader,
-							AvatarAttributes::ItemSubType,
+							&AvatarAttributes::ItemSubType,
 						);
 
 						let any_sacrifice_full_match_leader =
@@ -460,7 +451,7 @@ where
 								let equipable_sacrifice_item =
 									AvatarUtils::read_attribute_as::<EquipableItemType>(
 										input_leader,
-										AvatarAttributes::ItemSubType,
+										&AvatarAttributes::ItemSubType,
 									);
 
 								(AvatarUtils::has_attribute_set_with_same_values_as(
@@ -474,7 +465,7 @@ where
 								) && EquipableItemType::is_armor(equipable_sacrifice_item)) ||
 									AvatarUtils::has_attribute_with_value(
 										sacrifice,
-										AvatarAttributes::ItemType,
+										&AvatarAttributes::ItemType,
 										ItemType::Essence,
 									)
 							});
@@ -494,7 +485,7 @@ where
 				if input_sacrifices.iter().all(|sacrifice| {
 					AvatarUtils::has_attribute_with_value(
 						sacrifice,
-						AvatarAttributes::ItemType,
+						&AvatarAttributes::ItemType,
 						ItemType::Material,
 					)
 				}) {
@@ -506,7 +497,7 @@ where
 			ItemType::Special => {
 				let leader_sub_type = AvatarUtils::read_attribute_as::<SpecialItemType>(
 					input_leader,
-					AvatarAttributes::ItemSubType,
+					&AvatarAttributes::ItemSubType,
 				);
 
 				match leader_sub_type {
@@ -541,14 +532,14 @@ mod test {
 
 			let forger = AvatarForgerV2::<Test>(PhantomData);
 
-			let mut leader = create_random_material(&ALICE, MaterialItemType::Polymers, 10);
+			let mut leader = create_random_material(&ALICE, &MaterialItemType::Polymers, 10);
 			let sacrifices = [
-				create_random_material(&ALICE, MaterialItemType::Polymers, 10),
-				create_random_material(&ALICE, MaterialItemType::Polymers, 10),
-				create_random_material(&ALICE, MaterialItemType::Polymers, 10),
-				create_random_material(&ALICE, MaterialItemType::Polymers, 10),
-				create_random_material(&ALICE, MaterialItemType::Polymers, 10),
-				create_random_material(&ALICE, MaterialItemType::Polymers, 10),
+				create_random_material(&ALICE, &MaterialItemType::Polymers, 10),
+				create_random_material(&ALICE, &MaterialItemType::Polymers, 10),
+				create_random_material(&ALICE, &MaterialItemType::Polymers, 10),
+				create_random_material(&ALICE, &MaterialItemType::Polymers, 10),
+				create_random_material(&ALICE, &MaterialItemType::Polymers, 10),
+				create_random_material(&ALICE, &MaterialItemType::Polymers, 10),
 			];
 
 			// Can't forge non V2 avatar
@@ -575,24 +566,24 @@ mod test {
 			let (_, leader) = create_random_armor_component(
 				[0xA2; 32],
 				&ALICE,
-				PetType::TankyBullwog,
-				SlotType::ArmBack,
-				RarityType::Uncommon,
-				vec![EquipableItemType::ArmorComponent2],
-				(ColorType::ColorA, ColorType::None),
-				ForceType::Thermal,
+				&PetType::TankyBullwog,
+				&SlotType::ArmBack,
+				&RarityType::Uncommon,
+				&[EquipableItemType::ArmorComponent2],
+				&(ColorType::ColorA, ColorType::None),
+				&ForceType::Thermal,
 				2,
 			);
 			let sacrifices = [
 				&create_random_armor_component(
 					[0x2A; 32],
 					&ALICE,
-					PetType::TankyBullwog,
-					SlotType::ArmBack,
-					RarityType::Common,
-					vec![EquipableItemType::ArmorComponent2],
-					(ColorType::None, ColorType::ColorD),
-					ForceType::Astral,
+					&PetType::TankyBullwog,
+					&SlotType::ArmBack,
+					&RarityType::Common,
+					&[EquipableItemType::ArmorComponent2],
+					&(ColorType::None, ColorType::ColorD),
+					&ForceType::Astral,
 					2,
 				)
 				.1,
@@ -601,19 +592,20 @@ mod test {
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Assemble);
 
 			// Assemble without armor-parts or essence fails
-			let sacrifices_err = [&create_random_material(&ALICE, MaterialItemType::Polymers, 4).1];
+			let sacrifices_err =
+				[&create_random_material(&ALICE, &MaterialItemType::Polymers, 4).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
 
 			// Assemble with incompatible armor component fails
 			let sacrifices_err = [&create_random_armor_component(
 				[0x2A; 32],
 				&ALICE,
-				PetType::FoxishDude,
-				SlotType::ArmBack,
-				RarityType::Common,
-				vec![EquipableItemType::ArmorComponent2],
-				(ColorType::None, ColorType::ColorD),
-				ForceType::Astral,
+				&PetType::FoxishDude,
+				&SlotType::ArmBack,
+				&RarityType::Common,
+				&[EquipableItemType::ArmorComponent2],
+				&(ColorType::None, ColorType::ColorD),
+				&ForceType::Astral,
 				2,
 			)
 			.1];
@@ -628,18 +620,18 @@ mod test {
 
 			// Breed
 			let (_, leader) =
-				create_random_egg(None, &ALICE, RarityType::Rare, 0b0001_1110, 10, [0; 11]);
+				create_random_egg(None, &ALICE, &RarityType::Rare, 0b0001_1110, 10, [0; 11]);
 			let sacrifices =
-				[&create_random_egg(None, &ALICE, RarityType::Common, 0b0001_0010, 10, [2; 11]).1];
+				[&create_random_egg(None, &ALICE, &RarityType::Common, 0b0001_0010, 10, [2; 11]).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Breed);
 
 			// Breed with Legendary egg leader fails
 			let (_, leader_err) =
-				create_random_egg(None, &ALICE, RarityType::Legendary, 0b0101_0010, 10, [9; 11]);
+				create_random_egg(None, &ALICE, &RarityType::Legendary, 0b0101_0010, 10, [9; 11]);
 			assert_eq!(forger.determine_forge_type(&leader_err, &sacrifices), ForgeType::None);
 
 			// Breed with non-eggs fails
-			let sacrifices_err = [&create_random_material(&ALICE, MaterialItemType::Metals, 10).1];
+			let sacrifices_err = [&create_random_material(&ALICE, &MaterialItemType::Metals, 10).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
 		});
 	}
@@ -659,20 +651,15 @@ mod test {
 			);
 
 			// Build
-			let (_, leader) = create_random_blueprint(
-				&ALICE,
-				pet_type,
-				slot_type,
-				equip_type,
-				pattern.clone(),
-				2,
-			);
-			let sacrifices = [&create_random_material(&ALICE, MaterialItemType::Ceramics, 10).1];
+			let (_, leader) =
+				create_random_blueprint(&ALICE, &pet_type, &slot_type, &equip_type, &pattern, 2);
+			let sacrifices = [&create_random_material(&ALICE, &MaterialItemType::Ceramics, 10).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Build);
 
 			// Build with non-materials fails
 			let sacrifices_err =
-				[&create_random_blueprint(&ALICE, pet_type, slot_type, equip_type, pattern, 4).1];
+				[&create_random_blueprint(&ALICE, &pet_type, &slot_type, &equip_type, &pattern, 4)
+					.1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
 		});
 	}
@@ -686,7 +673,7 @@ mod test {
 				// Equip
 				let (_, leader) = create_random_pet(
 					&ALICE,
-					PetType::TankyBullwog,
+					&PetType::TankyBullwog,
 					0b0001_0001,
 					[0; 16],
 					[0; 11],
@@ -695,12 +682,12 @@ mod test {
 				let sacrifices = [&create_random_armor_component(
 					[0x2A; 32],
 					&ALICE,
-					PetType::TankyBullwog,
-					SlotType::ArmBack,
-					RarityType::Legendary,
-					vec![EquipableItemType::ArmorBase],
-					(ColorType::None, ColorType::ColorD),
-					ForceType::Astral,
+					&PetType::TankyBullwog,
+					&SlotType::ArmBack,
+					&RarityType::Legendary,
+					&[EquipableItemType::ArmorBase],
+					&(ColorType::None, ColorType::ColorD),
+					&ForceType::Astral,
 					2,
 				)
 				.1];
@@ -708,19 +695,19 @@ mod test {
 
 				// Equip without armor-parts fails
 				let sacrifices_err =
-					[&create_random_material(&ALICE, MaterialItemType::Polymers, 4).1];
+					[&create_random_material(&ALICE, &MaterialItemType::Polymers, 4).1];
 				assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
 
 				// Equip with incompatible armor component fails
 				let sacrifices_err = [&create_random_armor_component(
 					[0x2A; 32],
 					&ALICE,
-					PetType::FoxishDude,
-					SlotType::ArmBack,
-					RarityType::Common,
-					vec![EquipableItemType::ArmorComponent2],
-					(ColorType::None, ColorType::ColorD),
-					ForceType::Astral,
+					&PetType::FoxishDude,
+					&SlotType::ArmBack,
+					&RarityType::Common,
+					&[EquipableItemType::ArmorComponent2],
+					&(ColorType::None, ColorType::ColorD),
+					&ForceType::Astral,
 					2,
 				)
 				.1];
@@ -736,19 +723,25 @@ mod test {
 
 			// Feed
 			let (_, leader) =
-				create_random_pet(&ALICE, PetType::TankyBullwog, 0b0001_0001, [0; 16], [0; 11], 2);
+				create_random_pet(&ALICE, &PetType::TankyBullwog, 0b0001_0001, [0; 16], [0; 11], 2);
 			let sacrifices =
-				[&create_random_egg(None, &ALICE, RarityType::Common, 0b0001_0010, 10, [2; 11]).1];
+				[&create_random_egg(None, &ALICE, &RarityType::Common, 0b0001_0010, 10, [2; 11]).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Feed);
 
 			// Feed with Legendary egg sacrifices fails
-			let sacrifices_err =
-				[&create_random_egg(None, &ALICE, RarityType::Legendary, 0b0001_0010, 10, [2; 11])
-					.1];
+			let sacrifices_err = [&create_random_egg(
+				None,
+				&ALICE,
+				&RarityType::Legendary,
+				0b0001_0010,
+				10,
+				[2; 11],
+			)
+			.1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
 
 			// Feed with non-eggs fails
-			let sacrifices_err = [&create_random_material(&ALICE, MaterialItemType::Metals, 10).1];
+			let sacrifices_err = [&create_random_material(&ALICE, &MaterialItemType::Metals, 10).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
 		});
 	}
@@ -761,15 +754,15 @@ mod test {
 			// Glimmer
 			let (_, leader) = create_random_glimmer(&ALICE, 5);
 			let sacrifices = [
-				&create_random_material(&ALICE, MaterialItemType::Ceramics, 4).1,
-				&create_random_material(&ALICE, MaterialItemType::Nanomaterials, 5).1,
+				&create_random_material(&ALICE, &MaterialItemType::Ceramics, 4).1,
+				&create_random_material(&ALICE, &MaterialItemType::Nanomaterials, 5).1,
 			];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Glimmer);
 
 			// Glimmer without enough materials fails
 			let sacrifices_err = [
-				&create_random_material(&ALICE, MaterialItemType::Polymers, 2).1,
-				&create_random_material(&ALICE, MaterialItemType::Optics, 4).1,
+				&create_random_material(&ALICE, &MaterialItemType::Polymers, 2).1,
+				&create_random_material(&ALICE, &MaterialItemType::Optics, 4).1,
 			];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
 
@@ -778,9 +771,15 @@ mod test {
 			assert_eq!(forger.determine_forge_type(&leader_err, &sacrifices), ForgeType::None);
 
 			// Glimmer without material sacrifices fails
-			let sacrifices_err =
-				[&create_random_egg(None, &ALICE, RarityType::Legendary, 0b0001_0010, 10, [2; 11])
-					.1];
+			let sacrifices_err = [&create_random_egg(
+				None,
+				&ALICE,
+				&RarityType::Legendary,
+				0b0001_0010,
+				10,
+				[2; 11],
+			)
+			.1];
 			assert_eq!(forger.determine_forge_type(&leader_err, &sacrifices_err), ForgeType::None);
 		});
 	}
@@ -792,16 +791,22 @@ mod test {
 
 			// Mate
 			let (_, leader) =
-				create_random_pet(&ALICE, PetType::TankyBullwog, 0b0001_0001, [0; 16], [0; 11], 2);
+				create_random_pet(&ALICE, &PetType::TankyBullwog, 0b0001_0001, [0; 16], [0; 11], 2);
 			let sacrifices =
-				[&create_random_pet(&ALICE, PetType::CrazyDude, 0b0001_0001, [0; 16], [0; 11], 2)
+				[&create_random_pet(&ALICE, &PetType::CrazyDude, 0b0001_0001, [0; 16], [0; 11], 2)
 					.1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Mate);
 
 			// Mate with non-pet fails
-			let sacrifices_err =
-				[&create_random_egg(None, &ALICE, RarityType::Legendary, 0b0001_0010, 10, [2; 11])
-					.1];
+			let sacrifices_err = [&create_random_egg(
+				None,
+				&ALICE,
+				&RarityType::Legendary,
+				0b0001_0010,
+				10,
+				[2; 11],
+			)
+			.1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
 		});
 	}
@@ -815,14 +820,14 @@ mod test {
 			let (_, leader_color) = create_random_color_spark(
 				None,
 				&ALICE,
-				(ColorType::ColorA, ColorType::ColorC),
+				&(ColorType::ColorA, ColorType::ColorC),
 				100,
 				None,
 			);
 			let sacrifices_color = [&create_random_color_spark(
 				None,
 				&ALICE,
-				(ColorType::ColorC, ColorType::ColorD),
+				&(ColorType::ColorC, ColorType::ColorD),
 				3,
 				None,
 			)
@@ -834,9 +839,9 @@ mod test {
 
 			// Spark with GlowSpark
 			let (_, leader_glow) =
-				create_random_glow_spark(None, &ALICE, ForceType::Kinetic, 100, None);
+				create_random_glow_spark(None, &ALICE, &ForceType::Kinetic, 100, None);
 			let sacrifices_glow =
-				[&create_random_glow_spark(None, &ALICE, ForceType::Thermal, 100, None).1];
+				[&create_random_glow_spark(None, &ALICE, &ForceType::Thermal, 100, None).1];
 			assert_eq!(
 				forger.determine_forge_type(&leader_glow, &sacrifices_glow),
 				ForgeType::Spark
@@ -853,9 +858,15 @@ mod test {
 			);
 
 			// Spark without GlowSpark or ColorSpark fails
-			let sacrifices_err =
-				[&create_random_egg(None, &ALICE, RarityType::Legendary, 0b0001_0010, 10, [2; 11])
-					.1];
+			let sacrifices_err = [&create_random_egg(
+				None,
+				&ALICE,
+				&RarityType::Legendary,
+				0b0001_0010,
+				10,
+				[2; 11],
+			)
+			.1];
 			assert_eq!(
 				forger.determine_forge_type(&leader_color, &sacrifices_err),
 				ForgeType::None
@@ -870,11 +881,11 @@ mod test {
 			let forger = AvatarForgerV2::<Test>(PhantomData);
 
 			// Stack Materials
-			let (_, leader) = create_random_material(&ALICE, MaterialItemType::Polymers, 10);
-			let sacrifices = [&create_random_material(&ALICE, MaterialItemType::Polymers, 10).1];
+			let (_, leader) = create_random_material(&ALICE, &MaterialItemType::Polymers, 10);
+			let sacrifices = [&create_random_material(&ALICE, &MaterialItemType::Polymers, 10).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Stack);
 			// Stack different Materials fails
-			let sacrifices_err = [&create_random_material(&ALICE, MaterialItemType::Metals, 10).1];
+			let sacrifices_err = [&create_random_material(&ALICE, &MaterialItemType::Metals, 10).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
 
 			// Stack Dust
@@ -882,7 +893,7 @@ mod test {
 			let sacrifices = [&create_random_dust(&ALICE, 10).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Stack);
 			// Stack dust with non-dust fails
-			let sacrifices_err = [&create_random_material(&ALICE, MaterialItemType::Metals, 10).1];
+			let sacrifices_err = [&create_random_material(&ALICE, &MaterialItemType::Metals, 10).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
 
 			// Stack Glimmer
@@ -895,13 +906,13 @@ mod test {
 
 			// Stack PetPart
 			let (_, leader) =
-				create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::Head, 1);
+				create_random_pet_part(&ALICE, &PetType::FoxishDude, &SlotType::Head, 1);
 			let sacrifices =
-				[&create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::Head, 1).1];
+				[&create_random_pet_part(&ALICE, &PetType::FoxishDude, &SlotType::Head, 1).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Stack);
 			// Stack PetPart with different PetType fails
 			let sacrifices_err =
-				[&create_random_pet_part(&ALICE, PetType::BigHybrid, SlotType::Head, 1).1];
+				[&create_random_pet_part(&ALICE, &PetType::BigHybrid, &SlotType::Head, 1).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices_err), ForgeType::None);
 		});
 	}
@@ -913,15 +924,15 @@ mod test {
 
 			// Tinker
 			let (_, leader) =
-				create_random_pet_part(&ALICE, PetType::FoxishDude, SlotType::Head, 1);
-			let sacrifices = [&create_random_material(&ALICE, MaterialItemType::Polymers, 10).1];
+				create_random_pet_part(&ALICE, &PetType::FoxishDude, &SlotType::Head, 1);
+			let sacrifices = [&create_random_material(&ALICE, &MaterialItemType::Polymers, 10).1];
 			assert_eq!(forger.determine_forge_type(&leader, &sacrifices), ForgeType::Tinker);
 
 			// Tinker with non-materials fails
 			let sacrifices_err = [&create_random_color_spark(
 				None,
 				&ALICE,
-				(ColorType::ColorA, ColorType::ColorC),
+				&(ColorType::ColorA, ColorType::ColorC),
 				10,
 				None,
 			)

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/mutator.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/mutator.rs
@@ -9,10 +9,7 @@ pub(crate) trait AvatarMutator<T: Config> {
 	) -> Avatar;
 }
 
-impl<T> AvatarMutator<T> for PetItemType
-where
-	T: Config,
-{
+impl<T: Config> AvatarMutator<T> for PetItemType {
 	fn mutate_from_base(
 		&self,
 		base_avatar: Avatar,
@@ -26,7 +23,7 @@ where
 				let spec_bytes = [0; 16];
 
 				let progress_array = AvatarUtils::generate_progress_bytes(
-					RarityType::Legendary,
+					&RarityType::Legendary,
 					SCALING_FACTOR_PERC,
 					SPARK_PROGRESS_PROB_PERC,
 					[0; 11],
@@ -35,7 +32,7 @@ where
 				let soul_count = (hash_provider.get_hash_byte() as SoulCount % 25) + 1;
 
 				AvatarBuilder::with_base_avatar(base_avatar).into_pet(
-					pet_type,
+					&pet_type,
 					pet_variation,
 					spec_bytes,
 					Some(progress_array),
@@ -48,14 +45,14 @@ where
 				let pet_type = SlotRoller::<T>::roll_on(&PET_TYPE_PROBABILITIES, hash_provider);
 
 				AvatarBuilder::with_base_avatar(base_avatar)
-					.into_pet_part(pet_type, slot_type, quantity)
+					.into_pet_part(&pet_type, &slot_type, quantity)
 			},
 			PetItemType::Egg => {
 				let pet_variation = (hash_provider.get_hash_byte() % 15) + 1;
 				let soul_points = (hash_provider.get_hash_byte() % 99) + 1;
 
 				AvatarBuilder::with_base_avatar(base_avatar).into_egg(
-					RarityType::Epic,
+					&RarityType::Epic,
 					pet_variation,
 					soul_points as SoulCount,
 					None,
@@ -66,25 +63,19 @@ where
 	}
 }
 
-impl<T> AvatarMutator<T> for MaterialItemType
-where
-	T: Config,
-{
+impl<T: Config> AvatarMutator<T> for MaterialItemType {
 	fn mutate_from_base(
 		&self,
 		base_avatar: Avatar,
 		hash_provider: &mut HashProvider<T, 32>,
 	) -> Avatar {
 		AvatarBuilder::with_base_avatar(base_avatar)
-			.into_material(*self, (hash_provider.get_hash_byte() % MAX_QUANTITY) + 1)
+			.into_material(self, (hash_provider.get_hash_byte() % MAX_QUANTITY) + 1)
 			.build()
 	}
 }
 
-impl<T> AvatarMutator<T> for EssenceItemType
-where
-	T: Config,
-{
+impl<T: Config> AvatarMutator<T> for EssenceItemType {
 	fn mutate_from_base(
 		&self,
 		base_avatar: Avatar,
@@ -104,13 +95,13 @@ where
 
 				if *self == EssenceItemType::ColorSpark {
 					AvatarBuilder::with_base_avatar(base_avatar).into_color_spark(
-						color_pair,
+						&color_pair,
 						souls as SoulCount,
 						None,
 					)
 				} else {
 					AvatarBuilder::with_base_avatar(base_avatar).into_paint_flask(
-						color_pair,
+						&color_pair,
 						souls as SoulCount,
 						None,
 					)
@@ -123,13 +114,13 @@ where
 
 				if *self == EssenceItemType::GlowSpark {
 					AvatarBuilder::with_base_avatar(base_avatar).into_glow_spark(
-						force_type,
+						&force_type,
 						souls as SoulCount,
 						None,
 					)
 				} else {
 					AvatarBuilder::with_base_avatar(base_avatar).into_force_glow(
-						force_type,
+						&force_type,
 						souls as SoulCount,
 						None,
 					)
@@ -140,10 +131,7 @@ where
 	}
 }
 
-impl<T> AvatarMutator<T> for EquipableItemType
-where
-	T: Config,
-{
+impl<T: Config> AvatarMutator<T> for EquipableItemType {
 	fn mutate_from_base(
 		&self,
 		base_avatar: Avatar,
@@ -169,12 +157,12 @@ where
 
 				AvatarBuilder::with_base_avatar(base_avatar)
 					.try_into_armor_and_component(
-						pet_type,
-						slot_type,
-						vec![*self],
-						rarity_type,
-						(ColorType::None, ColorType::None),
-						ForceType::None,
+						&pet_type,
+						&slot_type,
+						&[self.clone()],
+						&rarity_type,
+						&(ColorType::None, ColorType::None),
+						&ForceType::None,
 						soul_count,
 					)
 					.unwrap()
@@ -194,7 +182,14 @@ where
 				);
 
 				AvatarBuilder::with_base_avatar(base_avatar)
-					.try_into_weapon(pet_type, slot_type, *self, color_pair, force_type, soul_count)
+					.try_into_weapon(
+						&pet_type,
+						&slot_type,
+						self,
+						&color_pair,
+						&force_type,
+						soul_count,
+					)
 					.unwrap()
 			},
 		}
@@ -202,10 +197,7 @@ where
 	}
 }
 
-impl<T> AvatarMutator<T> for BlueprintItemType
-where
-	T: Config,
-{
+impl<T: Config> AvatarMutator<T> for BlueprintItemType {
 	fn mutate_from_base(
 		&self,
 		base_avatar: Avatar,
@@ -225,15 +217,12 @@ where
 		);
 
 		AvatarBuilder::with_base_avatar(base_avatar)
-			.into_blueprint(*self, pet_type, slot_type, equipable_item_type, pattern, soul_count)
+			.into_blueprint(self, &pet_type, &slot_type, &equipable_item_type, &pattern, soul_count)
 			.build()
 	}
 }
 
-impl<T> AvatarMutator<T> for SpecialItemType
-where
-	T: Config,
-{
+impl<T: Config> AvatarMutator<T> for SpecialItemType {
 	fn mutate_from_base(
 		&self,
 		base_avatar: Avatar,

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/mutator.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/mutator.rs
@@ -88,9 +88,55 @@ where
 	fn mutate_from_base(
 		&self,
 		base_avatar: Avatar,
-		_hash_provider: &mut HashProvider<T, 32>,
+		hash_provider: &mut HashProvider<T, 32>,
 	) -> Avatar {
-		AvatarBuilder::with_base_avatar(base_avatar).into_glimmer(1).build()
+		let souls = (hash_provider.get_hash_byte() % 99) + 1;
+
+		match *self {
+			EssenceItemType::Glimmer =>
+				AvatarBuilder::with_base_avatar(base_avatar).into_glimmer(souls),
+			EssenceItemType::ColorSpark | EssenceItemType::PaintFlask => {
+				let hash_byte = hash_provider.get_hash_byte();
+				let color_pair = (
+					ColorType::from_byte(AvatarUtils::high_nibble_of(hash_byte)),
+					ColorType::from_byte(AvatarUtils::low_nibble_of(hash_byte)),
+				);
+
+				if *self == EssenceItemType::ColorSpark {
+					AvatarBuilder::with_base_avatar(base_avatar).into_color_spark(
+						color_pair,
+						souls as SoulCount,
+						None,
+					)
+				} else {
+					AvatarBuilder::with_base_avatar(base_avatar).into_paint_flask(
+						color_pair,
+						souls as SoulCount,
+						None,
+					)
+				}
+			},
+			EssenceItemType::GlowSpark | EssenceItemType::ForceGlow => {
+				let force_type = ForceType::from_byte(
+					hash_provider.get_hash_byte() % ForceType::range().end as u8,
+				);
+
+				if *self == EssenceItemType::GlowSpark {
+					AvatarBuilder::with_base_avatar(base_avatar).into_glow_spark(
+						force_type,
+						souls as SoulCount,
+						None,
+					)
+				} else {
+					AvatarBuilder::with_base_avatar(base_avatar).into_force_glow(
+						force_type,
+						souls as SoulCount,
+						None,
+					)
+				}
+			},
+		}
+		.build()
 	}
 }
 

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/mutator.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/mutator.rs
@@ -1,0 +1,209 @@
+use super::*;
+use crate::types::Avatar;
+
+pub(crate) trait AvatarMutator<T: Config> {
+	fn mutate_from_base(
+		&self,
+		base_avatar: Avatar,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Avatar;
+}
+
+impl<T> AvatarMutator<T> for PetItemType
+where
+	T: Config,
+{
+	fn mutate_from_base(
+		&self,
+		base_avatar: Avatar,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Avatar {
+		match self {
+			PetItemType::Pet => {
+				let pet_type = SlotRoller::<T>::roll_on(&PET_TYPE_PROBABILITIES, hash_provider);
+				let pet_variation = hash_provider.get_hash_byte() % 0x0F;
+
+				let spec_bytes = [0; 16];
+
+				let progress_array = AvatarUtils::generate_progress_bytes(
+					RarityType::Legendary,
+					SCALING_FACTOR_PERC,
+					SPARK_PROGRESS_PROB_PERC,
+					[0; 11],
+				);
+
+				let soul_count = (hash_provider.get_hash_byte() as SoulCount % 25) + 1;
+
+				AvatarBuilder::with_base_avatar(base_avatar).into_pet(
+					pet_type,
+					pet_variation,
+					spec_bytes,
+					progress_array,
+					soul_count,
+				)
+			},
+			PetItemType::PetPart => {
+				let quantity = (hash_provider.get_hash_byte() % MAX_QUANTITY) + 1;
+				let slot_type = SlotRoller::<T>::roll_on(&ARMOR_SLOT_PROBABILITIES, hash_provider);
+				let pet_type = SlotRoller::<T>::roll_on(&PET_TYPE_PROBABILITIES, hash_provider);
+
+				AvatarBuilder::with_base_avatar(base_avatar)
+					.into_pet_part(pet_type, slot_type, quantity)
+			},
+			PetItemType::Egg => {
+				let pet_variation = hash_provider.get_hash_byte() % 0x0F;
+				let soul_points = (hash_provider.get_hash_byte() % 99) + 1;
+
+				AvatarBuilder::with_base_avatar(base_avatar).into_egg(
+					RarityType::Epic,
+					pet_variation,
+					soul_points as SoulCount,
+					None,
+				)
+			},
+		}
+		.build()
+	}
+}
+
+impl<T> AvatarMutator<T> for MaterialItemType
+where
+	T: Config,
+{
+	fn mutate_from_base(
+		&self,
+		base_avatar: Avatar,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Avatar {
+		AvatarBuilder::with_base_avatar(base_avatar)
+			.into_material(*self, (hash_provider.get_hash_byte() % MAX_QUANTITY) + 1)
+			.build()
+	}
+}
+
+impl<T> AvatarMutator<T> for EssenceItemType
+where
+	T: Config,
+{
+	fn mutate_from_base(
+		&self,
+		base_avatar: Avatar,
+		_hash_provider: &mut HashProvider<T, 32>,
+	) -> Avatar {
+		AvatarBuilder::with_base_avatar(base_avatar).into_glimmer(1).build()
+	}
+}
+
+impl<T> AvatarMutator<T> for EquipableItemType
+where
+	T: Config,
+{
+	fn mutate_from_base(
+		&self,
+		base_avatar: Avatar,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Avatar {
+		let soul_count = (hash_provider.get_hash_byte() as SoulCount % 25) + 1;
+		let pet_type = SlotRoller::<T>::roll_on(&PET_TYPE_PROBABILITIES, hash_provider);
+
+		match *self {
+			EquipableItemType::ArmorBase |
+			EquipableItemType::ArmorComponent1 |
+			EquipableItemType::ArmorComponent2 |
+			EquipableItemType::ArmorComponent3 => {
+				let slot_type = SlotRoller::<T>::roll_on(&ARMOR_SLOT_PROBABILITIES, hash_provider);
+
+				AvatarBuilder::with_base_avatar(base_avatar)
+					.try_into_armor_and_component(
+						pet_type,
+						slot_type,
+						vec![*self],
+						RarityType::Common,
+						(ColorType::None, ColorType::None),
+						ForceType::None,
+						soul_count,
+					)
+					.unwrap()
+			},
+			EquipableItemType::WeaponVersion1 |
+			EquipableItemType::WeaponVersion2 |
+			EquipableItemType::WeaponVersion3 => {
+				let slot_type = SlotRoller::<T>::roll_on(&WEAPON_SLOT_PROBABILITIES, hash_provider);
+
+				let hash_byte = hash_provider.get_hash_byte();
+				let color_pair = (
+					ColorType::from_byte(AvatarUtils::high_nibble_of(hash_byte)),
+					ColorType::from_byte(AvatarUtils::low_nibble_of(hash_byte)),
+				);
+				let force_type = ForceType::from_byte(
+					hash_provider.get_hash_byte() % ForceType::range().end as u8,
+				);
+
+				AvatarBuilder::with_base_avatar(base_avatar)
+					.try_into_weapon(pet_type, slot_type, *self, color_pair, force_type, soul_count)
+					.unwrap()
+			},
+		}
+		.build()
+	}
+}
+
+impl<T> AvatarMutator<T> for BlueprintItemType
+where
+	T: Config,
+{
+	fn mutate_from_base(
+		&self,
+		base_avatar: Avatar,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Avatar {
+		let soul_count = (hash_provider.get_hash_byte() as SoulCount % 25) + 1;
+
+		let pet_type = SlotRoller::<T>::roll_on(&PET_TYPE_PROBABILITIES, hash_provider);
+		let slot_type = SlotRoller::<T>::roll_on(&ARMOR_SLOT_PROBABILITIES, hash_provider);
+		let equipable_item_type =
+			SlotRoller::<T>::roll_on(&EQUIPMENT_TYPE_PROBABILITIES, hash_provider);
+
+		let base_seed = pet_type.as_byte() as usize + slot_type.as_byte() as usize;
+		let pattern = AvatarUtils::create_pattern::<MaterialItemType>(
+			base_seed,
+			equipable_item_type.as_byte() as usize,
+		);
+
+		AvatarBuilder::with_base_avatar(base_avatar)
+			.into_blueprint(*self, pet_type, slot_type, equipable_item_type, pattern, soul_count)
+			.build()
+	}
+}
+
+impl<T> AvatarMutator<T> for SpecialItemType
+where
+	T: Config,
+{
+	fn mutate_from_base(
+		&self,
+		base_avatar: Avatar,
+		hash_provider: &mut HashProvider<T, 32>,
+	) -> Avatar {
+		let soul_count = (hash_provider.get_hash_byte() as SoulCount % 25) + 1;
+
+		match self {
+			SpecialItemType::Dust =>
+				AvatarBuilder::with_base_avatar(base_avatar).into_dust(soul_count),
+			SpecialItemType::Unidentified => {
+				let hash_byte = hash_provider.get_hash_byte();
+				let color_pair = (
+					ColorType::from_byte(AvatarUtils::high_nibble_of(hash_byte)),
+					ColorType::from_byte(AvatarUtils::low_nibble_of(hash_byte)),
+				);
+				let force_type = ForceType::from_byte(
+					hash_provider.get_hash_byte() % ForceType::range().end as u8,
+				);
+
+				AvatarBuilder::with_base_avatar(base_avatar)
+					.into_unidentified(color_pair, force_type, soul_count)
+			},
+		}
+		.build()
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/slot_roller.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/slot_roller.rs
@@ -1,0 +1,69 @@
+use crate::{
+	types::{avatar::tools::v2::avatar_utils::HashProvider, PackType},
+	Config,
+};
+use sp_std::marker::PhantomData;
+
+/// Represents a ‰ value, which goes from 1 to 1000
+pub type SlotPerMille = u16;
+pub type Slot<T> = (T, SlotPerMille);
+pub type ProbabilitySlots<T, const N: usize> = [Slot<T>; N];
+
+pub(crate) struct SlotRoller<'a, T: Config>(pub PhantomData<&'a T>);
+
+impl<'a, T> SlotRoller<'a, T>
+where
+	T: Config,
+{
+	/// Rolls number between 1 and 1000, representing a range of 0.1% increments in probability.
+	pub(crate) fn roll_number<const HS: usize>(hash_provider: &mut HashProvider<T, HS>) -> u16 {
+		let first_number = (hash_provider.get_hash_byte() as u16) << 8;
+		let second_number = hash_provider.get_hash_byte() as u16;
+		((first_number | second_number) % 1000) + 1
+	}
+
+	pub(crate) fn roll_on<S, const N: usize, const HS: usize>(
+		slots: &ProbabilitySlots<S, N>,
+		hash_provider: &mut HashProvider<T, HS>,
+	) -> S
+	where
+		S: Copy + Clone + Default,
+	{
+		let mut item_rolled = S::default();
+		let mut roll = Self::roll_number(hash_provider);
+
+		for (slot_item, slot_probability) in slots {
+			roll = roll.saturating_sub(*slot_probability);
+
+			if roll == 0 {
+				item_rolled = *slot_item;
+				break
+			}
+		}
+
+		item_rolled
+	}
+
+	/// Rolls and picks from one of the three slots used as arguments, based on the value of
+	/// pack_type
+	pub(crate) fn roll_on_pack_type<S, const N: usize, const HS: usize>(
+		pack_type: PackType,
+		on_material: &ProbabilitySlots<S, N>,
+		on_equipment: &ProbabilitySlots<S, N>,
+		on_special: &ProbabilitySlots<S, N>,
+		hash_provider: &mut HashProvider<T, HS>,
+	) -> S
+	where
+		S: Copy + Clone + Default,
+	{
+		let slots = match pack_type {
+			PackType::Material => on_material,
+			PackType::Equipment => on_equipment,
+			PackType::Special => on_special,
+		};
+
+		Self::roll_on(slots, hash_provider)
+	}
+}
+
+// TODO: Add probability verification tests

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/slot_roller.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/slot_roller.rs
@@ -9,12 +9,9 @@ pub type SlotPerMille = u16;
 pub type Slot<T> = (T, SlotPerMille);
 pub type ProbabilitySlots<T, const N: usize> = [Slot<T>; N];
 
-pub(crate) struct SlotRoller<'a, T: Config>(pub PhantomData<&'a T>);
+pub(crate) struct SlotRoller<T: Config>(pub PhantomData<T>);
 
-impl<'a, T> SlotRoller<'a, T>
-where
-	T: Config,
-{
+impl<T: Config> SlotRoller<T> {
 	/// Rolls number between 1 and 1000, representing a range of 0.1% increments in probability.
 	pub(crate) fn roll_number<const HS: usize>(hash_provider: &mut HashProvider<T, HS>) -> u16 {
 		let first_number = (hash_provider.get_hash_byte() as u16) << 8;
@@ -27,7 +24,7 @@ where
 		hash_provider: &mut HashProvider<T, HS>,
 	) -> S
 	where
-		S: Copy + Clone + Default,
+		S: Clone + Default,
 	{
 		let mut item_rolled = S::default();
 		let mut roll = Self::roll_number(hash_provider);
@@ -36,7 +33,7 @@ where
 			roll = roll.saturating_sub(*slot_probability);
 
 			if roll == 0 {
-				item_rolled = *slot_item;
+				item_rolled = slot_item.clone();
 				break
 			}
 		}
@@ -54,7 +51,7 @@ where
 		hash_provider: &mut HashProvider<T, HS>,
 	) -> S
 	where
-		S: Copy + Clone + Default,
+		S: Clone + Default,
 	{
 		let slots = match pack_type {
 			PackType::Material => on_material,

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/test_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/test_utils.rs
@@ -91,7 +91,7 @@ pub(crate) fn create_random_pet(
 		None,
 		Some(|avatar| {
 			AvatarBuilder::with_base_avatar(avatar)
-				.into_pet(pet_type, pet_variation, spec_bytes, progress_array, soul_points)
+				.into_pet(pet_type, pet_variation, spec_bytes, Some(progress_array), soul_points)
 				.build()
 		}),
 	)

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/test_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/test_utils.rs
@@ -1,0 +1,334 @@
+use crate::{
+	mock::{MockAccountId, Test},
+	pallet::AvatarIdOf,
+	types::{
+		avatar::tools::v2::{
+			avatar_utils::{AvatarAttributes, AvatarBuilder, AvatarUtils},
+			types::{
+				BlueprintItemType, ColorType, EquipableItemType, ForceType, MaterialItemType,
+				PetType, RarityType, SlotType,
+			},
+		},
+		Avatar, AvatarVersion, ForgeOutput, LeaderForgeOutput, SoulCount,
+	},
+	Config, Pallet,
+};
+use sp_core::bounded::BoundedVec;
+
+pub const HASH_BYTES: [u8; 32] = [
+	1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89,
+	97, 101, 103, 107, 109, 113, 127,
+];
+
+#[inline]
+pub(crate) fn create_random_avatar<T, F>(
+	creator: &T::AccountId,
+	initial_dna: Option<[u8; 32]>,
+	avatar_build_fn: Option<F>,
+) -> (AvatarIdOf<T>, Avatar)
+where
+	F: FnOnce(Avatar) -> Avatar,
+	T: Config,
+{
+	let base_avatar = Avatar {
+		season_id: 0,
+		version: AvatarVersion::V2,
+		dna: BoundedVec::try_from(initial_dna.unwrap_or([0_u8; 32]).to_vec())
+			.expect("Should create DNA!"),
+		souls: 0,
+	};
+
+	let avatar = match avatar_build_fn {
+		None => base_avatar,
+		Some(f) => f(base_avatar),
+	};
+	(Pallet::<T>::random_hash(b"mock_avatar", creator), avatar)
+}
+
+pub(crate) fn create_random_material(
+	account: &MockAccountId,
+	material_type: MaterialItemType,
+	quantity: u8,
+) -> (AvatarIdOf<Test>, Avatar) {
+	create_random_avatar::<Test, _>(
+		account,
+		None,
+		Some(|avatar| {
+			AvatarBuilder::with_base_avatar(avatar)
+				.into_material(material_type, quantity)
+				.build()
+		}),
+	)
+}
+
+pub(crate) fn create_random_pet_part(
+	account: &MockAccountId,
+	pet_type: PetType,
+	slot_type: SlotType,
+	quantity: u8,
+) -> (AvatarIdOf<Test>, Avatar) {
+	create_random_avatar::<Test, _>(
+		account,
+		None,
+		Some(|avatar| {
+			AvatarBuilder::with_base_avatar(avatar)
+				.into_pet_part(pet_type, slot_type, quantity)
+				.build()
+		}),
+	)
+}
+
+pub(crate) fn create_random_pet(
+	account: &MockAccountId,
+	pet_type: PetType,
+	pet_variation: u8,
+	spec_bytes: [u8; 16],
+	progress_array: [u8; 11],
+	soul_points: SoulCount,
+) -> (AvatarIdOf<Test>, Avatar) {
+	create_random_avatar::<Test, _>(
+		account,
+		None,
+		Some(|avatar| {
+			AvatarBuilder::with_base_avatar(avatar)
+				.into_pet(pet_type, pet_variation, spec_bytes, progress_array, soul_points)
+				.build()
+		}),
+	)
+}
+
+pub(crate) fn create_random_blueprint(
+	account: &MockAccountId,
+	pet_type: PetType,
+	slot_type: SlotType,
+	equipable_type: EquipableItemType,
+	material_pattern: Vec<MaterialItemType>,
+	soul_points: SoulCount,
+) -> (AvatarIdOf<Test>, Avatar) {
+	create_random_avatar::<Test, _>(
+		account,
+		None,
+		Some(|avatar| {
+			AvatarBuilder::with_base_avatar(avatar)
+				.into_blueprint(
+					BlueprintItemType::Blueprint,
+					pet_type,
+					slot_type,
+					equipable_type,
+					material_pattern,
+					soul_points,
+				)
+				.build()
+		}),
+	)
+}
+
+pub(crate) fn create_random_armor_component(
+	base_dna: [u8; 32],
+	account: &MockAccountId,
+	pet_type: PetType,
+	slot_type: SlotType,
+	rarity_type: RarityType,
+	equipable_type: Vec<EquipableItemType>,
+	color_pair: (ColorType, ColorType),
+	force_type: ForceType,
+	soul_points: SoulCount,
+) -> (AvatarIdOf<Test>, Avatar) {
+	create_random_avatar::<Test, _>(
+		account,
+		Some(base_dna),
+		Some(|avatar| {
+			AvatarBuilder::with_base_avatar(avatar)
+				.try_into_armor_and_component(
+					pet_type,
+					slot_type,
+					equipable_type,
+					rarity_type,
+					color_pair,
+					force_type,
+					soul_points,
+				)
+				.unwrap()
+				.build()
+		}),
+	)
+}
+
+pub(crate) fn create_random_weapon(
+	base_dna: [u8; 32],
+	account: &MockAccountId,
+	pet_type: PetType,
+	slot_type: SlotType,
+	equipable_type: EquipableItemType,
+	color_pair: (ColorType, ColorType),
+	force_type: ForceType,
+	soul_points: SoulCount,
+) -> (AvatarIdOf<Test>, Avatar) {
+	create_random_avatar::<Test, _>(
+		account,
+		Some(base_dna),
+		Some(|avatar| {
+			AvatarBuilder::with_base_avatar(avatar)
+				.try_into_weapon(
+					pet_type,
+					slot_type,
+					equipable_type,
+					color_pair,
+					force_type,
+					soul_points,
+				)
+				.unwrap()
+				.build()
+		}),
+	)
+}
+
+pub(crate) fn create_random_egg(
+	base_dna: Option<[u8; 32]>,
+	account: &MockAccountId,
+	rarity_type: RarityType,
+	pet_variation: u8,
+	soul_points: SoulCount,
+	progress_array: [u8; 11],
+) -> (AvatarIdOf<Test>, Avatar) {
+	create_random_avatar::<Test, _>(
+		account,
+		base_dna,
+		Some(|avatar| {
+			AvatarBuilder::with_base_avatar(avatar)
+				.into_egg(rarity_type, pet_variation, soul_points, Some(progress_array))
+				.build()
+		}),
+	)
+}
+
+pub(crate) fn create_random_glow_spark(
+	base_dna: Option<[u8; 32]>,
+	account: &MockAccountId,
+	force_type: ForceType,
+	soul_points: SoulCount,
+	progress_array: Option<[u8; 11]>,
+) -> (AvatarIdOf<Test>, Avatar) {
+	create_random_avatar::<Test, _>(
+		account,
+		base_dna,
+		Some(|avatar| {
+			AvatarBuilder::with_base_avatar(avatar)
+				.into_glow_spark(force_type, soul_points, progress_array)
+				.build()
+		}),
+	)
+}
+
+pub(crate) fn create_random_glimmer(
+	account: &MockAccountId,
+	quantity: u8,
+) -> (AvatarIdOf<Test>, Avatar) {
+	create_random_avatar::<Test, _>(
+		account,
+		None,
+		Some(|avatar| AvatarBuilder::with_base_avatar(avatar).into_glimmer(quantity).build()),
+	)
+}
+
+pub(crate) fn create_random_dust(
+	account: &MockAccountId,
+	soul_points: SoulCount,
+) -> (AvatarIdOf<Test>, Avatar) {
+	create_random_avatar::<Test, _>(
+		account,
+		None,
+		Some(|avatar| AvatarBuilder::with_base_avatar(avatar).into_dust(soul_points).build()),
+	)
+}
+
+pub(crate) fn create_random_color_spark(
+	base_dna: Option<[u8; 32]>,
+	account: &MockAccountId,
+	color_pair: (ColorType, ColorType),
+	soul_points: SoulCount,
+	progress_array: Option<[u8; 11]>,
+) -> (AvatarIdOf<Test>, Avatar) {
+	create_random_avatar::<Test, _>(
+		account,
+		base_dna,
+		Some(|avatar| {
+			AvatarBuilder::with_base_avatar(avatar)
+				.into_color_spark(color_pair, soul_points, progress_array)
+				.build()
+		}),
+	)
+}
+
+#[inline]
+pub(crate) fn is_leader_forged<T>(output: &LeaderForgeOutput<T>) -> bool
+where
+	T: Config,
+{
+	matches!(output, LeaderForgeOutput::Forged(_, _))
+}
+
+#[inline]
+pub(crate) fn is_leader_forged_with_attributes<T>(
+	output: &LeaderForgeOutput<T>,
+	attributes: &[(AvatarAttributes, u8)],
+) -> bool
+where
+	T: Config,
+{
+	matches!(output, LeaderForgeOutput::Forged((_, avatar), _) if AvatarUtils::has_attribute_set_with_values(avatar, attributes))
+}
+
+#[inline]
+pub(crate) fn is_leader_consumed<T>(output: &LeaderForgeOutput<T>) -> bool
+where
+	T: Config,
+{
+	matches!(output, LeaderForgeOutput::Consumed(_))
+}
+
+#[inline]
+pub(crate) fn is_forged<T>(output: &ForgeOutput<T>) -> bool
+where
+	T: Config,
+{
+	matches!(output, ForgeOutput::Forged(_, _))
+}
+
+#[inline]
+pub(crate) fn is_forged_with_attributes<T>(
+	output: &ForgeOutput<T>,
+	attributes: &[(AvatarAttributes, u8)],
+) -> bool
+where
+	T: Config,
+{
+	matches!(output, ForgeOutput::Forged((_, avatar), _) if AvatarUtils::has_attribute_set_with_values(avatar, attributes))
+}
+
+#[inline]
+pub(crate) fn is_minted<T>(output: &ForgeOutput<T>) -> bool
+where
+	T: Config,
+{
+	matches!(output, ForgeOutput::Minted(_))
+}
+
+#[inline]
+pub(crate) fn is_minted_with_attributes<T>(
+	output: &ForgeOutput<T>,
+	attributes: &[(AvatarAttributes, u8)],
+) -> bool
+where
+	T: Config,
+{
+	matches!(output, ForgeOutput::Minted(avatar) if AvatarUtils::has_attribute_set_with_values(avatar, attributes))
+}
+
+#[inline]
+pub(crate) fn is_consumed<T>(output: &ForgeOutput<T>) -> bool
+where
+	T: Config,
+{
+	matches!(output, ForgeOutput::Consumed(_))
+}

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/test_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/test_utils.rs
@@ -20,7 +20,6 @@ pub const HASH_BYTES: [u8; 32] = [
 	97, 101, 103, 107, 109, 113, 127,
 ];
 
-#[inline]
 pub(crate) fn create_random_avatar<T, F>(
 	creator: &T::AccountId,
 	initial_dna: Option<[u8; 32]>,
@@ -47,7 +46,7 @@ where
 
 pub(crate) fn create_random_material(
 	account: &MockAccountId,
-	material_type: MaterialItemType,
+	material_type: &MaterialItemType,
 	quantity: u8,
 ) -> (AvatarIdOf<Test>, Avatar) {
 	create_random_avatar::<Test, _>(
@@ -63,8 +62,8 @@ pub(crate) fn create_random_material(
 
 pub(crate) fn create_random_pet_part(
 	account: &MockAccountId,
-	pet_type: PetType,
-	slot_type: SlotType,
+	pet_type: &PetType,
+	slot_type: &SlotType,
 	quantity: u8,
 ) -> (AvatarIdOf<Test>, Avatar) {
 	create_random_avatar::<Test, _>(
@@ -80,7 +79,7 @@ pub(crate) fn create_random_pet_part(
 
 pub(crate) fn create_random_pet(
 	account: &MockAccountId,
-	pet_type: PetType,
+	pet_type: &PetType,
 	pet_variation: u8,
 	spec_bytes: [u8; 16],
 	progress_array: [u8; 11],
@@ -99,10 +98,10 @@ pub(crate) fn create_random_pet(
 
 pub(crate) fn create_random_blueprint(
 	account: &MockAccountId,
-	pet_type: PetType,
-	slot_type: SlotType,
-	equipable_type: EquipableItemType,
-	material_pattern: Vec<MaterialItemType>,
+	pet_type: &PetType,
+	slot_type: &SlotType,
+	equipable_type: &EquipableItemType,
+	material_pattern: &[MaterialItemType],
 	soul_points: SoulCount,
 ) -> (AvatarIdOf<Test>, Avatar) {
 	create_random_avatar::<Test, _>(
@@ -111,7 +110,7 @@ pub(crate) fn create_random_blueprint(
 		Some(|avatar| {
 			AvatarBuilder::with_base_avatar(avatar)
 				.into_blueprint(
-					BlueprintItemType::Blueprint,
+					&BlueprintItemType::Blueprint,
 					pet_type,
 					slot_type,
 					equipable_type,
@@ -126,12 +125,12 @@ pub(crate) fn create_random_blueprint(
 pub(crate) fn create_random_armor_component(
 	base_dna: [u8; 32],
 	account: &MockAccountId,
-	pet_type: PetType,
-	slot_type: SlotType,
-	rarity_type: RarityType,
-	equipable_type: Vec<EquipableItemType>,
-	color_pair: (ColorType, ColorType),
-	force_type: ForceType,
+	pet_type: &PetType,
+	slot_type: &SlotType,
+	rarity_type: &RarityType,
+	equipable_type: &[EquipableItemType],
+	color_pair: &(ColorType, ColorType),
+	force_type: &ForceType,
 	soul_points: SoulCount,
 ) -> (AvatarIdOf<Test>, Avatar) {
 	create_random_avatar::<Test, _>(
@@ -157,11 +156,11 @@ pub(crate) fn create_random_armor_component(
 pub(crate) fn create_random_weapon(
 	base_dna: [u8; 32],
 	account: &MockAccountId,
-	pet_type: PetType,
-	slot_type: SlotType,
-	equipable_type: EquipableItemType,
-	color_pair: (ColorType, ColorType),
-	force_type: ForceType,
+	pet_type: &PetType,
+	slot_type: &SlotType,
+	equipable_type: &EquipableItemType,
+	color_pair: &(ColorType, ColorType),
+	force_type: &ForceType,
 	soul_points: SoulCount,
 ) -> (AvatarIdOf<Test>, Avatar) {
 	create_random_avatar::<Test, _>(
@@ -186,7 +185,7 @@ pub(crate) fn create_random_weapon(
 pub(crate) fn create_random_egg(
 	base_dna: Option<[u8; 32]>,
 	account: &MockAccountId,
-	rarity_type: RarityType,
+	rarity_type: &RarityType,
 	pet_variation: u8,
 	soul_points: SoulCount,
 	progress_array: [u8; 11],
@@ -205,7 +204,7 @@ pub(crate) fn create_random_egg(
 pub(crate) fn create_random_glow_spark(
 	base_dna: Option<[u8; 32]>,
 	account: &MockAccountId,
-	force_type: ForceType,
+	force_type: &ForceType,
 	soul_points: SoulCount,
 	progress_array: Option<[u8; 11]>,
 ) -> (AvatarIdOf<Test>, Avatar) {
@@ -245,7 +244,7 @@ pub(crate) fn create_random_dust(
 pub(crate) fn create_random_color_spark(
 	base_dna: Option<[u8; 32]>,
 	account: &MockAccountId,
-	color_pair: (ColorType, ColorType),
+	color_pair: &(ColorType, ColorType),
 	soul_points: SoulCount,
 	progress_array: Option<[u8; 11]>,
 ) -> (AvatarIdOf<Test>, Avatar) {
@@ -260,7 +259,6 @@ pub(crate) fn create_random_color_spark(
 	)
 }
 
-#[inline]
 pub(crate) fn is_leader_forged<T>(output: &LeaderForgeOutput<T>) -> bool
 where
 	T: Config,
@@ -268,7 +266,6 @@ where
 	matches!(output, LeaderForgeOutput::Forged(_, _))
 }
 
-#[inline]
 pub(crate) fn is_leader_forged_with_attributes<T>(
 	output: &LeaderForgeOutput<T>,
 	attributes: &[(AvatarAttributes, u8)],
@@ -279,7 +276,6 @@ where
 	matches!(output, LeaderForgeOutput::Forged((_, avatar), _) if AvatarUtils::has_attribute_set_with_values(avatar, attributes))
 }
 
-#[inline]
 pub(crate) fn is_leader_consumed<T>(output: &LeaderForgeOutput<T>) -> bool
 where
 	T: Config,
@@ -287,7 +283,6 @@ where
 	matches!(output, LeaderForgeOutput::Consumed(_))
 }
 
-#[inline]
 pub(crate) fn is_forged<T>(output: &ForgeOutput<T>) -> bool
 where
 	T: Config,
@@ -295,7 +290,6 @@ where
 	matches!(output, ForgeOutput::Forged(_, _))
 }
 
-#[inline]
 pub(crate) fn is_forged_with_attributes<T>(
 	output: &ForgeOutput<T>,
 	attributes: &[(AvatarAttributes, u8)],
@@ -306,7 +300,6 @@ where
 	matches!(output, ForgeOutput::Forged((_, avatar), _) if AvatarUtils::has_attribute_set_with_values(avatar, attributes))
 }
 
-#[inline]
 pub(crate) fn is_minted<T>(output: &ForgeOutput<T>) -> bool
 where
 	T: Config,
@@ -314,7 +307,6 @@ where
 	matches!(output, ForgeOutput::Minted(_))
 }
 
-#[inline]
 pub(crate) fn is_minted_with_attributes<T>(
 	output: &ForgeOutput<T>,
 	attributes: &[(AvatarAttributes, u8)],
@@ -325,7 +317,6 @@ where
 	matches!(output, ForgeOutput::Minted(avatar) if AvatarUtils::has_attribute_set_with_values(avatar, attributes))
 }
 
-#[inline]
 pub(crate) fn is_consumed<T>(output: &ForgeOutput<T>) -> bool
 where
 	T: Config,

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/types.rs
@@ -1,8 +1,7 @@
 use sp_std::ops::Range;
 
-pub(crate) trait ByteConvertible: Copy + Clone {
+pub(crate) trait ByteConvertible: Clone {
 	fn from_byte(byte: u8) -> Self;
-
 	fn as_byte(&self) -> u8;
 }
 
@@ -10,7 +9,7 @@ pub(crate) trait Ranged: ByteConvertible {
 	fn range() -> Range<usize>;
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Default)]
 pub(crate) enum ByteType {
 	#[default]
 	Full = 0b1111_1111,
@@ -29,11 +28,11 @@ impl ByteConvertible for ByteType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Default)]
 pub(crate) enum HexType {
 	#[default]
 	X0 = 0b0000,
@@ -78,11 +77,11 @@ impl ByteConvertible for HexType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum NibbleType {
 	#[default]
 	X0 = 0b0000,
@@ -111,7 +110,7 @@ impl ByteConvertible for NibbleType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
@@ -121,7 +120,7 @@ impl Ranged for NibbleType {
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) enum ItemType {
 	#[default]
 	Pet = 1,
@@ -146,11 +145,11 @@ impl ByteConvertible for ItemType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default, PartialEq, PartialOrd)]
 pub(crate) enum RarityType {
 	#[default]
 	Common = 1,
@@ -175,11 +174,11 @@ impl ByteConvertible for RarityType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) enum PetItemType {
 	#[default]
 	Pet = 1,
@@ -198,11 +197,11 @@ impl ByteConvertible for PetItemType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) enum EquipableItemType {
 	#[default]
 	ArmorBase = 1,
@@ -229,7 +228,7 @@ impl ByteConvertible for EquipableItemType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
@@ -254,7 +253,7 @@ impl EquipableItemType {
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum PetType {
 	#[default]
 	TankyBullwog = 1,
@@ -281,7 +280,7 @@ impl ByteConvertible for PetType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
@@ -291,7 +290,7 @@ impl Ranged for PetType {
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) enum PetPartType {
 	#[default]
 	Horns = 1,
@@ -318,11 +317,11 @@ impl ByteConvertible for PetPartType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum SlotType {
 	#[default]
 	Head = 1,
@@ -351,7 +350,7 @@ impl ByteConvertible for SlotType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
@@ -361,7 +360,7 @@ impl Ranged for SlotType {
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum MaterialItemType {
 	#[default]
 	Polymers = 1,
@@ -390,7 +389,7 @@ impl ByteConvertible for MaterialItemType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
@@ -400,7 +399,7 @@ impl Ranged for MaterialItemType {
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) enum EssenceItemType {
 	#[default]
 	Glimmer = 1,
@@ -423,11 +422,11 @@ impl ByteConvertible for EssenceItemType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) enum BlueprintItemType {
 	#[default]
 	Blueprint = 1,
@@ -442,11 +441,11 @@ impl ByteConvertible for BlueprintItemType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) enum ColorType {
 	#[default]
 	None = 0,
@@ -469,7 +468,7 @@ impl ByteConvertible for ColorType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
@@ -479,7 +478,7 @@ impl Ranged for ColorType {
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) enum ForceType {
 	#[default]
 	None = 0,
@@ -506,7 +505,7 @@ impl ByteConvertible for ForceType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }
 
@@ -516,7 +515,7 @@ impl Ranged for ForceType {
 	}
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) enum SpecialItemType {
 	#[default]
 	Dust = 1,
@@ -533,6 +532,6 @@ impl ByteConvertible for SpecialItemType {
 	}
 
 	fn as_byte(&self) -> u8 {
-		*self as u8
+		self.clone() as u8
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/types.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/tools/v2/types.rs
@@ -1,0 +1,538 @@
+use sp_std::ops::Range;
+
+pub(crate) trait ByteConvertible: Copy + Clone {
+	fn from_byte(byte: u8) -> Self;
+
+	fn as_byte(&self) -> u8;
+}
+
+pub(crate) trait Ranged: ByteConvertible {
+	fn range() -> Range<usize>;
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum ByteType {
+	#[default]
+	Full = 0b1111_1111,
+	High = 0b0000_1111,
+	Low = 0b1111_0000,
+}
+
+impl ByteConvertible for ByteType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			0xFF => Self::Full,
+			0x0F => Self::High,
+			0xF0 => Self::Low,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum HexType {
+	#[default]
+	X0 = 0b0000,
+	X1 = 0b0001,
+	X2 = 0b0010,
+	X3 = 0b0011,
+	X4 = 0b0100,
+	X5 = 0b0101,
+	X6 = 0b0110,
+	X7 = 0b0111,
+	X8 = 0b1000,
+	X9 = 0b1001,
+	XA = 0b1010,
+	XB = 0b1011,
+	XC = 0b1100,
+	XD = 0b1101,
+	XE = 0b1110,
+	XF = 0b1111,
+}
+
+impl ByteConvertible for HexType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			0x0 => Self::X0,
+			0x1 => Self::X1,
+			0x2 => Self::X2,
+			0x3 => Self::X3,
+			0x4 => Self::X4,
+			0x5 => Self::X5,
+			0x6 => Self::X6,
+			0x7 => Self::X7,
+			0x8 => Self::X8,
+			0x9 => Self::X9,
+			0xA => Self::XA,
+			0xB => Self::XB,
+			0xC => Self::XC,
+			0xD => Self::XD,
+			0xE => Self::XE,
+			0xF => Self::XF,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum NibbleType {
+	#[default]
+	X0 = 0b0000,
+	X1 = 0b0001,
+	X2 = 0b0010,
+	X3 = 0b0011,
+	X4 = 0b0100,
+	X5 = 0b0101,
+	X6 = 0b0110,
+	X7 = 0b0111,
+}
+
+impl ByteConvertible for NibbleType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			0b0000 => Self::X0,
+			0b0001 => Self::X1,
+			0b0010 => Self::X2,
+			0b0011 => Self::X3,
+			0b0100 => Self::X4,
+			0b0101 => Self::X5,
+			0b0110 => Self::X6,
+			0b0111 => Self::X7,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+impl Ranged for NibbleType {
+	fn range() -> Range<usize> {
+		0..8
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum ItemType {
+	#[default]
+	Pet = 1,
+	Material = 2,
+	Essence = 3,
+	Equipable = 4,
+	Blueprint = 5,
+	Special = 6,
+}
+
+impl ByteConvertible for ItemType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			1 => Self::Pet,
+			2 => Self::Material,
+			3 => Self::Essence,
+			4 => Self::Equipable,
+			5 => Self::Blueprint,
+			6 => Self::Special,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum RarityType {
+	#[default]
+	Common = 1,
+	Uncommon = 2,
+	Rare = 3,
+	Epic = 4,
+	Legendary = 5,
+	Mythical = 6,
+}
+
+impl ByteConvertible for RarityType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			1 => Self::Common,
+			2 => Self::Uncommon,
+			3 => Self::Rare,
+			4 => Self::Epic,
+			5 => Self::Legendary,
+			6 => Self::Mythical,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum PetItemType {
+	#[default]
+	Pet = 1,
+	PetPart = 2,
+	Egg = 3,
+}
+
+impl ByteConvertible for PetItemType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			1 => Self::Pet,
+			2 => Self::PetPart,
+			3 => Self::Egg,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum EquipableItemType {
+	#[default]
+	ArmorBase = 1,
+	ArmorComponent1 = 2,
+	ArmorComponent2 = 3,
+	ArmorComponent3 = 4,
+	WeaponVersion1 = 5,
+	WeaponVersion2 = 6,
+	WeaponVersion3 = 7,
+}
+
+impl ByteConvertible for EquipableItemType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			1 => Self::ArmorBase,
+			2 => Self::ArmorComponent1,
+			3 => Self::ArmorComponent2,
+			4 => Self::ArmorComponent3,
+			5 => Self::WeaponVersion1,
+			6 => Self::WeaponVersion2,
+			7 => Self::WeaponVersion3,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+impl Ranged for EquipableItemType {
+	fn range() -> Range<usize> {
+		1..8
+	}
+}
+
+impl EquipableItemType {
+	pub fn is_armor(item: EquipableItemType) -> bool {
+		item == EquipableItemType::ArmorBase ||
+			item == EquipableItemType::ArmorComponent1 ||
+			item == EquipableItemType::ArmorComponent2 ||
+			item == EquipableItemType::ArmorComponent3
+	}
+
+	pub fn is_weapon(item: EquipableItemType) -> bool {
+		item == EquipableItemType::WeaponVersion1 ||
+			item == EquipableItemType::WeaponVersion2 ||
+			item == EquipableItemType::WeaponVersion3
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum PetType {
+	#[default]
+	TankyBullwog = 1,
+	FoxishDude = 2,
+	WierdFerry = 3,
+	FireDino = 4,
+	BigHybrid = 5,
+	GiantWoodStick = 6,
+	CrazyDude = 7,
+}
+
+impl ByteConvertible for PetType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			1 => Self::TankyBullwog,
+			2 => Self::FoxishDude,
+			3 => Self::WierdFerry,
+			4 => Self::FireDino,
+			5 => Self::BigHybrid,
+			6 => Self::GiantWoodStick,
+			7 => Self::CrazyDude,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+impl Ranged for PetType {
+	fn range() -> Range<usize> {
+		1..8
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum PetPartType {
+	#[default]
+	Horns = 1,
+	Furs = 2,
+	Wings = 3,
+	Scales = 4,
+	Claws = 5,
+	Sticks = 6,
+	Eyes = 7,
+}
+
+impl ByteConvertible for PetPartType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			1 => Self::Horns,
+			2 => Self::Furs,
+			3 => Self::Wings,
+			4 => Self::Scales,
+			5 => Self::Claws,
+			6 => Self::Sticks,
+			7 => Self::Eyes,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum SlotType {
+	#[default]
+	Head = 1,
+	Breast = 2,
+	ArmFront = 3,
+	ArmBack = 4,
+	LegFront = 5,
+	LegBack = 6,
+	WeaponFront = 8,
+	WeaponBack = 9,
+}
+
+impl ByteConvertible for SlotType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			1 => Self::Head,
+			2 => Self::Breast,
+			3 => Self::ArmFront,
+			4 => Self::ArmBack,
+			5 => Self::LegFront,
+			6 => Self::LegBack,
+			8 => Self::WeaponFront,
+			9 => Self::WeaponBack,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+impl Ranged for SlotType {
+	fn range() -> Range<usize> {
+		1..10
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum MaterialItemType {
+	#[default]
+	Polymers = 1,
+	Electronics = 2,
+	PowerCells = 3,
+	Optics = 4,
+	Metals = 5,
+	Ceramics = 6,
+	Superconductors = 7,
+	Nanomaterials = 8,
+}
+
+impl ByteConvertible for MaterialItemType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			1 => Self::Polymers,
+			2 => Self::Electronics,
+			3 => Self::PowerCells,
+			4 => Self::Optics,
+			5 => Self::Metals,
+			6 => Self::Ceramics,
+			7 => Self::Superconductors,
+			8 => Self::Nanomaterials,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+impl Ranged for MaterialItemType {
+	fn range() -> Range<usize> {
+		1..9
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum EssenceItemType {
+	#[default]
+	Glimmer = 1,
+	ColorSpark = 2,
+	GlowSpark = 3,
+	PaintFlask = 4,
+	ForceGlow = 5,
+}
+
+impl ByteConvertible for EssenceItemType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			1 => Self::Glimmer,
+			2 => Self::ColorSpark,
+			3 => Self::GlowSpark,
+			4 => Self::PaintFlask,
+			5 => Self::ForceGlow,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum BlueprintItemType {
+	#[default]
+	Blueprint = 1,
+}
+
+impl ByteConvertible for BlueprintItemType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			1 => Self::Blueprint,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum ColorType {
+	#[default]
+	None = 0,
+	ColorA = 1,
+	ColorB = 2,
+	ColorC = 3,
+	ColorD = 4,
+}
+
+impl ByteConvertible for ColorType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			0 => Self::None,
+			1 => Self::ColorA,
+			2 => Self::ColorB,
+			3 => Self::ColorC,
+			4 => Self::ColorD,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+impl Ranged for ColorType {
+	fn range() -> Range<usize> {
+		0..5
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum ForceType {
+	#[default]
+	None = 0,
+	Kinetic = 1,
+	Dream = 2,
+	Solar = 3,
+	Thermal = 4,
+	Astral = 5,
+	Empathy = 6,
+}
+
+impl ByteConvertible for ForceType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			0 => Self::None,
+			1 => Self::Kinetic,
+			2 => Self::Dream,
+			3 => Self::Solar,
+			4 => Self::Thermal,
+			5 => Self::Astral,
+			6 => Self::Empathy,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}
+
+impl Ranged for ForceType {
+	fn range() -> Range<usize> {
+		0..7
+	}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum SpecialItemType {
+	#[default]
+	Dust = 1,
+	Unidentified = 2,
+}
+
+impl ByteConvertible for SpecialItemType {
+	fn from_byte(byte: u8) -> Self {
+		match byte {
+			1 => Self::Dust,
+			2 => Self::Unidentified,
+			_ => Self::default(),
+		}
+	}
+
+	fn as_byte(&self) -> u8 {
+		*self as u8
+	}
+}

--- a/pallets/ajuna-awesome-avatars/src/types/config.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/config.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::types::AvatarVersion;
 use frame_support::pallet_prelude::*;
 
 /// Number of avatars to be minted.
@@ -68,11 +69,32 @@ impl Default for MintType {
 	}
 }
 
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Copy, Clone, Debug, Eq, PartialEq)]
+pub enum PackType {
+	Material = 1,
+	Equipment = 2,
+	Special = 3,
+}
+
+impl Default for PackType {
+	fn default() -> Self {
+		PackType::Material
+	}
+}
+
+impl PackType {
+	// TODO: Define probabilities here? Or in the minter?
+}
+
 /// Minting options
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, Eq, PartialEq)]
 pub struct MintOption {
 	/// Type of minting.
 	pub mint_type: MintType,
+	/// Type of pack to mint
+	pub mint_pack: PackType,
+	/// Avatar version to mint
+	pub mint_version: AvatarVersion,
 	/// Number of avatars to mint.
 	pub count: MintPackSize,
 }

--- a/pallets/ajuna-awesome-avatars/src/types/config.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/config.rs
@@ -18,17 +18,12 @@ use crate::types::AvatarVersion;
 use frame_support::pallet_prelude::*;
 
 /// Number of avatars to be minted.
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
 pub enum MintPackSize {
+	#[default]
 	One = 1,
 	Three = 3,
 	Six = 6,
-}
-
-impl Default for MintPackSize {
-	fn default() -> Self {
-		MintPackSize::One
-	}
 }
 
 impl MintPackSize {
@@ -38,7 +33,7 @@ impl MintPackSize {
 }
 
 /// Minting fee per pack of avatars.
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
 pub struct MintFees<Balance> {
 	pub one: Balance,
 	pub three: Balance,
@@ -55,39 +50,25 @@ impl<Balance> MintFees<Balance> {
 	}
 }
 
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Eq, PartialEq)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
 pub enum MintType {
 	/// Mint using free mint credits.
+	#[default]
 	Free,
 	/// Normal minting consuming currency.
 	Normal,
 }
 
-impl Default for MintType {
-	fn default() -> Self {
-		MintType::Free
-	}
-}
-
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
 pub enum PackType {
+	#[default]
 	Material = 1,
 	Equipment = 2,
 	Special = 3,
 }
 
-impl Default for PackType {
-	fn default() -> Self {
-		PackType::Material
-	}
-}
-
-impl PackType {
-	// TODO: Define probabilities here? Or in the minter?
-}
-
 /// Minting options
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
 pub struct MintOption {
 	/// Type of minting.
 	pub mint_type: MintType,

--- a/pallets/ajuna-awesome-avatars/src/types/season.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/season.rs
@@ -82,6 +82,10 @@ impl<BlockNumber: AtLeast32Bit + Copy> Season<BlockNumber> {
 		current_period.unique_saturated_into()
 	}
 
+	pub(crate) fn max_tier(&self) -> RarityTier {
+		*self.tiers.iter().max().unwrap_or(&RarityTier::Common)
+	}
+
 	fn full_cycle(&self) -> BlockNumber {
 		self.per_period.saturating_mul(self.periods.unique_saturated_into())
 	}


### PR DESCRIPTION
## Description

Since we want to have more complex avatar logic and types in the future, this PR plays around with the idea of trying to 
isolate parts of the logic behind avatar version enum.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
