### PR TITLE
[PLAT-786] Additional NFT-staking extrinsics

### DIFF
--- a/pallets/ajuna-nft-staking/src/contracts.rs
+++ b/pallets/ajuna-nft-staking/src/contracts.rs
@@ -80,6 +80,7 @@ type BoundedClauses<CollectionId, AttributeKey, AttributeValue> =
 pub struct Contract<Balance, CollectionId, ItemId, BlockNumber, AttributeKey, AttributeValue> {
 	pub reward: Reward<Balance, CollectionId, ItemId>,
 	pub duration: BlockNumber,
+	pub expire_after: BlockNumber,
 	pub stake_clauses: BoundedClauses<CollectionId, AttributeKey, AttributeValue>,
 	pub fee_clauses: BoundedClauses<CollectionId, AttributeKey, AttributeValue>,
 }
@@ -92,15 +93,6 @@ where
 	AttributeKey: Encode,
 	AttributeValue: Encode + Decode + PartialEq,
 {
-	pub fn new(
-		reward: Reward<Balance, CollectionId, ItemId>,
-		duration: BlockNumber,
-		stake_clauses: BoundedClauses<CollectionId, AttributeKey, AttributeValue>,
-		fee_clauses: BoundedClauses<CollectionId, AttributeKey, AttributeValue>,
-	) -> Self {
-		Self { reward, duration, stake_clauses, fee_clauses }
-	}
-
 	pub fn evaluate_stakes<AccountId, NftInspector>(
 		&self,
 		stakes: &[NftAddress<CollectionId, ItemId>],

--- a/pallets/ajuna-nft-staking/src/lib.rs
+++ b/pallets/ajuna-nft-staking/src/lib.rs
@@ -195,9 +195,12 @@ pub mod pallet {
 		MaxStakes,
 	}
 
-	//SBP-M3 review: Please add documentation in each extrinsic
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		/// Set a creator account.
+		///
+		/// This call allows setting an account to act as a contract creator. It must be called with
+		/// root privilege.
 		#[pallet::weight(T::WeightInfo::set_creator())]
 		#[pallet::call_index(0)]
 		pub fn set_creator(origin: OriginFor<T>, creator: T::AccountId) -> DispatchResult {
@@ -207,6 +210,11 @@ pub mod pallet {
 			Ok(())
 		}
 
+		/// Set a collection ID for contract NFTs.
+		///
+		///
+		/// This call allows setting an externally created collection ID to associate contract NFTs.
+		/// It must be signed with the creator account.
 		#[pallet::weight(T::WeightInfo::set_contract_collection_id())]
 		#[pallet::call_index(1)]
 		pub fn set_contract_collection_id(
@@ -220,6 +228,10 @@ pub mod pallet {
 			Ok(())
 		}
 
+		/// Set new values for global configuration.
+		///
+		/// This call allows updating global configuration. It must be signed by the creator
+		/// account.
 		#[pallet::weight(T::WeightInfo::set_global_config())]
 		#[pallet::call_index(2)]
 		pub fn set_global_config(origin: OriginFor<T>, new_config: GlobalConfig) -> DispatchResult {
@@ -229,6 +241,13 @@ pub mod pallet {
 			Ok(())
 		}
 
+		/// Create a staking contract.
+		///
+		/// This call allows the creator to define and initiate a new staking contract. The creator
+		/// sets the parameters of the contract, such as the assets involved, the staking period,
+		/// and any other requirements. The creator will also transfer the necessary reward NFTs or
+		/// tokens to the provider, which will be locked until a staker claims them, or the contract
+		/// is removed in an unaccepted state.
 		#[pallet::weight(
 			T::WeightInfo::create_token_reward()
 				.max(T::WeightInfo::create_nft_reward())
@@ -245,6 +264,12 @@ pub mod pallet {
 			Self::create_contract(creator, contract_id, contract)
 		}
 
+		/// Accept an available staking contract.
+		///
+		/// This call allows a player (staker) to accept an available staking contract. When
+		/// executing this call, the staker will transfer the required stake and fee NFTs to the
+		/// provider, thus engaging in the contract. The provider will issue a contract NFT to the
+		/// staker, acknowledging their participation in the staking contract.
 		#[pallet::weight(T::WeightInfo::accept())]
 		#[pallet::call_index(5)]
 		pub fn accept(
@@ -259,6 +284,11 @@ pub mod pallet {
 			Self::accept_contract(contract_id, staker, &stakes, &fees)
 		}
 
+		/// Claim a fulfilled staking contract.
+		///
+		/// The staker, who holds a contract NFT, can call this function to claim the rewards
+		/// associated with the fulfilled staking contract. Upon successful execution, the provider
+		/// will transfer the reward NFTs / tokens to the staker and return the stake NFT.
 		#[pallet::weight(
 			T::WeightInfo::claim_token_reward()
 				.max(T::WeightInfo::claim_nft_reward())

--- a/pallets/ajuna-nft-staking/src/mock.rs
+++ b/pallets/ajuna-nft-staking/src/mock.rs
@@ -224,6 +224,10 @@ impl ContractOf<Test> {
 		self.duration = duration;
 		self
 	}
+	pub fn expire_after(mut self, expire_after: MockBlockNumber) -> Self {
+		self.expire_after = expire_after;
+		self
+	}
 	pub fn stake_clauses(mut self, clauses: Vec<MockClause>) -> Self {
 		self.stake_clauses = clauses.try_into().unwrap();
 		self

--- a/pallets/ajuna-nft-staking/src/mock.rs
+++ b/pallets/ajuna-nft-staking/src/mock.rs
@@ -199,6 +199,41 @@ impl pallet_nft_staking::Config for Test {
 	type WeightInfo = ();
 }
 
+impl Default for RewardOf<Test> {
+	fn default() -> Self {
+		Reward::Tokens(Default::default())
+	}
+}
+impl Default for ContractOf<Test> {
+	fn default() -> Self {
+		Contract {
+			reward: Default::default(),
+			duration: Default::default(),
+			expire_after: Default::default(),
+			stake_clauses: Default::default(),
+			fee_clauses: Default::default(),
+		}
+	}
+}
+impl ContractOf<Test> {
+	pub fn reward(mut self, reward: RewardOf<Test>) -> Self {
+		self.reward = reward;
+		self
+	}
+	pub fn duration(mut self, duration: MockBlockNumber) -> Self {
+		self.duration = duration;
+		self
+	}
+	pub fn stake_clauses(mut self, clauses: Vec<MockClause>) -> Self {
+		self.stake_clauses = clauses.try_into().unwrap();
+		self
+	}
+	pub fn fee_clauses(mut self, clauses: Vec<MockClause>) -> Self {
+		self.fee_clauses = clauses.try_into().unwrap();
+		self
+	}
+}
+
 pub type MockClause = Clause<MockCollectionId, AttributeKey, AttributeValue>;
 pub struct MockClauses(pub Vec<MockClause>);
 pub type MockMints = Vec<(NftAddress<MockCollectionId, MockItemId>, AttributeKey, AttributeValue)>;

--- a/pallets/ajuna-nft-staking/src/tests.rs
+++ b/pallets/ajuna-nft-staking/src/tests.rs
@@ -91,7 +91,7 @@ mod set_global_config {
 	#[test]
 	fn works() {
 		ExtBuilder::default().set_creator(ALICE).build().execute_with(|| {
-			let new_config = GlobalConfig { pallet_locked: true };
+			let new_config = GlobalConfig { pallet_locked: true, cancel_fee: 123 };
 			assert_ok!(NftStake::set_global_config(RuntimeOrigin::signed(ALICE), new_config));
 			assert_eq!(GlobalConfigs::<Test>::get(), new_config);
 			System::assert_last_event(mock::RuntimeEvent::NftStake(
@@ -386,7 +386,7 @@ mod accept {
 				assert_eq!(ContractEnds::<Test>::get(contract_id), Some(current_block + duration));
 
 				System::assert_last_event(mock::RuntimeEvent::NftStake(crate::Event::Accepted {
-					accepted_by: BOB,
+					by: BOB,
 					contract_id,
 				}));
 			});
@@ -758,7 +758,7 @@ mod claim {
 				assert_eq!(ContractStakedItems::<Test>::get(contract_id), None);
 
 				System::assert_last_event(mock::RuntimeEvent::NftStake(crate::Event::Claimed {
-					claimed_by: BOB,
+					by: BOB,
 					contract_id,
 					reward: contract.reward,
 				}));
@@ -816,7 +816,7 @@ mod claim {
 				assert_eq!(ContractStakedItems::<Test>::get(contract_id), None);
 
 				System::assert_last_event(mock::RuntimeEvent::NftStake(crate::Event::Claimed {
-					claimed_by: BOB,
+					by: BOB,
 					contract_id,
 					reward: contract.reward,
 				}));
@@ -889,6 +889,141 @@ mod claim {
 					assert_noop!(
 						NftStake::claim(RuntimeOrigin::signed(BOB), contract_id),
 						Error::<Test>::ContractStillActive
+					);
+				}
+			});
+	}
+}
+
+mod cancel {
+	use super::*;
+
+	#[test]
+	fn works() {
+		let stake_clauses = vec![
+			Clause::HasAttribute(RESERVED_COLLECTION_0, 1),
+			Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 3, 4),
+		];
+		let fee_clauses = vec![Clause::HasAttribute(RESERVED_COLLECTION_1, 11)];
+		let duration = 4;
+		let reward_amount = 135;
+		let contract = Contract::new(
+			Reward::Tokens(reward_amount),
+			duration,
+			stake_clauses.clone().try_into().unwrap(),
+			fee_clauses.clone().try_into().unwrap(),
+		);
+		let contract_id = H256::random();
+
+		let stakes = MockMints::from(MockClauses(stake_clauses));
+		let stake_addresses =
+			stakes.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
+		let fees = MockMints::from(MockClauses(fee_clauses));
+		let fee_addresses =
+			fees.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
+
+		let initial_balance = 333;
+
+		ExtBuilder::default()
+			.set_creator(ALICE)
+			.balances(vec![(BOB, initial_balance)])
+			.create_contract_collection()
+			.create_contract(contract_id, contract)
+			.accept_contract(vec![(BOB, stakes)], vec![(BOB, fees)], contract_id, BOB)
+			.build()
+			.execute_with(|| {
+				let cancellation_fee = 333;
+				GlobalConfigs::<Test>::mutate(|config| config.cancel_fee = cancellation_fee);
+
+				assert_ok!(NftStake::cancel(RuntimeOrigin::signed(BOB), contract_id));
+
+				for NftAddress(collection_id, item_id) in stake_addresses {
+					assert_eq!(Nft::owner(collection_id, item_id), Some(BOB));
+				}
+				for NftAddress(collection_id, item_id) in fee_addresses {
+					assert_eq!(Nft::owner(collection_id, item_id), Some(ALICE));
+				}
+				assert_eq!(Balances::free_balance(BOB), initial_balance - cancellation_fee);
+				assert_eq!(NftStake::account_balance(), reward_amount + cancellation_fee);
+
+				let contract_collection_id = ContractCollectionId::<Test>::get().unwrap();
+				assert_eq!(Nft::owner(contract_collection_id, contract_id), None);
+				assert_eq!(ContractOwners::<Test>::get(contract_id), None);
+				assert_eq!(ContractEnds::<Test>::get(contract_id), None);
+				assert_eq!(ContractStakedItems::<Test>::get(contract_id), None);
+
+				System::assert_last_event(mock::RuntimeEvent::NftStake(crate::Event::Cancelled {
+					by: BOB,
+					contract_id,
+				}));
+			});
+	}
+
+	#[test]
+	fn rejects_unsigned_calls() {
+		ExtBuilder::default().build().execute_with(|| {
+			assert_noop!(
+				NftStake::cancel(RuntimeOrigin::none(), Default::default()),
+				DispatchError::BadOrigin
+			);
+		});
+	}
+
+	#[test]
+	fn rejects_when_pallet_is_locked() {
+		ExtBuilder::default().build().execute_with(|| {
+			GlobalConfigs::<Test>::mutate(|config| config.pallet_locked = true);
+			assert_noop!(
+				NftStake::cancel(RuntimeOrigin::signed(ALICE), Default::default()),
+				Error::<Test>::PalletLocked
+			);
+		});
+	}
+
+	#[test]
+	fn rejects_when_contract_is_not_owned() {
+		let contract = Contract::new(Reward::Tokens(1), 2, Default::default(), Default::default());
+		let contract_id = H256::random();
+		ExtBuilder::default()
+			.set_creator(ALICE)
+			.create_contract_collection()
+			.create_contract(contract_id, contract)
+			.build()
+			.execute_with(|| {
+				assert_noop!(
+					NftStake::cancel(RuntimeOrigin::signed(BOB), contract_id),
+					Error::<Test>::ContractOwnership
+				);
+			});
+	}
+
+	#[test]
+	fn rejects_when_contract_is_claimable() {
+		let stake_clauses = vec![Clause::HasAttribute(RESERVED_COLLECTION_0, 4)];
+		let fee_clauses = vec![Clause::HasAttribute(RESERVED_COLLECTION_2, 2)];
+		let duration = 3;
+		let contract = Contract::new(
+			Reward::Tokens(321),
+			duration,
+			stake_clauses.clone().try_into().unwrap(),
+			fee_clauses.clone().try_into().unwrap(),
+		);
+		let contract_id = H256::random();
+		let stakes = MockMints::from(MockClauses(stake_clauses));
+		let fees = MockMints::from(MockClauses(fee_clauses));
+
+		ExtBuilder::default()
+			.set_creator(ALICE)
+			.create_contract_collection()
+			.create_contract(contract_id, contract)
+			.accept_contract(vec![(BOB, stakes)], vec![(BOB, fees)], contract_id, BOB)
+			.build()
+			.execute_with(|| {
+				for i in duration..(duration + 3) {
+					run_to_block(System::block_number() + i);
+					assert_noop!(
+						NftStake::cancel(RuntimeOrigin::signed(BOB), contract_id),
+						Error::<Test>::ContractClaimable
 					);
 				}
 			});


### PR DESCRIPTION
## Description

Adding the additional extrinsic calls:
- `remove`: opposite of `create`, where a creator can remove existing available (not accepted yet) contracts
- `cancel`: opposite of `accept`, where stakers can cancel ongoing contracts for a fee
- `snipe`: similar to `claim`, where other players can claim expired, fulfilled contracts

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
