### PR TITLE
Remove transfer holding account

### DIFF
--- a/node/service/src/chain_spec/bajun.rs
+++ b/node/service/src/chain_spec/bajun.rs
@@ -169,6 +169,5 @@ fn testnet_genesis(
 		polkadot_xcm: bajun_runtime::PolkadotXcmConfig { safe_xcm_version: Some(SAFE_XCM_VERSION) },
 		awesome_avatars: Default::default(),
 		nft_stake: Default::default(),
-		nft_transfer: Default::default(),
 	}
 }

--- a/node/service/src/chain_spec/solo.rs
+++ b/node/service/src/chain_spec/solo.rs
@@ -204,6 +204,5 @@ fn compose_genesis_config(config: Config) -> GenesisConfig {
 		democracy: Default::default(),
 		awesome_avatars: Default::default(),
 		nft_staking: Default::default(),
-		nft_transfer: Default::default(),
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -116,7 +116,17 @@ pub mod pallet {
 
 		type Randomness: Randomness<Self::Hash, Self::BlockNumber>;
 
-		type NftHandler: NftHandler<Self::AccountId, Avatar>;
+		/// Type that holds the specific configuration for an avatar once transformed into an NFT.
+		type AvatarNftConfig: Copy
+			+ Clone
+			+ Default
+			+ PartialEq
+			+ Encode
+			+ Decode
+			+ MaxEncodedLen
+			+ TypeInfo;
+
+		type NftHandler: NftHandler<Self::AccountId, Avatar, Self::AvatarNftConfig>;
 
 		type WeightInfo: WeightInfo;
 	}
@@ -745,7 +755,9 @@ pub mod pallet {
 			ensure!(Self::ensure_for_trade(&avatar_id).is_err(), Error::<T>::AvatarInTrade);
 			Self::ensure_unlocked(&avatar_id)?;
 
-			let asset_id = T::NftHandler::store_as_nft(account, avatar)?;
+			// TODO: Use a defined config, either as parameter or as a constant in the pallet config
+			let asset_config = T::AvatarNftConfig::default();
+			let asset_id = T::NftHandler::store_as_nft(account, avatar, asset_config)?;
 			LockedAvatars::<T>::insert(avatar_id, &asset_id);
 			Self::deposit_event(Event::AvatarLocked { avatar_id, asset_id });
 			Ok(())

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -95,8 +95,11 @@ pub mod pallet {
 	pub(crate) type BoundedAvatarIdsOf<T> = BoundedVec<AvatarIdOf<T>, MaxAvatarsPerPlayer>;
 	pub(crate) type GlobalConfigOf<T> = GlobalConfig<BalanceOf<T>, BlockNumberFor<T>>;
 
-	pub(crate) type AssetIdOf<T> =
-		<<T as Config>::NftHandler as NftHandler<AccountIdOf<T>, Avatar>>::AssetId;
+	pub(crate) type AssetIdOf<T> = <<T as Config>::NftHandler as NftHandler<
+		AccountIdOf<T>,
+		Avatar,
+		<T as Config>::AvatarNftConfig,
+	>>::AssetId;
 
 	pub(crate) const MAX_PERCENTAGE: u8 = 100;
 

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -158,6 +158,7 @@ impl pallet_ajuna_awesome_avatars::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type Randomness = Randomness;
+	type AvatarNftConfig = pallet_nfts::ItemConfig;
 	type NftHandler = NftTransfer;
 	type WeightInfo = ();
 }
@@ -168,6 +169,7 @@ parameter_types! {
 
 impl pallet_ajuna_nft_transfer::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
+	#[cfg(feature = "runtime-benchmarks")]
 	type Currency = Balances;
 	type MaxAssetEncodedSize = ValueLimit;
 	type CollectionId = MockCollectionId;

--- a/pallets/ajuna-nft-transfer/src/benchmarking.rs
+++ b/pallets/ajuna-nft-transfer/src/benchmarking.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
+use frame_support::traits::Currency;
 
 #[allow(unused)]
 use crate::Pallet as NftTransfer;
@@ -47,7 +48,8 @@ benchmarks! {
 	}
 
 	set_holding_collection_id {
-		let account = NftTransfer::<T>::holding_account_id();
+		let account = account::<T>("organizer");
+		T::Currency::make_free_balance_be(&account, T::Currency::minimum_balance());
 		let collection_id = create_holding_contract_collection::<T>(&account);
 		Organizer::<T>::put(&account);
 	}: _(RawOrigin::Signed(account), collection_id)

--- a/pallets/ajuna-nft-transfer/src/mock.rs
+++ b/pallets/ajuna-nft-transfer/src/mock.rs
@@ -149,6 +149,7 @@ pub type CollectionConfig =
 
 impl pallet_ajuna_nft_transfer::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
+	#[cfg(feature = "runtime-benchmarks")]
 	type Currency = Balances;
 	type MaxAssetEncodedSize = frame_support::traits::ConstU32<MAX_ENCODING_SIZE>;
 	type CollectionId = MockCollectionId;
@@ -178,7 +179,6 @@ impl ExtBuilder {
 		let config = GenesisConfig {
 			system: Default::default(),
 			balances: BalancesConfig { balances: self.balances },
-			nft_transfer: Default::default(),
 		};
 
 		let mut ext: sp_io::TestExternalities = config.build_storage().unwrap().into();

--- a/pallets/ajuna-nft-transfer/src/tests.rs
+++ b/pallets/ajuna-nft-transfer/src/tests.rs
@@ -120,8 +120,12 @@ mod set_lock_state {
 			));
 
 			let asset = MockStruct { data: vec![1; MAX_ENCODING_SIZE as usize] };
+			let asset_config = pallet_nfts::ItemConfig::default();
 
-			assert_noop!(NftTransfer::store_as_nft(BOB, asset), Error::<Test>::PalletLocked);
+			assert_noop!(
+				NftTransfer::store_as_nft(BOB, asset, asset_config),
+				Error::<Test>::PalletLocked
+			);
 		});
 	}
 
@@ -149,8 +153,9 @@ mod store_as_nft {
 		ExtBuilder::default().build().execute_with(|| {
 			let collection_id = create_and_set_random_nft_collection(ALICE);
 			let asset = MockStruct::default();
+			let asset_config = pallet_nfts::ItemConfig::default();
 
-			let result = NftTransfer::store_as_nft(BOB, asset.clone());
+			let result = NftTransfer::store_as_nft(BOB, asset.clone(), asset_config);
 
 			assert_ok!(result);
 
@@ -189,9 +194,10 @@ mod store_as_nft {
 		ExtBuilder::default().build().execute_with(|| {
 			let _ = create_and_set_random_nft_collection(ALICE);
 			let asset = MockStruct { data: vec![1; MAX_ENCODING_SIZE as usize] };
+			let asset_config = pallet_nfts::ItemConfig::default();
 
 			assert_noop!(
-				NftTransfer::store_as_nft(BOB, asset),
+				NftTransfer::store_as_nft(BOB, asset, asset_config),
 				Error::<Test>::AssetSizeAboveEncodingLimit
 			);
 		});
@@ -206,8 +212,9 @@ mod recover_from_nft {
 		ExtBuilder::default().build().execute_with(|| {
 			let collection_id = create_and_set_random_nft_collection(ALICE);
 			let asset = MockStruct::default();
+			let asset_config = pallet_nfts::ItemConfig::default();
 
-			let asset_id = NftTransfer::store_as_nft(BOB, asset.clone())
+			let asset_id = NftTransfer::store_as_nft(BOB, asset.clone(), asset_config)
 				.expect("Storage should have been successful!");
 
 			let result = NftTransfer::recover_from_nft(BOB, asset_id);
@@ -239,8 +246,9 @@ mod recover_from_nft {
 		ExtBuilder::default().build().execute_with(|| {
 			let collection_id = create_and_set_random_nft_collection(ALICE);
 			let asset = MockStruct::default();
+			let asset_config = pallet_nfts::ItemConfig::default();
 
-			let asset_id = NftTransfer::store_as_nft(BOB, asset)
+			let asset_id = NftTransfer::store_as_nft(BOB, asset, asset_config)
 				.expect("Storage should have been successful!");
 
 			LockItemStatus::<Test>::insert(collection_id, asset_id, NftStatus::Uploaded);
@@ -256,8 +264,9 @@ mod recover_from_nft {
 		ExtBuilder::default().build().execute_with(|| {
 			let _ = create_and_set_random_nft_collection(ALICE);
 			let asset = MockStruct::default();
+			let asset_config = pallet_nfts::ItemConfig::default();
 
-			let asset_id = NftTransfer::store_as_nft(BOB, asset)
+			let asset_id = NftTransfer::store_as_nft(BOB, asset, asset_config)
 				.expect("Storage should have been successful!");
 
 			let result: Result<MockStruct, _> = NftTransfer::recover_from_nft(ALICE, asset_id);

--- a/pallets/ajuna-nft-transfer/src/traits.rs
+++ b/pallets/ajuna-nft-transfer/src/traits.rs
@@ -33,13 +33,16 @@ pub trait NftConvertible: Codec {
 }
 
 /// Trait to define the transformation and bridging of assets as NFT.
-pub trait NftHandler<Account, Asset: NftConvertible> {
+pub trait NftHandler<Account, Asset: NftConvertible, AssetConfig> {
 	type AssetId: Codec + Parameter + MaxEncodedLen;
-	type AssetConfig: Default;
 
 	/// Consumes the given **asset** and stores it as an NFT owned by **owner**,
 	/// returns the NFT index for tracking and recovering the asset.
-	fn store_as_nft(owner: Account, asset: Asset) -> Result<Self::AssetId, DispatchError>;
+	fn store_as_nft(
+		owner: Account,
+		asset: Asset,
+		asset_config: AssetConfig,
+	) -> Result<Self::AssetId, DispatchError>;
 	/// Attempts to recover the NFT indexed by **nft_id** and transform it back into an
 	/// asset, returns an appropriate error if the process fails.
 	fn recover_from_nft(owner: Account, asset_id: Self::AssetId) -> Result<Asset, DispatchError>;

--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -679,6 +679,7 @@ impl pallet_ajuna_awesome_avatars::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type Randomness = Randomness;
+	type AvatarNftConfig = pallet_nfts::ItemConfig;
 	type NftHandler = NftTransfer;
 	type WeightInfo = pallet_ajuna_awesome_avatars::weights::AjunaWeight<Runtime>;
 }
@@ -733,6 +734,7 @@ type CollectionConfig = pallet_nfts::CollectionConfig<Balance, BlockNumber, Coll
 
 impl pallet_ajuna_nft_transfer::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	#[cfg(feature = "runtime-benchmarks")]
 	type Currency = Balances;
 	type MaxAssetEncodedSize = MaxAssetEncodedSize;
 	type CollectionId = CollectionId;

--- a/runtime/solo/src/lib.rs
+++ b/runtime/solo/src/lib.rs
@@ -521,6 +521,7 @@ impl pallet_ajuna_awesome_avatars::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type Randomness = Randomness;
+	type AvatarNftConfig = pallet_nfts::ItemConfig;
 	type NftHandler = NftTransfer;
 	type WeightInfo = ();
 }
@@ -617,6 +618,7 @@ type CollectionConfig = pallet_nfts::CollectionConfig<Balance, BlockNumber, Coll
 
 impl pallet_ajuna_nft_transfer::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	#[cfg(feature = "runtime-benchmarks")]
 	type Currency = Balances;
 	type MaxAssetEncodedSize = frame_support::traits::ConstU32<200>;
 	type CollectionId = CollectionId;


### PR DESCRIPTION
## Description

I think it's nicer for users to be able to view their NFTs under the "My NFTs" page ([see Westmint example](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwestmint-rpc.polkadot.io#/nfts/my-nfts)). We can also expect users to pay `ItemDeposit` when freeing an avatar.

The PR removes `holding_account_id` and uses `owner` instead.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [x] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
