### PR TITLE
[PLAT-759] Seasonal trade storage

### DIFF
--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -307,7 +307,7 @@ benchmarks! {
 		let caller = account::<T>(name);
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
 		let avatar_id = Owners::<T>::get(&caller, season_id)[0];
-		Trade::<T>::insert(avatar_id, BalanceOf::<T>::unique_saturated_from(u128::MAX));
+		Trade::<T>::insert(season_id, avatar_id, BalanceOf::<T>::unique_saturated_from(u128::MAX));
 	}: _(RawOrigin::Signed(caller), avatar_id)
 	verify {
 		assert_last_event::<T>(Event::AvatarPriceUnset { avatar_id })
@@ -328,7 +328,7 @@ benchmarks! {
 
 		let season_id = CurrentSeasonStatus::<T>::get().season_id;
 		let avatar_id = Owners::<T>::get(&seller, season_id)[0];
-		Trade::<T>::insert(avatar_id, sell_fee);
+		Trade::<T>::insert(season_id, avatar_id, sell_fee);
 	}: _(RawOrigin::Signed(buyer.clone()), avatar_id)
 	verify {
 		assert_last_event::<T>(Event::AvatarTraded { avatar_id, from: seller, to: buyer })

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -2551,9 +2551,9 @@ mod trading {
 				let avatar_for_sale = create_avatars(SEASON_ID, BOB, 1)[0];
 				let price = 7357;
 
-				assert_eq!(Trade::<Test>::get(avatar_for_sale), None);
+				assert_eq!(Trade::<Test>::get(SEASON_ID, avatar_for_sale), None);
 				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, price));
-				assert_eq!(Trade::<Test>::get(avatar_for_sale), Some(price));
+				assert_eq!(Trade::<Test>::get(SEASON_ID, avatar_for_sale), Some(price));
 				System::assert_last_event(mock::RuntimeEvent::AAvatars(
 					crate::Event::AvatarPriceSet { avatar_id: avatar_for_sale, price },
 				));
@@ -2614,9 +2614,9 @@ mod trading {
 
 				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_for_sale, price));
 
-				assert_eq!(Trade::<Test>::get(avatar_for_sale), Some(101));
+				assert_eq!(Trade::<Test>::get(SEASON_ID, avatar_for_sale), Some(101));
 				assert_ok!(AAvatars::remove_price(RuntimeOrigin::signed(BOB), avatar_for_sale));
-				assert_eq!(Trade::<Test>::get(avatar_for_sale), None);
+				assert_eq!(Trade::<Test>::get(SEASON_ID, avatar_for_sale), None);
 				System::assert_last_event(mock::RuntimeEvent::AAvatars(
 					crate::Event::AvatarPriceUnset { avatar_id: avatar_for_sale },
 				));
@@ -2667,8 +2667,9 @@ mod trading {
 	#[test]
 	fn remove_price_should_reject_unlisted_avatar() {
 		ExtBuilder::default().build().execute_with(|| {
+			let avatar_ids = create_avatars(SEASON_ID, BOB, 1);
 			assert_noop!(
-				AAvatars::remove_price(RuntimeOrigin::signed(CHARLIE), sp_core::H256::default()),
+				AAvatars::remove_price(RuntimeOrigin::signed(CHARLIE), avatar_ids[0]),
 				Error::<Test>::UnknownAvatarForSale,
 			);
 		});
@@ -2730,7 +2731,7 @@ mod trading {
 				assert_eq!(Avatars::<Test>::get(avatar_for_sale).unwrap().0, ALICE);
 
 				// check for removal from trade storage
-				assert_eq!(Trade::<Test>::get(avatar_for_sale), None);
+				assert_eq!(Trade::<Test>::get(SEASON_ID, avatar_for_sale), None);
 
 				// check for account stats
 				assert_eq!(Accounts::<Test>::get(ALICE).stats.trade.bought, 1);
@@ -2829,8 +2830,9 @@ mod trading {
 	#[test]
 	fn buy_should_reject_unlisted_avatar() {
 		ExtBuilder::default().build().execute_with(|| {
+			let avatar_ids = create_avatars(SEASON_ID, ALICE, 1);
 			assert_noop!(
-				AAvatars::buy(RuntimeOrigin::signed(BOB), H256::default()),
+				AAvatars::buy(RuntimeOrigin::signed(BOB), avatar_ids[0]),
 				Error::<Test>::UnknownAvatarForSale,
 			);
 		});

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -1324,7 +1324,7 @@ mod minting {
 					}
 				}
 				assert_noop!(
-					AAvatars::mint(RuntimeOrigin::signed(BOB), MintOption::default(),),
+					AAvatars::mint(RuntimeOrigin::signed(BOB), MintOption::default()),
 					Error::<Test>::MaxOwnershipReached
 				);
 			});
@@ -1594,10 +1594,10 @@ mod forging {
 
 				assert_ok!(AAvatars::forge(RuntimeOrigin::signed(BOB), *leader_id, sacrifice_ids));
 				assert_eq!(
-					Avatars::<Test>::get(leader_id,).unwrap().1.souls,
+					Avatars::<Test>::get(leader_id).unwrap().1.souls,
 					original_leader_souls + sacrifice_souls
 				);
-				assert_eq!(Avatars::<Test>::get(leader_id,).unwrap().1.dna.to_vec(), expected_dna);
+				assert_eq!(Avatars::<Test>::get(leader_id).unwrap().1.dna.to_vec(), expected_dna);
 
 				forged_count += 1;
 				assert_eq!(


### PR DESCRIPTION
## Description

Changing the Trade storage from Map -> DoubleMap with SeasonId as the first key.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
