### PR TITLE
Remove storage getters

### DIFF
--- a/pallets/ajuna-nft-staking/src/benchmarking.rs
+++ b/pallets/ajuna-nft-staking/src/benchmarking.rs
@@ -199,7 +199,7 @@ benchmarks! {
 		let reward = StakingRewardOf::<T>::Tokens(reward_amt);
 		let clause = create_contract_clause::<T>(10, 10);
 		let contract = create_staking_contract::<T>(reward, 10_u32.into(), clause);
-		let expected_id = NftStake::<T>::next_contract_id();
+		let expected_id = NextContractId::<T>::get();
 	}: submit_staking_contract(RawOrigin::Signed(caller.clone()), contract)
 	verify {
 		assert_last_event::<T>(Event::StakingContractCreated { creator: caller, contract: expected_id }.into())
@@ -216,7 +216,7 @@ benchmarks! {
 		let reward = StakingRewardOf::<T>::Nft(nft_addr);
 		let clause = create_contract_clause::<T>(10, 10);
 		let contract = create_staking_contract::<T>(reward, 10_u32.into(), clause);
-		let expected_id = NftStake::<T>::next_contract_id();
+		let expected_id = NextContractId::<T>::get();
 	}: submit_staking_contract(RawOrigin::Signed(caller.clone()), contract)
 	verify {
 		assert_last_event::<T>(Event::StakingContractCreated { creator: caller, contract: expected_id }.into())
@@ -232,7 +232,7 @@ benchmarks! {
 		let reward = StakingRewardOf::<T>::Tokens(reward_amt);
 		let clause = create_contract_clause::<T>(10, 10);
 		let contract = create_staking_contract::<T>(reward, 10_u32.into(), clause);
-		let contract_id = NftStake::<T>::next_contract_id();
+		let contract_id = NextContractId::<T>::get();
 
 		NftStake::<T>::submit_staking_contract(RawOrigin::Signed(caller).into(), contract)?;
 
@@ -256,7 +256,7 @@ benchmarks! {
 		let reward = StakingRewardOf::<T>::Tokens(reward_amt);
 		let clause = create_contract_clause::<T>(10, 10);
 		let contract = create_staking_contract::<T>(reward.clone(), 0_u32.into(), clause);
-		let contract_id = NftStake::<T>::next_contract_id();
+		let contract_id = NextContractId::<T>::get();
 
 		NftStake::<T>::submit_staking_contract(RawOrigin::Signed(caller).into(), contract)?;
 
@@ -284,7 +284,7 @@ benchmarks! {
 		let reward = StakingRewardOf::<T>::Nft(reward_nft_addr);
 		let clause = create_contract_clause::<T>(10, 10);
 		let contract = create_staking_contract::<T>(reward.clone(), 0_u32.into(), clause);
-		let contract_id = NftStake::<T>::next_contract_id();
+		let contract_id = NextContractId::<T>::get();
 
 		NftStake::<T>::submit_staking_contract(RawOrigin::Signed(caller).into(), contract)?;
 

--- a/pallets/ajuna-nft-transfer/src/lib.rs
+++ b/pallets/ajuna-nft-transfer/src/lib.rs
@@ -85,7 +85,6 @@ pub mod pallet {
 	}
 
 	#[pallet::storage]
-	#[pallet::getter(fn nft_statuses)]
 	pub type NftStatuses<T: Config> =
 		StorageDoubleMap<_, Identity, T::CollectionId, Identity, T::ItemId, NftStatus, OptionQuery>;
 

--- a/pallets/ajuna-nft-transfer/src/tests.rs
+++ b/pallets/ajuna-nft-transfer/src/tests.rs
@@ -120,7 +120,7 @@ mod store_as_nft {
 					);
 				}
 				assert_eq!(
-					NftTransfer::nft_statuses(collection_id, item_id),
+					NftStatuses::<Test>::get(collection_id, item_id),
 					Some(NftStatus::Stored)
 				);
 


### PR DESCRIPTION
## Description

Trivially removing storage getters since they will be deprecated in upcoming releases (RE: substrate: 13365).

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
