### PR TITLE
[PLAT-746] Seasonal inventory

### DIFF
--- a/pallets/ajuna-awesome-avatars/Cargo.toml
+++ b/pallets/ajuna-awesome-avatars/Cargo.toml
@@ -46,4 +46,4 @@ std = [
     "sp-std/std",
     "log/std",
 ]
-try-runtime = [ "frame-support/try-runtime", "pallet-ajuna-nft-transfer/try-runtime" ]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/ajuna-awesome-avatars/benchmarking/Cargo.toml
+++ b/pallets/ajuna-awesome-avatars/benchmarking/Cargo.toml
@@ -55,4 +55,4 @@ std = [
     "sp-std/std",
     "log/std",
 ]
-try-runtime = [ "frame-support/try-runtime", "pallet-ajuna-nft-transfer/try-runtime" ]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -256,7 +256,7 @@ benchmarks! {
 
 		let GlobalConfig { transfer, .. } = GlobalConfigs::<T>::get();
 		<T as AvatarsConfig>::Currency::make_free_balance_be(&from, transfer.avatar_transfer_fee);
-	}: transfer_avatar(RawOrigin::Signed(from.clone()), to.clone(), season_id, avatar_id)
+	}: transfer_avatar(RawOrigin::Signed(from.clone()), to.clone(), avatar_id)
 	verify {
 		assert_last_event::<T>(Event::AvatarTransferred { from, to, avatar_id })
 	}
@@ -272,7 +272,7 @@ benchmarks! {
 
 		let GlobalConfig { transfer, .. } = GlobalConfigs::<T>::get();
 		CurrencyOf::<T>::make_free_balance_be(&organizer, transfer.avatar_transfer_fee);
-	}: transfer_avatar(RawOrigin::Signed(organizer.clone()), to.clone(), season_id, avatar_id)
+	}: transfer_avatar(RawOrigin::Signed(organizer.clone()), to.clone(), avatar_id)
 	verify {
 		assert_last_event::<T>(Event::AvatarTransferred { from: organizer, to, avatar_id })
 	}
@@ -329,7 +329,7 @@ benchmarks! {
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
 		let avatar_id = Owners::<T>::get(&seller, season_id)[0];
 		Trade::<T>::insert(avatar_id, sell_fee);
-	}: _(RawOrigin::Signed(buyer.clone()), season_id, avatar_id)
+	}: _(RawOrigin::Signed(buyer.clone()), avatar_id)
 	verify {
 		assert_last_event::<T>(Event::AvatarTraded { avatar_id, from: seller, to: buyer })
 	}
@@ -489,7 +489,7 @@ benchmarks! {
 		let item_deposit = <T as pallet_nfts::Config>::ItemDeposit::get();
 		let ed = <T as pallet_nfts::Config>::Currency::minimum_balance();
 		<T as pallet_nfts::Config>::Currency::make_free_balance_be(&player, item_deposit + ed);
-	}: _(RawOrigin::Signed(player), season_id, avatar_id)
+	}: _(RawOrigin::Signed(player), avatar_id)
 	verify {
 		assert_last_event::<T>(Event::AvatarLocked { avatar_id })
 	}
@@ -514,8 +514,8 @@ benchmarks! {
 		let item_deposit = <T as pallet_nfts::Config>::ItemDeposit::get();
 		let ed = <T as pallet_nfts::Config>::Currency::minimum_balance();
 		<T as pallet_nfts::Config>::Currency::make_free_balance_be(&player, item_deposit + ed);
-		AAvatars::<T>::lock_avatar(RawOrigin::Signed(player.clone()).into(), season_id, avatar_id)?;
-	}: _(RawOrigin::Signed(player), season_id, avatar_id)
+		AAvatars::<T>::lock_avatar(RawOrigin::Signed(player.clone()).into(), avatar_id)?;
+	}: _(RawOrigin::Signed(player), avatar_id)
 	verify {
 		assert_last_event::<T>(Event::AvatarUnlocked { avatar_id })
 	}

--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -195,7 +195,8 @@ benchmarks! {
 	}: mint(RawOrigin::Signed(caller.clone()), mint_option)
 	verify {
 		let n = n as usize;
-		let avatar_ids = Owners::<T>::get(caller)[n..(n + 6)].to_vec();
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_ids = Owners::<T>::get(caller, season_id)[n..(n + 6)].to_vec();
 		assert_last_event::<T>(Event::AvatarsMinted { avatar_ids })
 	}
 
@@ -213,7 +214,8 @@ benchmarks! {
 	}: mint(RawOrigin::Signed(caller.clone()), mint_option)
 	verify {
 		let n = n as usize;
-		let avatar_ids = Owners::<T>::get(caller)[n..(n + 6)].to_vec();
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_ids = Owners::<T>::get(caller, season_id)[n..(n + 6)].to_vec();
 		assert_last_event::<T>(Event::AvatarsMinted { avatar_ids })
 	}
 
@@ -223,7 +225,8 @@ benchmarks! {
 		create_avatars::<T>(name, n)?;
 
 		let player = account::<T>(name);
-		let avatar_ids = Owners::<T>::get(&player);
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_ids = Owners::<T>::get(&player, season_id);
 		let avatar_id = avatar_ids[0];
 		let (_owner, original_avatar) = Avatars::<T>::get(avatar_id).unwrap();
 	}: _(RawOrigin::Signed(player), avatar_id, avatar_ids[1..5].to_vec())
@@ -248,11 +251,12 @@ benchmarks! {
 		let n in 1 .. MaxAvatarsPerPlayer::get();
 		create_avatars::<T>("from", MaxAvatarsPerPlayer::get())?;
 		create_avatars::<T>("to", MaxAvatarsPerPlayer::get() - n)?;
-		let avatar_id = Owners::<T>::get(&from)[n as usize - 1];
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_id = Owners::<T>::get(&from, season_id)[n as usize - 1];
 
 		let GlobalConfig { transfer, .. } = GlobalConfigs::<T>::get();
 		<T as AvatarsConfig>::Currency::make_free_balance_be(&from, transfer.avatar_transfer_fee);
-	}: transfer_avatar(RawOrigin::Signed(from.clone()), to.clone(), avatar_id)
+	}: transfer_avatar(RawOrigin::Signed(from.clone()), to.clone(), season_id, avatar_id)
 	verify {
 		assert_last_event::<T>(Event::AvatarTransferred { from, to, avatar_id })
 	}
@@ -263,11 +267,12 @@ benchmarks! {
 		let n in 1 .. MaxAvatarsPerPlayer::get();
 		create_avatars::<T>("organizer", MaxAvatarsPerPlayer::get())?;
 		create_avatars::<T>("to", MaxAvatarsPerPlayer::get() - n)?;
-		let avatar_id = Owners::<T>::get(&organizer)[n as usize - 1];
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_id = Owners::<T>::get(&organizer, season_id)[n as usize - 1];
 
 		let GlobalConfig { transfer, .. } = GlobalConfigs::<T>::get();
 		CurrencyOf::<T>::make_free_balance_be(&organizer, transfer.avatar_transfer_fee);
-	}: transfer_avatar(RawOrigin::Signed(organizer.clone()), to.clone(), avatar_id)
+	}: transfer_avatar(RawOrigin::Signed(organizer.clone()), to.clone(), season_id, avatar_id)
 	verify {
 		assert_last_event::<T>(Event::AvatarTransferred { from: organizer, to, avatar_id })
 	}
@@ -288,7 +293,8 @@ benchmarks! {
 		let name = "player";
 		create_avatars::<T>(name, MaxAvatarsPerPlayer::get())?;
 		let caller = account::<T>(name);
-		let avatar_id = Owners::<T>::get(&caller)[0];
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_id = Owners::<T>::get(&caller, season_id)[0];
 		let price = BalanceOf::<T>::unique_saturated_from(u128::MAX);
 	}: _(RawOrigin::Signed(caller), avatar_id, price)
 	verify {
@@ -299,7 +305,8 @@ benchmarks! {
 		let name = "player";
 		create_avatars::<T>(name, MaxAvatarsPerPlayer::get())?;
 		let caller = account::<T>(name);
-		let avatar_id = Owners::<T>::get(&caller)[0];
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_id = Owners::<T>::get(&caller, season_id)[0];
 		Trade::<T>::insert(avatar_id, BalanceOf::<T>::unique_saturated_from(u128::MAX));
 	}: _(RawOrigin::Signed(caller), avatar_id)
 	verify {
@@ -319,9 +326,10 @@ benchmarks! {
 		CurrencyOf::<T>::make_free_balance_be(&buyer, sell_fee + trade_fee);
 		CurrencyOf::<T>::make_free_balance_be(&seller, sell_fee);
 
-		let avatar_id = Owners::<T>::get(&seller)[0];
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_id = Owners::<T>::get(&seller, season_id)[0];
 		Trade::<T>::insert(avatar_id, sell_fee);
-	}: _(RawOrigin::Signed(buyer.clone()), avatar_id)
+	}: _(RawOrigin::Signed(buyer.clone()), season_id, avatar_id)
 	verify {
 		assert_last_event::<T>(Event::AvatarTraded { avatar_id, from: seller, to: buyer })
 	}
@@ -467,7 +475,8 @@ benchmarks! {
 		create_avatars::<T>(name, n)?;
 
 		let player = account::<T>(name);
-		let avatar_ids = Owners::<T>::get(&player);
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_ids = Owners::<T>::get(&player, season_id);
 		let avatar_id = avatar_ids[avatar_ids.len() - 1];
 
 		let organizer = account::<T>("organizer");
@@ -480,7 +489,7 @@ benchmarks! {
 		let item_deposit = <T as pallet_nfts::Config>::ItemDeposit::get();
 		let ed = <T as pallet_nfts::Config>::Currency::minimum_balance();
 		<T as pallet_nfts::Config>::Currency::make_free_balance_be(&player, item_deposit + ed);
-	}: _(RawOrigin::Signed(player), avatar_id)
+	}: _(RawOrigin::Signed(player), season_id, avatar_id)
 	verify {
 		assert_last_event::<T>(Event::AvatarLocked { avatar_id })
 	}
@@ -491,7 +500,8 @@ benchmarks! {
 		create_avatars::<T>(name, n)?;
 
 		let player = account::<T>(name);
-		let avatar_ids = Owners::<T>::get(&player);
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_ids = Owners::<T>::get(&player, season_id);
 		let avatar_id = avatar_ids[avatar_ids.len() - 1];
 
 		let organizer = account::<T>("organizer");
@@ -504,8 +514,8 @@ benchmarks! {
 		let item_deposit = <T as pallet_nfts::Config>::ItemDeposit::get();
 		let ed = <T as pallet_nfts::Config>::Currency::minimum_balance();
 		<T as pallet_nfts::Config>::Currency::make_free_balance_be(&player, item_deposit + ed);
-		AAvatars::<T>::lock_avatar(RawOrigin::Signed(player.clone()).into(), avatar_id)?;
-	}: _(RawOrigin::Signed(player), avatar_id)
+		AAvatars::<T>::lock_avatar(RawOrigin::Signed(player.clone()).into(), season_id, avatar_id)?;
+	}: _(RawOrigin::Signed(player), season_id, avatar_id)
 	verify {
 		assert_last_event::<T>(Event::AvatarUnlocked { avatar_id })
 	}
@@ -515,7 +525,8 @@ benchmarks! {
 		create_avatars::<T>(name, 1)?;
 
 		let player = account::<T>(name);
-		let avatar_id = Owners::<T>::get(&player)[0];
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_id = Owners::<T>::get(&player, season_id)[0];
 		let (_owner, original_avatar) = Avatars::<T>::get(avatar_id).unwrap();
 	}: _(RawOrigin::Signed(player), avatar_id)
 	verify {
@@ -535,7 +546,8 @@ benchmarks! {
 		let name = "player";
 		create_avatars::<T>(name, 1)?;
 		let player = account::<T>(name);
-		let avatar_id = Owners::<T>::get(&player)[0];
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_id = Owners::<T>::get(&player, season_id)[0];
 		let _ = create_service_account::<T>();
 		let prepare_fee = GlobalConfigs::<T>::get().nft_transfer.prepare_fee;
 		CurrencyOf::<T>::make_free_balance_be(&player, prepare_fee);
@@ -548,7 +560,8 @@ benchmarks! {
 		let name = "player";
 		create_avatars::<T>(name, 1)?;
 		let player = account::<T>(name);
-		let avatar_id = Owners::<T>::get(&player)[0];
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_id = Owners::<T>::get(&player, season_id)[0];
 		let _ = create_service_account_and_prepare_avatar::<T>(&player, &avatar_id)?;
 	}: _(RawOrigin::Signed(player), avatar_id)
 	verify {
@@ -559,7 +572,8 @@ benchmarks! {
 		let name = "player";
 		create_avatars::<T>(name, 1)?;
 		let player = account::<T>(name);
-		let avatar_id = Owners::<T>::get(&player)[0];
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		let avatar_id = Owners::<T>::get(&player, season_id)[0];
 		let service_account = create_service_account_and_prepare_avatar::<T>(&player, &avatar_id)?;
 		let url = IpfsUrl::try_from(b"ipfs://".to_vec()).unwrap();
 	}: _(RawOrigin::Signed(service_account), avatar_id, url.clone())

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -88,7 +88,7 @@ use sp_std::{collections::btree_set::BTreeSet, prelude::*};
 pub mod pallet {
 	use super::*;
 
-	type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+	pub(crate) type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 	pub(crate) type SeasonOf<T> = Season<BlockNumberFor<T>>;
 	pub(crate) type BalanceOf<T> = <<T as Config>::Currency as Currency<AccountIdOf<T>>>::Balance;
 	pub(crate) type AvatarIdOf<T> = <T as frame_system::Config>::Hash;

--- a/pallets/ajuna-awesome-avatars/src/migration/v5.rs
+++ b/pallets/ajuna-awesome-avatars/src/migration/v5.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
+use frame_support::storage::migration;
 
 #[derive(Decode)]
 pub struct OldSeasonStatus {
@@ -54,9 +55,33 @@ impl<T: Config> OnRuntimeUpgrade for MigrateToV5<T> {
 				})
 			});
 
+			let owners = migration::storage_iter::<BoundedAvatarIdsOf<T>>(
+				<Pallet<T>>::name().as_bytes(),
+				b"Owners",
+			)
+			.drain()
+			.filter(|(_owner, avatar_ids)| !avatar_ids.is_empty())
+			.map(|(owner, avatar_ids)| (T::AccountId::decode(&mut &owner[..]).unwrap(), avatar_ids))
+			.collect::<Vec<_>>();
+
+			let mut translated_account = 0_u64;
+			let mut translated_avatars = 0_u64;
+			owners.iter().for_each(|(owner, avatar_ids)| {
+				let season_id = 1;
+				Owners::<T>::insert(owner, season_id, avatar_ids);
+				translated_account += 1;
+				translated_avatars += avatar_ids.len() as u64;
+			});
+			log::info!(
+				target: LOG_TARGET,
+				"Updated {} accounts and {} avatars",
+				translated_account,
+				translated_avatars,
+			);
+
 			current_version.put::<Pallet<T>>();
 			log::info!(target: LOG_TARGET, "Upgraded storage to version {:?}", current_version);
-			T::DbWeight::get().reads_writes(2, 2)
+			T::DbWeight::get().reads_writes(2 + 2 * translated_account, 2 + 2 * translated_account)
 		} else {
 			log::info!(
 				target: LOG_TARGET,
@@ -68,8 +93,35 @@ impl<T: Config> OnRuntimeUpgrade for MigrateToV5<T> {
 
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
-		assert_eq!(Pallet::<T>::on_chain_storage_version(), 4);
+		assert_eq!(Pallet::<T>::on_chain_storage_version(), 5);
 		assert!(CurrentSeasonStatus::<T>::get().season_id > Zero::zero());
+
+		let mut avatar_ids_from_avatars = Avatars::<T>::iter_keys().collect::<Vec<_>>();
+		avatar_ids_from_avatars.sort();
+		avatar_ids_from_avatars.dedup();
+
+		let mut avatar_ids_from_owners = Owners::<T>::iter_values().flatten().collect::<Vec<_>>();
+		avatar_ids_from_owners.sort();
+		avatar_ids_from_owners.dedup();
+
+		// There should be 13,111 avatars in storage.
+		assert_eq!(avatar_ids_from_avatars.len(), 13_111);
+		assert_eq!(avatar_ids_from_owners.len(), 13_111);
+		assert_eq!(avatar_ids_from_avatars, avatar_ids_from_owners);
+
+		// There should be 892 owners of avatars in storage.
+		let mut season_ids = Owners::<T>::iter_keys()
+			.filter(|(owner, season_id)| !Owners::<T>::get(owner, season_id).is_empty())
+			.map(|(_owner, season_id)| season_id)
+			.collect::<Vec<SeasonId>>();
+		assert_eq!(season_ids.len(), 892);
+
+		// Check all migrated season IDs are 1.
+		season_ids.sort();
+		season_ids.dedup();
+		assert_eq!(season_ids.len(), 1);
+		assert_eq!(season_ids, vec![1]);
+
 		Ok(())
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/migration/v5.rs
+++ b/pallets/ajuna-awesome-avatars/src/migration/v5.rs
@@ -104,17 +104,20 @@ impl<T: Config> OnRuntimeUpgrade for MigrateToV5<T> {
 		avatar_ids_from_owners.sort();
 		avatar_ids_from_owners.dedup();
 
-		// There should be 13,111 avatars in storage.
-		assert_eq!(avatar_ids_from_avatars.len(), 13_111);
-		assert_eq!(avatar_ids_from_owners.len(), 13_111);
+		// There are 13,107 avatars as of 26/05/2023. But the exact number could be smaller as
+		// avatars are forged away. We estimate there should be at least 10,000.
+		assert!(avatar_ids_from_avatars.len() > 10_000 && avatar_ids_from_avatars.len() <= 13_107);
+		assert!(avatar_ids_from_avatars.len() > 10_000 && avatar_ids_from_owners.len() <= 13_107);
 		assert_eq!(avatar_ids_from_avatars, avatar_ids_from_owners);
 
-		// There should be 892 owners of avatars in storage.
+		// There are 892 owners of avatars in storage as of 26/05/2023. But the exact number could
+		// change as avatars are traded between accounts. We estimate there should be between 850
+		// and 1,000 accounts.
 		let mut season_ids = Owners::<T>::iter_keys()
 			.filter(|(owner, season_id)| !Owners::<T>::get(owner, season_id).is_empty())
 			.map(|(_owner, season_id)| season_id)
 			.collect::<Vec<SeasonId>>();
-		assert_eq!(season_ids.len(), 892);
+		assert!(season_ids.len() > 850 && season_ids.len() < 1_000);
 
 		// Check all migrated season IDs are 1.
 		season_ids.sort();

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -27,8 +27,9 @@ use frame_system::{
 	mocking::{MockBlock, MockUncheckedExtrinsic},
 	EnsureRoot, EnsureSigned,
 };
+pub(crate) use sp_runtime::testing::H256;
 use sp_runtime::{
-	testing::{Header, TestSignature, H256},
+	testing::{Header, TestSignature},
 	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
 };
 
@@ -44,6 +45,8 @@ pub const ALICE: MockAccountId = 1;
 pub const BOB: MockAccountId = 2;
 pub const CHARLIE: MockAccountId = 3;
 pub const DAVE: MockAccountId = 4;
+
+pub const SEASON_ID: SeasonId = 1;
 
 frame_support::construct_runtime!(
 	pub enum Test where

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -25,7 +25,7 @@ fn create_avatars(season_id: SeasonId, account: MockAccountId, n: u8) -> Vec<Ava
 			let avatar = Avatar::default().season_id(season_id).dna(&[i; 32]);
 			let avatar_id = H256::random();
 			Avatars::<Test>::insert(avatar_id, (account, avatar));
-			Owners::<Test>::try_append(account, avatar_id).unwrap();
+			Owners::<Test>::try_append(account, season_id, avatar_id).unwrap();
 			avatar_id
 		})
 		.collect()
@@ -175,34 +175,38 @@ mod treasury {
 		let initial_balance = MockExistentialDeposit::get() + 999_999;
 		let total_supply = initial_balance;
 		ExtBuilder::default()
-			.seasons(&[(1, season_1.clone())])
+			.seasons(&[(SEASON_ID, season_1.clone())])
 			.mint_fees(mint_fees)
 			.balances(&[(BOB, initial_balance)])
 			.build()
 			.execute_with(|| {
 				let treasury_account = AAvatars::treasury_account_id();
-				Treasurer::<Test>::insert(1, BOB);
-				assert_eq!(Treasury::<Test>::get(1), 0);
+				Treasurer::<Test>::insert(SEASON_ID, BOB);
+				assert_eq!(Treasury::<Test>::get(SEASON_ID), 0);
 				assert_eq!(Balances::total_balance(&BOB), initial_balance);
 				assert_eq!(Balances::free_balance(&treasury_account), 0);
 				assert_eq!(Balances::total_issuance(), total_supply);
 
-				deposit_into_treasury(1, 333);
-				assert_eq!(Treasury::<Test>::get(1), 333);
+				deposit_into_treasury(SEASON_ID, 333);
+				assert_eq!(Treasury::<Test>::get(SEASON_ID), 333);
 				assert_eq!(Balances::free_balance(&treasury_account), 333);
 				assert_noop!(
-					AAvatars::claim_treasury(RuntimeOrigin::signed(BOB), 1),
+					AAvatars::claim_treasury(RuntimeOrigin::signed(BOB), SEASON_ID),
 					Error::<Test>::CannotClaimDuringSeason
 				);
 
 				run_to_block(season_1.end + 1);
-				assert_ok!(AAvatars::claim_treasury(RuntimeOrigin::signed(BOB), 1));
-				assert_eq!(Treasury::<Test>::get(1), 0);
+				assert_ok!(AAvatars::claim_treasury(RuntimeOrigin::signed(BOB), SEASON_ID));
+				assert_eq!(Treasury::<Test>::get(SEASON_ID), 0);
 				assert_eq!(Balances::total_balance(&BOB), initial_balance + 333);
 				assert_eq!(Balances::free_balance(&treasury_account), 0);
 				assert_eq!(Balances::total_issuance(), total_supply + 333); // total supply increases from injection
 				System::assert_last_event(mock::RuntimeEvent::AAvatars(
-					crate::Event::TreasuryClaimed { season_id: 1, treasurer: BOB, amount: 333 },
+					crate::Event::TreasuryClaimed {
+						season_id: SEASON_ID,
+						treasurer: BOB,
+						amount: 333,
+					},
 				));
 			})
 	}
@@ -211,7 +215,7 @@ mod treasury {
 	fn claim_treasury_rejects_unsigned_calls() {
 		ExtBuilder::default().build().execute_with(|| {
 			assert_noop!(
-				AAvatars::claim_treasury(RuntimeOrigin::none(), 123),
+				AAvatars::claim_treasury(RuntimeOrigin::none(), SeasonId::default()),
 				DispatchError::BadOrigin
 			);
 		});
@@ -221,7 +225,7 @@ mod treasury {
 	fn claim_treasury_rejects_unknown_treasurer() {
 		ExtBuilder::default().build().execute_with(|| {
 			assert_noop!(
-				AAvatars::claim_treasury(RuntimeOrigin::signed(ALICE), 1),
+				AAvatars::claim_treasury(RuntimeOrigin::signed(ALICE), SeasonId::default()),
 				Error::<Test>::UnknownTreasurer
 			);
 		})
@@ -230,9 +234,10 @@ mod treasury {
 	#[test]
 	fn claim_treasury_rejects_non_treasurer_calls() {
 		ExtBuilder::default().build().execute_with(|| {
-			Treasurer::<Test>::insert(3, BOB);
+			let season_id = 3;
+			Treasurer::<Test>::insert(season_id, BOB);
 			assert_noop!(
-				AAvatars::claim_treasury(RuntimeOrigin::signed(CHARLIE), 3),
+				AAvatars::claim_treasury(RuntimeOrigin::signed(CHARLIE), season_id),
 				DispatchError::BadOrigin
 			);
 		})
@@ -342,13 +347,13 @@ mod treasury {
 	fn claim_treasury_rejects_empty_treasury() {
 		let season_1 = Season::default();
 		ExtBuilder::default()
-			.seasons(&[(1, season_1.clone())])
+			.seasons(&[(SEASON_ID, season_1.clone())])
 			.build()
 			.execute_with(|| {
 				run_to_block(season_1.end + 1);
 				Treasurer::<Test>::insert(1, CHARLIE);
 				assert_noop!(
-					AAvatars::claim_treasury(RuntimeOrigin::signed(CHARLIE), 1),
+					AAvatars::claim_treasury(RuntimeOrigin::signed(CHARLIE), SEASON_ID),
 					Error::<Test>::CannotClaimZero
 				);
 			})
@@ -358,7 +363,7 @@ mod treasury {
 	fn claim_treasury_rejects_more_than_available() {
 		let season_1 = Season::default();
 		ExtBuilder::default()
-			.seasons(&[(1, season_1.clone())])
+			.seasons(&[(SEASON_ID, season_1.clone())])
 			.build()
 			.execute_with(|| {
 				run_to_block(season_1.end + 1);
@@ -366,7 +371,7 @@ mod treasury {
 				Treasury::<Test>::insert(1, 999);
 				assert!(Balances::free_balance(&AAvatars::treasury_account_id()) < 999);
 				assert_noop!(
-					AAvatars::claim_treasury(RuntimeOrigin::signed(CHARLIE), 1),
+					AAvatars::claim_treasury(RuntimeOrigin::signed(CHARLIE), SEASON_ID),
 					pallet_balances::Error::<Test>::InsufficientBalance
 				);
 			})
@@ -567,7 +572,11 @@ mod season {
 	fn set_season_should_reject_non_organizer_calls() {
 		ExtBuilder::default().organizer(ALICE).build().execute_with(|| {
 			assert_noop!(
-				AAvatars::set_season(RuntimeOrigin::signed(BOB), 7357, Season::default()),
+				AAvatars::set_season(
+					RuntimeOrigin::signed(BOB),
+					SeasonId::default(),
+					Season::default()
+				),
 				DispatchError::BadOrigin
 			);
 		});
@@ -962,7 +971,7 @@ mod minting {
 		let mut initial_free_mints = 12;
 
 		ExtBuilder::default()
-			.seasons(&[(1, season_1.clone()), (2, season_2)])
+			.seasons(&[(SEASON_ID, season_1.clone()), (2, season_2)])
 			.mint_fees(fees.clone())
 			.mint_cooldown(mint_cooldown)
 			.balances(&[(ALICE, initial_balance)])
@@ -979,7 +988,7 @@ mod minting {
 					CurrentSeasonStatus::<Test>::mutate(|status| status.season_id = 1);
 					SeasonStats::<Test>::mutate(1, ALICE, |info| info.minted = 0);
 					SeasonStats::<Test>::mutate(2, ALICE, |info| info.minted = 0);
-					Owners::<Test>::remove(ALICE);
+					Owners::<Test>::remove(ALICE, SEASON_ID);
 					Accounts::<Test>::mutate(ALICE, |account| {
 						account.stats.mint.first = 0;
 						account.stats.mint.last = 0;
@@ -993,7 +1002,7 @@ mod minting {
 							assert_eq!(Accounts::<Test>::get(ALICE).free_mints, initial_free_mints),
 					}
 					assert_eq!(System::account_nonce(ALICE), expected_nonce);
-					assert_eq!(Owners::<Test>::get(ALICE).len(), owned_avatar_count);
+					assert_eq!(Owners::<Test>::get(ALICE, SEASON_ID).len(), owned_avatar_count);
 					assert!(!CurrentSeasonStatus::<Test>::get().active);
 
 					// single mint
@@ -1025,7 +1034,7 @@ mod minting {
 					minted_count += 1;
 					season_minted_count += 1;
 					assert_eq!(System::account_nonce(ALICE), expected_nonce);
-					assert_eq!(Owners::<Test>::get(ALICE).len(), owned_avatar_count);
+					assert_eq!(Owners::<Test>::get(ALICE, SEASON_ID).len(), owned_avatar_count);
 					assert_eq!(SeasonStats::<Test>::get(1, ALICE).minted, season_minted_count);
 					assert!(CurrentSeasonStatus::<Test>::get().active);
 					assert_eq!(Accounts::<Test>::get(ALICE).stats.mint.first, season_1.start);
@@ -1034,7 +1043,7 @@ mod minting {
 					));
 					System::assert_last_event(mock::RuntimeEvent::AAvatars(
 						crate::Event::AvatarsMinted {
-							avatar_ids: vec![Owners::<Test>::get(ALICE)[0]],
+							avatar_ids: vec![Owners::<Test>::get(ALICE, SEASON_ID)[0]],
 						},
 					));
 
@@ -1067,12 +1076,12 @@ mod minting {
 					minted_count += 3;
 					season_minted_count += 3;
 					assert_eq!(System::account_nonce(ALICE), expected_nonce);
-					assert_eq!(Owners::<Test>::get(ALICE).len(), owned_avatar_count);
+					assert_eq!(Owners::<Test>::get(ALICE, SEASON_ID).len(), owned_avatar_count);
 					assert_eq!(SeasonStats::<Test>::get(1, ALICE).minted, season_minted_count);
 					assert!(CurrentSeasonStatus::<Test>::get().active);
 					System::assert_last_event(mock::RuntimeEvent::AAvatars(
 						crate::Event::AvatarsMinted {
-							avatar_ids: Owners::<Test>::get(ALICE)[1..=3].to_vec(),
+							avatar_ids: Owners::<Test>::get(ALICE, SEASON_ID)[1..=3].to_vec(),
 						},
 					));
 
@@ -1106,12 +1115,12 @@ mod minting {
 					minted_count += 6;
 					season_minted_count += 6;
 					assert_eq!(System::account_nonce(ALICE), expected_nonce);
-					assert_eq!(Owners::<Test>::get(ALICE).len(), owned_avatar_count);
+					assert_eq!(Owners::<Test>::get(ALICE, SEASON_ID).len(), owned_avatar_count);
 					assert_eq!(SeasonStats::<Test>::get(1, ALICE).minted, season_minted_count);
 					assert!(CurrentSeasonStatus::<Test>::get().active);
 					System::assert_last_event(mock::RuntimeEvent::AAvatars(
 						crate::Event::AvatarsMinted {
-							avatar_ids: Owners::<Test>::get(ALICE)[4..=9].to_vec(),
+							avatar_ids: Owners::<Test>::get(ALICE, SEASON_ID)[4..=9].to_vec(),
 						},
 					));
 
@@ -1177,7 +1186,7 @@ mod minting {
 					assert_eq!(SeasonStats::<Test>::get(2, ALICE).minted, 0);
 
 					// check for minted avatars
-					let minted = Owners::<Test>::get(ALICE)
+					let minted = Owners::<Test>::get(ALICE, SEASON_ID)
 						.into_iter()
 						.map(|avatar_id| Avatars::<Test>::get(avatar_id).unwrap())
 						.collect::<Vec<_>>();
@@ -1278,13 +1287,13 @@ mod minting {
 		assert_eq!(avatar_ids.len(), MaxAvatarsPerPlayer::get() as usize);
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.balances(&[(ALICE, 1_234_567_890_123_456)])
 			.free_mints(&[(ALICE, 10)])
 			.build()
 			.execute_with(|| {
 				run_to_block(season.start);
-				Owners::<Test>::insert(ALICE, avatar_ids);
+				Owners::<Test>::insert(ALICE, SEASON_ID, avatar_ids);
 				for count in [MintPackSize::One, MintPackSize::Three, MintPackSize::Six] {
 					for payment in [MintPayment::Normal, MintPayment::Free] {
 						assert_noop!(
@@ -1301,6 +1310,23 @@ mod minting {
 						);
 					}
 				}
+
+				Accounts::<Test>::mutate(BOB, |account| {
+					account.storage_tier = StorageTier::One;
+					account.free_mints = 999;
+				});
+				let mut storage_limit = StorageTier::One as usize;
+				for i in 0..10 {
+					create_avatars(i, BOB, 5);
+					storage_limit -= 5;
+					if storage_limit == 0 {
+						break
+					}
+				}
+				assert_noop!(
+					AAvatars::mint(RuntimeOrigin::signed(BOB), MintOption::default(),),
+					Error::<Test>::MaxOwnershipReached
+				);
 			});
 	}
 
@@ -1310,7 +1336,7 @@ mod minting {
 		let mint_cooldown = 7;
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.mint_cooldown(mint_cooldown)
 			.balances(&[(ALICE, 1_234_567_890_123_456)])
 			.free_mints(&[(ALICE, 10)])
@@ -1369,7 +1395,7 @@ mod minting {
 
 		ExtBuilder::default()
 			.mint_fees(MintFees { one: 1, three: 2, six: 3 })
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.build()
 			.execute_with(|| {
 				run_to_block(season.start);
@@ -1439,14 +1465,14 @@ mod forging {
 	use sp_runtime::testing::H256;
 
 	fn create_avatar_for_bob(dna: &[u8]) -> AvatarIdOf<Test> {
-		let avatar = Avatar::default().season_id(1).dna(dna);
+		let avatar = Avatar::default().season_id(SEASON_ID).dna(dna);
 		if avatar.rarity() == RarityTier::Legendary as u8 {
 			CurrentSeasonStatus::<Test>::mutate(|status| status.max_tier_avatars += 1);
 		}
 
 		let avatar_id = H256::random();
 		Avatars::<Test>::insert(avatar_id, (BOB, avatar));
-		Owners::<Test>::try_append(BOB, avatar_id).unwrap();
+		Owners::<Test>::try_append(BOB, SEASON_ID, avatar_id).unwrap();
 
 		avatar_id
 	}
@@ -1474,7 +1500,7 @@ mod forging {
 		};
 
 		ExtBuilder::default()
-			.seasons(&[(1, season)])
+			.seasons(&[(SEASON_ID, season)])
 			.mint_cooldown(5)
 			.build()
 			.execute_with(|| {
@@ -1549,7 +1575,7 @@ mod forging {
 				));
 
 				if let Some(dna) = insert_dna {
-					Owners::<Test>::get(BOB)[1..=4].iter().for_each(|id| {
+					Owners::<Test>::get(BOB, SEASON_ID)[1..=4].iter().for_each(|id| {
 						Avatars::<Test>::mutate(id, |maybe_avatar| {
 							if let Some((_, avatar)) = maybe_avatar {
 								avatar.dna = dna.to_vec().try_into().unwrap();
@@ -1559,7 +1585,7 @@ mod forging {
 				}
 
 				let original_leader_souls = Avatars::<Test>::get(leader_id).unwrap().1.souls;
-				let sacrifice_ids = Owners::<Test>::get(BOB)[1..=4].to_vec();
+				let sacrifice_ids = Owners::<Test>::get(BOB, SEASON_ID)[1..=4].to_vec();
 				let sacrifice_souls = sacrifice_ids
 					.iter()
 					.map(|id| Avatars::<Test>::get(id).unwrap().1.souls)
@@ -1568,10 +1594,10 @@ mod forging {
 
 				assert_ok!(AAvatars::forge(RuntimeOrigin::signed(BOB), *leader_id, sacrifice_ids));
 				assert_eq!(
-					Avatars::<Test>::get(leader_id).unwrap().1.souls,
+					Avatars::<Test>::get(leader_id,).unwrap().1.souls,
 					original_leader_souls + sacrifice_souls
 				);
-				assert_eq!(Avatars::<Test>::get(leader_id).unwrap().1.dna.to_vec(), expected_dna);
+				assert_eq!(Avatars::<Test>::get(leader_id,).unwrap().1.dna.to_vec(), expected_dna);
 
 				forged_count += 1;
 				assert_eq!(
@@ -1590,7 +1616,7 @@ mod forging {
 			};
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.mint_cooldown(0)
 			.mint_fees(MintFees { one: 1, three: 3, six: 6 })
 			.balances(&[(BOB, MockBalance::max_value())])
@@ -1607,7 +1633,7 @@ mod forging {
 						version: AvatarVersion::V1
 					}
 				));
-				let leader_id = Owners::<Test>::get(BOB)[0];
+				let leader_id = Owners::<Test>::get(BOB, SEASON_ID)[0];
 				assert_eq!(
 					Avatars::<Test>::get(leader_id).unwrap().1.dna.to_vec(),
 					&[0x13, 0x12, 0x12, 0x12, 0x11, 0x11, 0x14, 0x11]
@@ -1686,7 +1712,7 @@ mod forging {
 			.max_tier_forges(5);
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.mint_cooldown(0)
 			.free_mints(&[(BOB, MintCount::MAX)])
 			.build()
@@ -1710,7 +1736,7 @@ mod forging {
 				));
 				max_tier_avatars += 1;
 				assert_eq!(CurrentSeasonStatus::<Test>::get().max_tier_avatars, max_tier_avatars);
-				assert_eq!(Owners::<Test>::get(BOB).len(), 4 - 3);
+				assert_eq!(Owners::<Test>::get(BOB, SEASON_ID).len(), 4 - 3);
 
 				// `max_tier_avatars` decreases when legendaries are sacrificed
 				let legendary_avatar_ids = [
@@ -1729,7 +1755,7 @@ mod forging {
 					legendary_avatar_ids[1..].to_vec()
 				));
 				assert_eq!(CurrentSeasonStatus::<Test>::get().max_tier_avatars, max_tier_avatars);
-				assert_eq!(Owners::<Test>::get(BOB).len(), (4 - 3) + (4 - 3));
+				assert_eq!(Owners::<Test>::get(BOB, SEASON_ID).len(), (4 - 3) + (4 - 3));
 				assert_eq!(
 					Accounts::<Test>::get(BOB)
 						.stats
@@ -1758,7 +1784,7 @@ mod forging {
 			.base_prob(100);
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.mint_cooldown(1)
 			.free_mints(&[(BOB, 10)])
 			.build()
@@ -1776,7 +1802,7 @@ mod forging {
 				));
 
 				// forge
-				let owned_avatar_ids = Owners::<Test>::get(BOB);
+				let owned_avatar_ids = Owners::<Test>::get(BOB, SEASON_ID);
 				let leader_id = owned_avatar_ids[0];
 				let sacrifice_ids = &owned_avatar_ids[1..3];
 
@@ -1838,7 +1864,7 @@ mod forging {
 			.max_sacrifices(5);
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.mint_cooldown(1)
 			.free_mints(&[(BOB, 10)])
 			.build()
@@ -1856,7 +1882,7 @@ mod forging {
 				));
 
 				// forge
-				let owned_avatar_ids = Owners::<Test>::get(BOB);
+				let owned_avatar_ids = Owners::<Test>::get(BOB, SEASON_ID);
 				let leader_id = owned_avatar_ids[0];
 				let sacrifice_id = owned_avatar_ids[1];
 
@@ -1897,7 +1923,7 @@ mod forging {
 			.max_sacrifices(4);
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.mint_cooldown(0)
 			.free_mints(&[(ALICE, MintCount::MAX)])
 			.build()
@@ -1912,7 +1938,7 @@ mod forging {
 						version: AvatarVersion::V1
 					}
 				));
-				let leader_id = Owners::<Test>::get(ALICE)[0];
+				let leader_id = Owners::<Test>::get(ALICE, SEASON_ID)[0];
 				assert_eq!(
 					Avatars::<Test>::get(leader_id).unwrap().1.dna.to_vec(),
 					&[0x14, 0x15, 0x15, 0x13]
@@ -1939,7 +1965,7 @@ mod forging {
 				);
 
 				// forging doesn't take effect
-				let sacrifice_ids = &Owners::<Test>::get(ALICE)[1..5];
+				let sacrifice_ids = &Owners::<Test>::get(ALICE, SEASON_ID)[1..5];
 				assert_ok!(AAvatars::forge(
 					RuntimeOrigin::signed(ALICE),
 					leader_id,
@@ -2039,8 +2065,8 @@ mod forging {
 						run_to_block(n);
 						assert_ok!(AAvatars::forge(
 							RuntimeOrigin::signed(ALICE),
-							Owners::<Test>::get(ALICE)[0],
-							Owners::<Test>::get(ALICE)[1..3].to_vec()
+							Owners::<Test>::get(ALICE, 1)[0],
+							Owners::<Test>::get(ALICE, 1)[1..3].to_vec()
 						));
 					}
 				}
@@ -2070,7 +2096,7 @@ mod forging {
 		let season = Season::default().min_sacrifices(1).max_sacrifices(3);
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.mint_cooldown(0)
 			.free_mints(&[(ALICE, 10)])
 			.build()
@@ -2088,7 +2114,7 @@ mod forging {
 					));
 				}
 
-				let owned_avatars = Owners::<Test>::get(ALICE);
+				let owned_avatars = Owners::<Test>::get(ALICE, SEASON_ID);
 				for (leader, sacrifices) in [
 					(H256::default(), vec![owned_avatars[0], owned_avatars[2]]),
 					(owned_avatars[1], vec![H256::default(), H256::default()]),
@@ -2107,7 +2133,7 @@ mod forging {
 		let season = Season::default().min_sacrifices(1).max_sacrifices(3);
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.mint_cooldown(0)
 			.free_mints(&[(ALICE, 10), (BOB, 10)])
 			.build()
@@ -2128,9 +2154,21 @@ mod forging {
 				}
 
 				for (player, leader, sacrifices) in [
-					(ALICE, Owners::<Test>::get(ALICE)[0], Owners::<Test>::get(BOB)[0..2].to_vec()),
-					(ALICE, Owners::<Test>::get(BOB)[0], Owners::<Test>::get(ALICE)[0..2].to_vec()),
-					(ALICE, Owners::<Test>::get(BOB)[0], Owners::<Test>::get(BOB)[1..2].to_vec()),
+					(
+						ALICE,
+						Owners::<Test>::get(ALICE, SEASON_ID)[0],
+						Owners::<Test>::get(BOB, SEASON_ID)[0..2].to_vec(),
+					),
+					(
+						ALICE,
+						Owners::<Test>::get(BOB, SEASON_ID)[0],
+						Owners::<Test>::get(ALICE, SEASON_ID)[0..2].to_vec(),
+					),
+					(
+						ALICE,
+						Owners::<Test>::get(BOB, SEASON_ID)[0],
+						Owners::<Test>::get(BOB, SEASON_ID)[1..2].to_vec(),
+					),
 				] {
 					assert_noop!(
 						AAvatars::forge(RuntimeOrigin::signed(player), leader, sacrifices),
@@ -2145,7 +2183,7 @@ mod forging {
 		let season = Season::default().min_sacrifices(1).max_sacrifices(3);
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.mint_cooldown(0)
 			.free_mints(&[(ALICE, 10)])
 			.build()
@@ -2166,13 +2204,13 @@ mod forging {
 				for (player, leader, sacrifices) in [
 					(
 						ALICE,
-						Owners::<Test>::get(ALICE)[0],
-						Owners::<Test>::get(ALICE)[0..2].to_vec(),
+						Owners::<Test>::get(ALICE, SEASON_ID)[0],
+						Owners::<Test>::get(ALICE, SEASON_ID)[0..2].to_vec(),
 					),
 					(
 						ALICE,
-						Owners::<Test>::get(ALICE)[1],
-						Owners::<Test>::get(ALICE)[0..2].to_vec(),
+						Owners::<Test>::get(ALICE, SEASON_ID)[1],
+						Owners::<Test>::get(ALICE, SEASON_ID)[0..2].to_vec(),
 					),
 				] {
 					assert_noop!(
@@ -2190,7 +2228,7 @@ mod forging {
 		let initial_balance = 6 + MockExistentialDeposit::get();
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.balances(&[(ALICE, initial_balance), (BOB, 6 + initial_balance)])
 			.mint_fees(MintFees { one: 1, three: 1, six: 1 })
 			.build()
@@ -2215,8 +2253,8 @@ mod forging {
 					}
 				));
 
-				let leader = Owners::<Test>::get(ALICE)[0];
-				let sacrifices = Owners::<Test>::get(ALICE)[1..3].to_vec();
+				let leader = Owners::<Test>::get(ALICE, SEASON_ID)[0];
+				let sacrifices = Owners::<Test>::get(ALICE, SEASON_ID)[1..3].to_vec();
 
 				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(ALICE), leader, price));
 				assert_noop!(
@@ -2256,55 +2294,24 @@ mod forging {
 			.max_sacrifices(max_sacrifices);
 
 		ExtBuilder::default()
-			.seasons(&[(1, season1.clone()), (2, season2.clone())])
+			.seasons(&[(1, season1), (2, season2)])
 			.mint_cooldown(0)
 			.free_mints(&[(ALICE, 10)])
 			.build()
 			.execute_with(|| {
-				run_to_block(season1.early_start + 1);
-				for _ in 0..max_sacrifices {
-					assert_ok!(AAvatars::mint(
-						RuntimeOrigin::signed(ALICE),
-						MintOption {
-							pack_size: MintPackSize::One,
-							payment: MintPayment::Free,
-							pack_type: PackType::Material,
-							version: AvatarVersion::V1
-						}
-					));
-					run_to_block(System::block_number() + 1);
-				}
-				run_to_block(season2.start + 2);
-
-				for _ in 0..max_sacrifices {
-					assert_ok!(AAvatars::mint(
-						RuntimeOrigin::signed(ALICE),
-						MintOption {
-							pack_size: MintPackSize::One,
-							payment: MintPayment::Free,
-							pack_type: PackType::Material,
-							version: AvatarVersion::V1
-						}
-					));
-					run_to_block(System::block_number() + 1);
-				}
-				run_to_block(season2.end + 1);
+				create_avatars(1, ALICE, max_sacrifices);
+				create_avatars(2, ALICE, max_sacrifices);
 
 				for (player, leader, sacrifices) in [
 					(
 						ALICE,
-						Owners::<Test>::get(ALICE)[0],
-						Owners::<Test>::get(ALICE)[2..5].to_vec(),
+						Owners::<Test>::get(ALICE, 1)[0],
+						Owners::<Test>::get(ALICE, 2).to_vec(),
 					),
 					(
 						ALICE,
-						Owners::<Test>::get(ALICE)[0],
-						Owners::<Test>::get(ALICE)[3..6].to_vec(),
-					),
-					(
-						ALICE,
-						Owners::<Test>::get(ALICE)[5],
-						Owners::<Test>::get(ALICE)[0..2].to_vec(),
+						Owners::<Test>::get(ALICE, 2)[0],
+						Owners::<Test>::get(ALICE, 1).to_vec(),
 					),
 				] {
 					assert_noop!(
@@ -2391,23 +2398,28 @@ mod transferring {
 				assert_eq!(Balances::free_balance(treasury_account), treasury_balance);
 				assert_eq!(Balances::total_issuance(), total_supply);
 
-				let mut alice_avatar_ids = create_avatars(1, ALICE, 3);
-				let mut bob_avatar_ids = create_avatars(1, BOB, 6);
+				let mut alice_avatar_ids = create_avatars(SEASON_ID, ALICE, 3);
+				let mut bob_avatar_ids = create_avatars(SEASON_ID, BOB, 6);
 				let avatar_id = alice_avatar_ids[0];
 				Avatars::<Test>::mutate(avatar_id, |maybe_avatar| {
 					let (_, avatar) = maybe_avatar.as_mut().unwrap();
 					avatar.season_id = season_id;
 				});
 
-				assert_ok!(AAvatars::transfer_avatar(RuntimeOrigin::signed(ALICE), BOB, avatar_id));
+				assert_ok!(AAvatars::transfer_avatar(
+					RuntimeOrigin::signed(ALICE),
+					BOB,
+					SEASON_ID,
+					avatar_id
+				));
 				alice_avatar_ids.retain(|x| x != &avatar_id);
 				bob_avatar_ids.push(avatar_id);
 
 				// transfer checks
-				assert_eq!(Owners::<Test>::get(ALICE).len(), 3 - 1);
-				assert_eq!(Owners::<Test>::get(ALICE), alice_avatar_ids);
-				assert_eq!(Owners::<Test>::get(BOB).len(), 6 + 1);
-				assert_eq!(Owners::<Test>::get(BOB), bob_avatar_ids);
+				assert_eq!(Owners::<Test>::get(ALICE, SEASON_ID).len(), 3 - 1);
+				assert_eq!(Owners::<Test>::get(ALICE, SEASON_ID), alice_avatar_ids);
+				assert_eq!(Owners::<Test>::get(BOB, SEASON_ID).len(), 6 + 1);
+				assert_eq!(Owners::<Test>::get(BOB, SEASON_ID), bob_avatar_ids);
 				assert_eq!(Avatars::<Test>::get(avatar_id).unwrap().0, BOB);
 				System::assert_last_event(mock::RuntimeEvent::AAvatars(
 					crate::Event::AvatarTransferred { from: ALICE, to: BOB, avatar_id },
@@ -2429,10 +2441,11 @@ mod transferring {
 				assert_ok!(AAvatars::transfer_avatar(
 					RuntimeOrigin::signed(BOB),
 					CHARLIE,
+					SEASON_ID,
 					bob_avatar_ids[0]
 				));
-				assert_eq!(Owners::<Test>::get(BOB).len(), 6);
-				assert_eq!(Owners::<Test>::get(CHARLIE).len(), 1);
+				assert_eq!(Owners::<Test>::get(BOB, SEASON_ID).len(), 6);
+				assert_eq!(Owners::<Test>::get(CHARLIE, SEASON_ID).len(), 1);
 			});
 	}
 
@@ -2441,7 +2454,12 @@ mod transferring {
 		ExtBuilder::default().build().execute_with(|| {
 			GlobalConfigs::<Test>::mutate(|config| config.transfer.open = false);
 			assert_noop!(
-				AAvatars::transfer_avatar(RuntimeOrigin::signed(BOB), CHARLIE, H256::random()),
+				AAvatars::transfer_avatar(
+					RuntimeOrigin::signed(BOB),
+					CHARLIE,
+					SeasonId::default(),
+					H256::random()
+				),
 				Error::<Test>::TransferClosed
 			);
 		});
@@ -2457,8 +2475,13 @@ mod transferring {
 			.build()
 			.execute_with(|| {
 				GlobalConfigs::<Test>::mutate(|config| config.transfer.open = false);
-				let avatar_id = create_avatars(1, BOB, 1)[0];
-				assert_ok!(AAvatars::transfer_avatar(RuntimeOrigin::signed(BOB), DAVE, avatar_id));
+				let avatar_id = create_avatars(SEASON_ID, BOB, 1)[0];
+				assert_ok!(AAvatars::transfer_avatar(
+					RuntimeOrigin::signed(BOB),
+					DAVE,
+					SEASON_ID,
+					avatar_id
+				));
 			});
 	}
 
@@ -2467,7 +2490,12 @@ mod transferring {
 		ExtBuilder::default().build().execute_with(|| {
 			for who in [ALICE, BOB] {
 				assert_noop!(
-					AAvatars::transfer_avatar(RuntimeOrigin::signed(who), who, H256::random()),
+					AAvatars::transfer_avatar(
+						RuntimeOrigin::signed(who),
+						who,
+						SeasonId::default(),
+						H256::random()
+					),
 					Error::<Test>::CannotTransferToSelf
 				);
 			}
@@ -2477,10 +2505,15 @@ mod transferring {
 	#[test]
 	fn transfer_avatar_rejects_avatar_in_trade() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, CHARLIE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, CHARLIE, 1)[0];
 			assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(CHARLIE), avatar_id, 999));
 			assert_noop!(
-				AAvatars::transfer_avatar(RuntimeOrigin::signed(CHARLIE), DAVE, avatar_id),
+				AAvatars::transfer_avatar(
+					RuntimeOrigin::signed(CHARLIE),
+					DAVE,
+					SEASON_ID,
+					avatar_id
+				),
 				Error::<Test>::AvatarInTrade
 			);
 		});
@@ -2489,9 +2522,9 @@ mod transferring {
 	#[test]
 	fn transfer_avatar_rejects_unowned_avatars() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, CHARLIE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, CHARLIE, 1)[0];
 			assert_noop!(
-				AAvatars::transfer_avatar(RuntimeOrigin::signed(ALICE), BOB, avatar_id),
+				AAvatars::transfer_avatar(RuntimeOrigin::signed(ALICE), BOB, SEASON_ID, avatar_id),
 				Error::<Test>::Ownership
 			);
 		});
@@ -2501,7 +2534,12 @@ mod transferring {
 	fn transfer_avatar_rejects_unknown_avatars() {
 		ExtBuilder::default().build().execute_with(|| {
 			assert_noop!(
-				AAvatars::transfer_avatar(RuntimeOrigin::signed(ALICE), BOB, H256::random()),
+				AAvatars::transfer_avatar(
+					RuntimeOrigin::signed(ALICE),
+					BOB,
+					SeasonId::default(),
+					H256::random()
+				),
 				Error::<Test>::UnknownAvatar
 			);
 		});
@@ -2517,11 +2555,16 @@ mod transferring {
 			.execute_with(|| {
 				Accounts::<Test>::mutate(BOB, |info| info.storage_tier = StorageTier::Three);
 
-				let avatar_id = create_avatars(1, ALICE, 1)[0];
-				let _ = create_avatars(1, BOB, StorageTier::Three as u8);
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
+				let _ = create_avatars(SEASON_ID, BOB, StorageTier::Three as u8);
 
 				assert_noop!(
-					AAvatars::transfer_avatar(RuntimeOrigin::signed(ALICE), BOB, avatar_id),
+					AAvatars::transfer_avatar(
+						RuntimeOrigin::signed(ALICE),
+						BOB,
+						SEASON_ID,
+						avatar_id
+					),
 					Error::<Test>::MaxOwnershipReached
 				);
 			});
@@ -2535,19 +2578,21 @@ mod trading {
 	fn set_price_should_work() {
 		let season = Season::default();
 
-		ExtBuilder::default().seasons(&[(1, season.clone())]).build().execute_with(|| {
-			run_to_block(season.start);
-			let avatar_for_sale = create_avatars(1, BOB, 1)[0];
-			let price = 7357;
+		ExtBuilder::default()
+			.seasons(&[(SEASON_ID, season.clone())])
+			.build()
+			.execute_with(|| {
+				run_to_block(season.start);
+				let avatar_for_sale = create_avatars(SEASON_ID, BOB, 1)[0];
+				let price = 7357;
 
-			assert_eq!(Trade::<Test>::get(avatar_for_sale), None);
-			assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, price));
-			assert_eq!(Trade::<Test>::get(avatar_for_sale), Some(price));
-			System::assert_last_event(mock::RuntimeEvent::AAvatars(crate::Event::AvatarPriceSet {
-				avatar_id: avatar_for_sale,
-				price,
-			}));
-		});
+				assert_eq!(Trade::<Test>::get(avatar_for_sale), None);
+				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, price));
+				assert_eq!(Trade::<Test>::get(avatar_for_sale), Some(price));
+				System::assert_last_event(mock::RuntimeEvent::AAvatars(
+					crate::Event::AvatarPriceSet { avatar_id: avatar_for_sale, price },
+				));
+			});
 	}
 
 	#[test]
@@ -2575,36 +2620,42 @@ mod trading {
 	fn set_price_should_reject_incorrect_ownership() {
 		let season = Season::default();
 
-		ExtBuilder::default().seasons(&[(1, season.clone())]).build().execute_with(|| {
-			run_to_block(season.start);
-			let avatar_ids = create_avatars(1, BOB, 2);
+		ExtBuilder::default()
+			.seasons(&[(SEASON_ID, season.clone())])
+			.build()
+			.execute_with(|| {
+				run_to_block(season.start);
+				let avatar_ids = create_avatars(SEASON_ID, BOB, 2);
 
-			assert_noop!(
-				AAvatars::set_price(RuntimeOrigin::signed(CHARLIE), avatar_ids[0], 101),
-				Error::<Test>::Ownership
-			);
-		});
+				assert_noop!(
+					AAvatars::set_price(RuntimeOrigin::signed(CHARLIE), avatar_ids[0], 101),
+					Error::<Test>::Ownership
+				);
+			});
 	}
 
 	#[test]
 	fn remove_price_should_work() {
 		let season = Season::default();
 
-		ExtBuilder::default().seasons(&[(1, season.clone())]).build().execute_with(|| {
-			run_to_block(season.start);
-			let avatar_ids = create_avatars(1, BOB, 2);
-			let avatar_for_sale = avatar_ids[0];
-			let price = 101;
+		ExtBuilder::default()
+			.seasons(&[(SEASON_ID, season.clone())])
+			.build()
+			.execute_with(|| {
+				run_to_block(season.start);
+				let avatar_ids = create_avatars(SEASON_ID, BOB, 2);
+				let avatar_for_sale = avatar_ids[0];
+				let price = 101;
 
-			assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, price));
+				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, price));
 
-			assert_eq!(Trade::<Test>::get(avatar_for_sale), Some(101));
-			assert_ok!(AAvatars::remove_price(RuntimeOrigin::signed(BOB), avatar_for_sale));
-			assert_eq!(Trade::<Test>::get(avatar_for_sale), None);
-			System::assert_last_event(mock::RuntimeEvent::AAvatars(
-				crate::Event::AvatarPriceUnset { avatar_id: avatar_for_sale },
-			));
-		});
+				assert_eq!(Trade::<Test>::get(avatar_for_sale), Some(101));
+				assert_ok!(AAvatars::remove_price(RuntimeOrigin::signed(BOB), avatar_for_sale));
+				assert_eq!(Trade::<Test>::get(avatar_for_sale), None);
+				System::assert_last_event(mock::RuntimeEvent::AAvatars(
+					crate::Event::AvatarPriceUnset { avatar_id: avatar_for_sale },
+				));
+			});
 	}
 
 	#[test]
@@ -2632,17 +2683,20 @@ mod trading {
 	fn remove_price_should_reject_incorrect_ownership() {
 		let season = Season::default();
 
-		ExtBuilder::default().seasons(&[(1, season.clone())]).build().execute_with(|| {
-			run_to_block(season.start);
-			let avatar_ids = create_avatars(1, BOB, 3);
-			let avatar_for_sale = avatar_ids[0];
+		ExtBuilder::default()
+			.seasons(&[(SEASON_ID, season.clone())])
+			.build()
+			.execute_with(|| {
+				run_to_block(season.start);
+				let avatar_ids = create_avatars(SEASON_ID, BOB, 3);
+				let avatar_for_sale = avatar_ids[0];
 
-			assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, 123));
-			assert_noop!(
-				AAvatars::remove_price(RuntimeOrigin::signed(CHARLIE), avatar_for_sale),
-				Error::<Test>::Ownership
-			);
-		});
+				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, 123));
+				assert_noop!(
+					AAvatars::remove_price(RuntimeOrigin::signed(CHARLIE), avatar_for_sale),
+					Error::<Test>::Ownership
+				);
+			});
 	}
 
 	#[test]
@@ -2667,7 +2721,7 @@ mod trading {
 
 		ExtBuilder::default()
 			.existential_deposit(0)
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.balances(&[
 				(ALICE, alice_initial_bal),
 				(BOB, bob_initial_bal),
@@ -2679,35 +2733,35 @@ mod trading {
 				let mut treasury_balance_season_1 = 0;
 				let treasury_account = AAvatars::treasury_account_id();
 
-				assert_eq!(Treasury::<Test>::get(1), treasury_balance_season_1);
+				assert_eq!(Treasury::<Test>::get(SEASON_ID), treasury_balance_season_1);
 				assert_eq!(Balances::free_balance(&treasury_account), treasury_balance_season_1);
 				assert_eq!(Balances::total_issuance(), total_supply);
 
 				run_to_block(season.start);
-				let avatar_ids = create_avatars(1, BOB, 3);
-				assert_eq!(Treasury::<Test>::get(1), treasury_balance_season_1);
+				let avatar_ids = create_avatars(SEASON_ID, BOB, 3);
+				assert_eq!(Treasury::<Test>::get(SEASON_ID), treasury_balance_season_1);
 				assert_eq!(Balances::free_balance(&treasury_account), treasury_balance_season_1);
 
-				let owned_by_alice = Owners::<Test>::get(ALICE);
-				let owned_by_bob = Owners::<Test>::get(BOB);
+				let owned_by_alice = Owners::<Test>::get(ALICE, SEASON_ID);
+				let owned_by_bob = Owners::<Test>::get(BOB, SEASON_ID);
 
 				let avatar_for_sale = avatar_ids[0];
 				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, price));
-				assert_ok!(AAvatars::buy(RuntimeOrigin::signed(ALICE), avatar_for_sale));
+				assert_ok!(AAvatars::buy(RuntimeOrigin::signed(ALICE), SEASON_ID, avatar_for_sale));
 				treasury_balance_season_1 += min_fee;
 
 				// check for balance transfer
 				assert_eq!(Balances::free_balance(ALICE), alice_initial_bal - price - min_fee);
 				assert_eq!(Balances::free_balance(BOB), bob_initial_bal + price);
-				assert_eq!(Treasury::<Test>::get(1), treasury_balance_season_1);
+				assert_eq!(Treasury::<Test>::get(SEASON_ID), treasury_balance_season_1);
 				assert_eq!(Balances::free_balance(&treasury_account), treasury_balance_season_1);
 				assert_eq!(Balances::total_issuance(), total_supply);
 
 				// check for ownership transfer
-				assert_eq!(Owners::<Test>::get(ALICE).len(), owned_by_alice.len() + 1);
-				assert_eq!(Owners::<Test>::get(BOB).len(), owned_by_bob.len() - 1);
-				assert!(Owners::<Test>::get(ALICE).contains(&avatar_for_sale));
-				assert!(!Owners::<Test>::get(BOB).contains(&avatar_for_sale));
+				assert_eq!(Owners::<Test>::get(ALICE, SEASON_ID).len(), owned_by_alice.len() + 1);
+				assert_eq!(Owners::<Test>::get(BOB, SEASON_ID).len(), owned_by_bob.len() - 1);
+				assert!(Owners::<Test>::get(ALICE, SEASON_ID).contains(&avatar_for_sale));
+				assert!(!Owners::<Test>::get(BOB, SEASON_ID).contains(&avatar_for_sale));
 				assert_eq!(Avatars::<Test>::get(avatar_for_sale).unwrap().0, ALICE);
 
 				// check for removal from trade storage
@@ -2725,7 +2779,11 @@ mod trading {
 				// charlie buys from bob
 				let avatar_for_sale = avatar_ids[1];
 				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, 1357));
-				assert_ok!(AAvatars::buy(RuntimeOrigin::signed(CHARLIE), avatar_for_sale));
+				assert_ok!(AAvatars::buy(
+					RuntimeOrigin::signed(CHARLIE),
+					SEASON_ID,
+					avatar_for_sale
+				));
 				treasury_balance_season_1 += min_fee;
 				assert_eq!(Accounts::<Test>::get(CHARLIE).stats.trade.bought, 1);
 				assert_eq!(Accounts::<Test>::get(BOB).stats.trade.sold, 2);
@@ -2733,9 +2791,9 @@ mod trading {
 				// check season id
 				let avatar_on_sale = create_avatars(33, ALICE, 1)[0];
 				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(ALICE), avatar_on_sale, 369));
-				assert_ok!(AAvatars::buy(RuntimeOrigin::signed(BOB), avatar_on_sale));
+				assert_ok!(AAvatars::buy(RuntimeOrigin::signed(BOB), SEASON_ID, avatar_on_sale));
 				assert_eq!(Treasury::<Test>::get(33), min_fee);
-				assert_eq!(Treasury::<Test>::get(1), treasury_balance_season_1);
+				assert_eq!(Treasury::<Test>::get(SEASON_ID), treasury_balance_season_1);
 			});
 	}
 
@@ -2749,12 +2807,12 @@ mod trading {
 		let mut treasury_balance = 0;
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.balances(&[(ALICE, alice_balance), (BOB, bob_balance)])
 			.build()
 			.execute_with(|| {
 				run_to_block(season.start);
-				let avatar_ids = create_avatars(1, ALICE, 2);
+				let avatar_ids = create_avatars(SEASON_ID, ALICE, 2);
 
 				GlobalConfigs::<Test>::mutate(|cfg| {
 					cfg.trade.min_fee = min_fee;
@@ -2764,25 +2822,25 @@ mod trading {
 				// when price is much greater (> 30%) than min_fee, percent_fee should be charged
 				let price = 9_999;
 				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(ALICE), avatar_ids[0], price));
-				assert_ok!(AAvatars::buy(RuntimeOrigin::signed(BOB), avatar_ids[0]));
+				assert_ok!(AAvatars::buy(RuntimeOrigin::signed(BOB), SEASON_ID, avatar_ids[0]));
 				let expected_fee = price * percent_fee as u64 / 100_u64;
 				bob_balance -= price + expected_fee;
 				alice_balance += price;
 				treasury_balance += expected_fee;
 				assert_eq!(Balances::free_balance(BOB), bob_balance);
 				assert_eq!(Balances::free_balance(ALICE), alice_balance);
-				assert_eq!(Treasury::<Test>::get(1), treasury_balance);
+				assert_eq!(Treasury::<Test>::get(SEASON_ID), treasury_balance);
 
 				// when price is less than min_fee, min_fee should be charged
 				let price = 100;
 				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(ALICE), avatar_ids[1], price));
-				assert_ok!(AAvatars::buy(RuntimeOrigin::signed(BOB), avatar_ids[1]));
+				assert_ok!(AAvatars::buy(RuntimeOrigin::signed(BOB), SEASON_ID, avatar_ids[1]));
 				bob_balance -= price + min_fee;
 				alice_balance += price;
 				treasury_balance += min_fee;
 				assert_eq!(Balances::free_balance(BOB), bob_balance);
 				assert_eq!(Balances::free_balance(ALICE), alice_balance);
-				assert_eq!(Treasury::<Test>::get(1), treasury_balance);
+				assert_eq!(Treasury::<Test>::get(SEASON_ID), treasury_balance);
 			});
 	}
 
@@ -2791,7 +2849,7 @@ mod trading {
 		ExtBuilder::default().build().execute_with(|| {
 			GlobalConfigs::<Test>::mutate(|config| config.trade.open = false);
 			assert_noop!(
-				AAvatars::buy(RuntimeOrigin::signed(ALICE), sp_core::H256::default()),
+				AAvatars::buy(RuntimeOrigin::signed(ALICE), SeasonId::default(), H256::default()),
 				Error::<Test>::TradeClosed,
 			);
 		});
@@ -2801,7 +2859,7 @@ mod trading {
 	fn buy_should_reject_unsigned_calls() {
 		ExtBuilder::default().build().execute_with(|| {
 			assert_noop!(
-				AAvatars::buy(RuntimeOrigin::none(), sp_core::H256::default()),
+				AAvatars::buy(RuntimeOrigin::none(), SeasonId::default(), H256::default()),
 				DispatchError::BadOrigin,
 			);
 		});
@@ -2811,7 +2869,7 @@ mod trading {
 	fn buy_should_reject_unlisted_avatar() {
 		ExtBuilder::default().build().execute_with(|| {
 			assert_noop!(
-				AAvatars::buy(RuntimeOrigin::signed(BOB), sp_core::H256::default()),
+				AAvatars::buy(RuntimeOrigin::signed(BOB), SeasonId::default(), H256::default()),
 				Error::<Test>::UnknownAvatarForSale,
 			);
 		});
@@ -2823,17 +2881,17 @@ mod trading {
 		let price = 310_984;
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.balances(&[(ALICE, price - 1)])
 			.build()
 			.execute_with(|| {
 				run_to_block(season.start);
-				let avatar_ids = create_avatars(1, BOB, 3);
+				let avatar_ids = create_avatars(SEASON_ID, BOB, 3);
 				let avatar_for_sale = avatar_ids[0];
 
 				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, price));
 				assert_noop!(
-					AAvatars::buy(RuntimeOrigin::signed(ALICE), avatar_for_sale),
+					AAvatars::buy(RuntimeOrigin::signed(ALICE), SEASON_ID, avatar_for_sale),
 					pallet_balances::Error::<Test>::InsufficientBalance
 				);
 			});
@@ -2843,17 +2901,20 @@ mod trading {
 	fn buy_should_reject_when_buyer_buys_its_own_avatar() {
 		let season = Season::default();
 
-		ExtBuilder::default().seasons(&[(1, season.clone())]).build().execute_with(|| {
-			run_to_block(season.start);
-			let avatar_ids = create_avatars(1, BOB, 3);
-			let avatar_for_sale = avatar_ids[0];
+		ExtBuilder::default()
+			.seasons(&[(SEASON_ID, season.clone())])
+			.build()
+			.execute_with(|| {
+				run_to_block(season.start);
+				let avatar_ids = create_avatars(SEASON_ID, BOB, 3);
+				let avatar_for_sale = avatar_ids[0];
 
-			assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, 123));
-			assert_noop!(
-				AAvatars::buy(RuntimeOrigin::signed(BOB), avatar_for_sale),
-				Error::<Test>::AlreadyOwned
-			);
-		});
+				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, 123));
+				assert_noop!(
+					AAvatars::buy(RuntimeOrigin::signed(BOB), SEASON_ID, avatar_for_sale),
+					Error::<Test>::AlreadyOwned
+				);
+			});
 	}
 }
 
@@ -2975,7 +3036,7 @@ mod nft_transfer {
 		let season = Season::default().max_components(8).max_variations(5);
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.balances(&[(ALICE, 1_000_000_000_000)])
 			.create_nft_collection(true)
 			.build()
@@ -2990,7 +3051,7 @@ mod nft_transfer {
 						version: AvatarVersion::V1
 					}
 				));
-				let avatar_ids = Owners::<Test>::get(ALICE);
+				let avatar_ids = Owners::<Test>::get(ALICE, SEASON_ID);
 				let avatar_id = avatar_ids[0];
 
 				assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), ALICE));
@@ -3000,7 +3061,11 @@ mod nft_transfer {
 					avatar_id,
 					IpfsUrl::try_from(b"test".to_vec()).unwrap()
 				));
-				assert_ok!(AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
+				assert_ok!(AAvatars::lock_avatar(
+					RuntimeOrigin::signed(ALICE),
+					SEASON_ID,
+					avatar_id
+				));
 				assert!(!Preparation::<Test>::contains_key(avatar_id));
 				assert!(LockedAvatars::<Test>::contains_key(avatar_id));
 				System::assert_last_event(mock::RuntimeEvent::AAvatars(
@@ -3050,8 +3115,8 @@ mod nft_transfer {
 
 				// Ensure ownership transferred to technical account
 				let technical_account = AAvatars::technical_account_id();
-				assert!(!Owners::<Test>::get(ALICE).contains(&avatar_id));
-				assert_eq!(Owners::<Test>::get(technical_account)[0], avatar_id);
+				assert!(!Owners::<Test>::get(ALICE, SEASON_ID).contains(&avatar_id));
+				assert_eq!(Owners::<Test>::get(technical_account, SEASON_ID)[0], avatar_id);
 				assert_eq!(Avatars::<Test>::get(avatar_id).unwrap().0, technical_account);
 
 				// Ensure locked avatars cannot be used in trading, transferring and forging
@@ -3060,6 +3125,7 @@ mod nft_transfer {
 					AAvatars::transfer_avatar(
 						RuntimeOrigin::signed(technical_account),
 						BOB,
+						SEASON_ID,
 						avatar_id,
 					),
 					AAvatars::forge(
@@ -3080,10 +3146,10 @@ mod nft_transfer {
 			.create_nft_collection(true)
 			.build()
 			.execute_with(|| {
-				let avatar_id = create_avatars(1, ALICE, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 				GlobalConfigs::<Test>::mutate(|config| config.nft_transfer.open = false);
 				assert_noop!(
-					AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
+					AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), SEASON_ID, avatar_id),
 					Error::<Test>::NftTransferClosed
 				);
 			})
@@ -3096,9 +3162,9 @@ mod nft_transfer {
 			.create_nft_collection(true)
 			.build()
 			.execute_with(|| {
-				let avatar_id = create_avatars(1, BOB, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, BOB, 1)[0];
 				assert_noop!(
-					AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
+					AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), SEASON_ID, avatar_id),
 					Error::<Test>::Ownership
 				);
 			});
@@ -3111,10 +3177,10 @@ mod nft_transfer {
 			.create_nft_collection(true)
 			.build()
 			.execute_with(|| {
-				let avatar_id = create_avatars(1, ALICE, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(ALICE), avatar_id, 1_000));
 				assert_noop!(
-					AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
+					AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), SEASON_ID, avatar_id),
 					Error::<Test>::AvatarInTrade
 				);
 			});
@@ -3127,7 +3193,7 @@ mod nft_transfer {
 			.create_nft_collection(true)
 			.build()
 			.execute_with(|| {
-				let avatar_id = create_avatars(1, ALICE, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 				assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), ALICE));
 				assert_ok!(AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
 				assert_ok!(AAvatars::prepare_ipfs(
@@ -3135,10 +3201,15 @@ mod nft_transfer {
 					avatar_id,
 					IpfsUrl::try_from(b"test".to_vec()).unwrap()
 				));
-				assert_ok!(AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
+				assert_ok!(AAvatars::lock_avatar(
+					RuntimeOrigin::signed(ALICE),
+					SEASON_ID,
+					avatar_id
+				));
 				assert_noop!(
 					AAvatars::lock_avatar(
 						RuntimeOrigin::signed(AAvatars::technical_account_id()),
+						SEASON_ID,
 						avatar_id
 					),
 					Error::<Test>::AvatarLocked
@@ -3153,9 +3224,9 @@ mod nft_transfer {
 			.create_nft_collection(true)
 			.build()
 			.execute_with(|| {
-				let avatar_id = create_avatars(1, ALICE, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 				assert_noop!(
-					AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
+					AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), SEASON_ID, avatar_id),
 					Error::<Test>::NotPrepared
 				);
 			});
@@ -3168,7 +3239,7 @@ mod nft_transfer {
 			.create_nft_collection(true)
 			.build()
 			.execute_with(|| {
-				let avatar_id = create_avatars(1, ALICE, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 				assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), ALICE));
 				assert_ok!(AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
 				assert_ok!(AAvatars::prepare_ipfs(
@@ -3181,7 +3252,7 @@ mod nft_transfer {
 				Preparation::<Test>::insert(avatar_id, IpfsUrl::default());
 
 				assert_noop!(
-					AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
+					AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), SEASON_ID, avatar_id),
 					pallet_ajuna_nft_transfer::Error::<Test>::EmptyIpfsUrl
 				);
 			});
@@ -3197,13 +3268,13 @@ mod nft_transfer {
 			.value_limit(value_limit)
 			.build()
 			.execute_with(|| {
-				let avatar_id = create_avatars(1, ALICE, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 				let (_, avatar) = Avatars::<Test>::get(avatar_id).unwrap();
 				assert!(avatar.encode().len() > value_limit as usize);
 				assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), ALICE));
 				assert_ok!(AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
 				assert_noop!(
-					AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
+					AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), SEASON_ID, avatar_id),
 					pallet_nfts::Error::<Test>::IncorrectData
 				);
 			});
@@ -3216,7 +3287,7 @@ mod nft_transfer {
 			.create_nft_collection(true)
 			.build()
 			.execute_with(|| {
-				let avatar_id = create_avatars(1, ALICE, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 				assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), ALICE));
 				assert_ok!(AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
 				assert_ok!(AAvatars::prepare_ipfs(
@@ -3224,8 +3295,16 @@ mod nft_transfer {
 					avatar_id,
 					IpfsUrl::try_from(b"test".to_vec()).unwrap()
 				));
-				assert_ok!(AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
-				assert_ok!(AAvatars::unlock_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
+				assert_ok!(AAvatars::lock_avatar(
+					RuntimeOrigin::signed(ALICE),
+					SEASON_ID,
+					avatar_id
+				));
+				assert_ok!(AAvatars::unlock_avatar(
+					RuntimeOrigin::signed(ALICE),
+					SEASON_ID,
+					avatar_id
+				));
 				assert_eq!(LockedAvatars::<Test>::get(avatar_id), None);
 				System::assert_last_event(mock::RuntimeEvent::AAvatars(
 					crate::Event::AvatarUnlocked { avatar_id },
@@ -3240,7 +3319,7 @@ mod nft_transfer {
 			.create_nft_collection(true)
 			.build()
 			.execute_with(|| {
-				let avatar_id = create_avatars(1, ALICE, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 				assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), ALICE));
 				assert_ok!(AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
 				assert_ok!(AAvatars::prepare_ipfs(
@@ -3248,10 +3327,14 @@ mod nft_transfer {
 					avatar_id,
 					IpfsUrl::try_from(b"test".to_vec()).unwrap()
 				));
-				assert_ok!(AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
+				assert_ok!(AAvatars::lock_avatar(
+					RuntimeOrigin::signed(ALICE),
+					SEASON_ID,
+					avatar_id
+				));
 				GlobalConfigs::<Test>::mutate(|config| config.nft_transfer.open = false);
 				assert_noop!(
-					AAvatars::unlock_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
+					AAvatars::unlock_avatar(RuntimeOrigin::signed(ALICE), SEASON_ID, avatar_id),
 					Error::<Test>::NftTransferClosed
 				);
 			})
@@ -3264,7 +3347,7 @@ mod nft_transfer {
 			.create_nft_collection(true)
 			.build()
 			.execute_with(|| {
-				let avatar_id = create_avatars(1, BOB, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, BOB, 1)[0];
 				assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), ALICE));
 				assert_ok!(AAvatars::prepare_avatar(RuntimeOrigin::signed(BOB), avatar_id));
 				assert_ok!(AAvatars::prepare_ipfs(
@@ -3272,9 +3355,9 @@ mod nft_transfer {
 					avatar_id,
 					IpfsUrl::try_from(b"test".to_vec()).unwrap()
 				));
-				assert_ok!(AAvatars::lock_avatar(RuntimeOrigin::signed(BOB), avatar_id));
+				assert_ok!(AAvatars::lock_avatar(RuntimeOrigin::signed(BOB), SEASON_ID, avatar_id));
 				assert_noop!(
-					AAvatars::unlock_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
+					AAvatars::unlock_avatar(RuntimeOrigin::signed(ALICE), SEASON_ID, avatar_id),
 					pallet_nfts::Error::<Test>::NoPermission
 				);
 			});
@@ -3285,14 +3368,14 @@ mod nft_transfer {
 		let season = Season::default();
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.balances(&[(ALICE, 1_000_000_000_000)])
 			.create_nft_collection(true)
 			.build()
 			.execute_with(|| {
 				run_to_block(season.start);
 
-				let avatar_id = create_avatars(1, ALICE, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 				assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), ALICE));
 				assert_ok!(AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
 				assert_ok!(AAvatars::prepare_ipfs(
@@ -3300,7 +3383,11 @@ mod nft_transfer {
 					avatar_id,
 					IpfsUrl::try_from(b"test".to_vec()).unwrap()
 				));
-				assert_ok!(AAvatars::lock_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
+				assert_ok!(AAvatars::lock_avatar(
+					RuntimeOrigin::signed(ALICE),
+					SEASON_ID,
+					avatar_id
+				));
 
 				pallet_ajuna_nft_transfer::NftStatuses::<Test>::insert(
 					CollectionId::<Test>::get().unwrap(),
@@ -3308,7 +3395,7 @@ mod nft_transfer {
 					pallet_ajuna_nft_transfer::NftStatus::Uploaded,
 				);
 				assert_noop!(
-					AAvatars::unlock_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
+					AAvatars::unlock_avatar(RuntimeOrigin::signed(ALICE), SEASON_ID, avatar_id),
 					pallet_ajuna_nft_transfer::Error::<Test>::NftOutsideOfChain
 				);
 			});
@@ -3323,13 +3410,13 @@ mod fix_variation {
 		let season = Season::default();
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(SEASON_ID, season.clone())])
 			.balances(&[(ALICE, 1_000_000_000_000)])
 			.build()
 			.execute_with(|| {
 				run_to_block(season.start);
 
-				let avatar_id = create_avatars(1, ALICE, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 
 				let (_, mut avatar_before) = Avatars::<Test>::get(avatar_id).unwrap();
 
@@ -3397,17 +3484,22 @@ mod ipfs {
 	#[test]
 	fn prepare_avatar_rejects_forging_trading_and_transferring() {
 		ExtBuilder::default()
-			.seasons(&[(1, Season::default())])
+			.seasons(&[(SEASON_ID, Season::default())])
 			.build()
 			.execute_with(|| {
-				let avatar_ids = create_avatars(1, ALICE, 5);
+				let avatar_ids = create_avatars(SEASON_ID, ALICE, 5);
 				let avatar_id = avatar_ids[0];
 				assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), ALICE));
 				assert_ok!(AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
 
 				for extrinsic in [
 					AAvatars::set_price(RuntimeOrigin::signed(ALICE), avatar_id, 1_000),
-					AAvatars::transfer_avatar(RuntimeOrigin::signed(ALICE), BOB, avatar_id),
+					AAvatars::transfer_avatar(
+						RuntimeOrigin::signed(ALICE),
+						BOB,
+						SEASON_ID,
+						avatar_id,
+					),
 					AAvatars::forge(
 						RuntimeOrigin::signed(ALICE),
 						avatar_id,
@@ -3422,7 +3514,7 @@ mod ipfs {
 	#[test]
 	fn prepare_avatar_rejects_unsigned_calls() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, ALICE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 			assert_noop!(
 				AAvatars::prepare_avatar(RuntimeOrigin::none(), avatar_id),
 				DispatchError::BadOrigin
@@ -3433,7 +3525,7 @@ mod ipfs {
 	#[test]
 	fn prepare_avatar_rejects_unowned_avatars() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, ALICE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 			assert_noop!(
 				AAvatars::prepare_avatar(RuntimeOrigin::signed(BOB), avatar_id),
 				Error::<Test>::Ownership
@@ -3444,7 +3536,7 @@ mod ipfs {
 	#[test]
 	fn prepare_avatar_rejects_avatars_in_trade() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, ALICE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 			assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(ALICE), avatar_id, 1));
 			assert_noop!(
 				AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
@@ -3456,7 +3548,7 @@ mod ipfs {
 	#[test]
 	fn prepare_avatar_rejects_when_closed() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, ALICE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 			GlobalConfigs::<Test>::mutate(|config| config.nft_transfer.open = false);
 			assert_noop!(
 				AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
@@ -3468,7 +3560,7 @@ mod ipfs {
 	#[test]
 	fn prepare_avatar_rejects_locked_avatars() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, ALICE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 			LockedAvatars::<Test>::insert(avatar_id, ());
 			assert_noop!(
 				AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
@@ -3480,7 +3572,7 @@ mod ipfs {
 	#[test]
 	fn prepare_avatar_rejects_already_prepared_avatars() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, ALICE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 			let ipfs_url = IpfsUrl::try_from(Vec::new()).unwrap();
 			Preparation::<Test>::insert(avatar_id, ipfs_url);
 			assert_noop!(
@@ -3497,7 +3589,7 @@ mod ipfs {
 			.balances(&[(ALICE, MockExistentialDeposit::get())])
 			.build()
 			.execute_with(|| {
-				let avatar_id = create_avatars(1, ALICE, 1)[0];
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 				assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), BOB));
 				assert_noop!(
 					AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
@@ -3509,7 +3601,7 @@ mod ipfs {
 	#[test]
 	fn unprepare_avatar_works() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, ALICE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 			assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), ALICE));
 			assert_ok!(AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
 			assert_ok!(AAvatars::unprepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
@@ -3533,7 +3625,7 @@ mod ipfs {
 	#[test]
 	fn unprepare_avatar_rejects_unowned_avatars() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, ALICE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 			assert_noop!(
 				AAvatars::unprepare_avatar(RuntimeOrigin::signed(BOB), avatar_id),
 				Error::<Test>::Ownership
@@ -3544,7 +3636,7 @@ mod ipfs {
 	#[test]
 	fn unprepare_avatar_rejects_when_closed() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, ALICE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 			GlobalConfigs::<Test>::mutate(|config| config.nft_transfer.open = false);
 			assert_noop!(
 				AAvatars::unprepare_avatar(RuntimeOrigin::signed(BOB), avatar_id),
@@ -3556,7 +3648,7 @@ mod ipfs {
 	#[test]
 	fn unprepare_avatar_rejects_unprepared_avatars() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, ALICE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 			assert_noop!(
 				AAvatars::unprepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
 				Error::<Test>::NotPrepared
@@ -3567,7 +3659,7 @@ mod ipfs {
 	#[test]
 	fn prepare_ipfs_works() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, ALICE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 			assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), ALICE));
 			assert_ok!(AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
 			ServiceAccount::<Test>::put(BOB);
@@ -3601,7 +3693,7 @@ mod ipfs {
 	#[test]
 	fn prepare_ipfs_rejects_empty_url() {
 		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(1, ALICE, 1)[0];
+			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
 			assert_ok!(AAvatars::set_service_account(RuntimeOrigin::root(), ALICE));
 			assert_ok!(AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id));
 			ServiceAccount::<Test>::put(BOB);

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v1.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v1.rs
@@ -32,7 +32,7 @@ impl<T: Config> Minter<T> for MinterV1<T> {
 				let avatar =
 					Avatar { season_id: *season_id, version: AvatarVersion::V1, dna, souls };
 				Avatars::<T>::insert(avatar_id, (player, avatar));
-				Owners::<T>::try_append(&player, avatar_id)
+				Owners::<T>::try_append(&player, &season_id, avatar_id)
 					.map_err(|_| Error::<T>::MaxOwnershipReached)?;
 				Ok(avatar_id)
 			})
@@ -432,6 +432,7 @@ mod test {
 	#[test]
 	fn forge_should_work_for_matches() {
 		let tiers = &[RarityTier::Common, RarityTier::Legendary];
+		let season_id = 1;
 		let season = Season::default()
 			.tiers(tiers)
 			.batch_mint_probs(&[100])
@@ -441,7 +442,7 @@ mod test {
 			.max_sacrifices(2);
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(season_id, season.clone())])
 			.mint_cooldown(1)
 			.free_mints(&[(BOB, 10)])
 			.build()
@@ -459,7 +460,7 @@ mod test {
 				));
 
 				// forge
-				let owned_avatar_ids = Owners::<Test>::get(BOB);
+				let owned_avatar_ids = Owners::<Test>::get(BOB, season_id);
 				let leader_id = owned_avatar_ids[0];
 				let sacrifice_ids = &owned_avatar_ids[1..3];
 
@@ -533,6 +534,7 @@ mod test {
 	fn forge_should_work_for_non_matches() {
 		let tiers =
 			&[RarityTier::Common, RarityTier::Uncommon, RarityTier::Rare, RarityTier::Legendary];
+		let season_id = 1;
 		let season = Season::default()
 			.tiers(tiers)
 			.batch_mint_probs(&[33, 33, 34])
@@ -542,7 +544,7 @@ mod test {
 			.max_sacrifices(5);
 
 		ExtBuilder::default()
-			.seasons(&[(1, season.clone())])
+			.seasons(&[(season_id, season.clone())])
 			.mint_cooldown(1)
 			.free_mints(&[(BOB, 10)])
 			.build()
@@ -560,7 +562,7 @@ mod test {
 				));
 
 				// forge
-				let owned_avatar_ids = Owners::<Test>::get(BOB);
+				let owned_avatar_ids = Owners::<Test>::get(BOB, season_id);
 				let leader_id = owned_avatar_ids[0];
 				let sacrifice_id = owned_avatar_ids[1];
 

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/mod.rs
@@ -79,7 +79,7 @@ impl<T: Config> Minter<T> for MinterV2<T> {
 				)?;
 
 				Avatars::<T>::insert(avatar_id, (player, avatar));
-				Owners::<T>::try_append(&player, avatar_id)
+				Owners::<T>::try_append(&player, &season_id, avatar_id)
 					.map_err(|_| Error::<T>::MaxOwnershipReached)?;
 
 				Ok(avatar_id)


### PR DESCRIPTION
## Description

Changing the `Owners` storage from `Map` -> `DoubleMap` with `SeasonId` as the second key.

There will be another PR for updating the `Trade` storage.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
