### PR TITLE
[PLAT-801] Season 2: Trade filters

### DIFF
--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -28,8 +28,9 @@ use frame_support::{
 use frame_system::RawOrigin;
 use pallet_ajuna_awesome_avatars::{types::*, Config as AvatarsConfig, Pallet as AAvatars, *};
 use pallet_ajuna_nft_transfer::traits::NftHandler;
-use sp_runtime::traits::{
-	Saturating, StaticLookup, UniqueSaturatedFrom, UniqueSaturatedInto, Zero,
+use sp_runtime::{
+	traits::{Saturating, StaticLookup, UniqueSaturatedFrom, UniqueSaturatedInto, Zero},
+	BoundedVec,
 };
 
 pub struct Pallet<T: Config>(pallet_ajuna_awesome_avatars::Pallet<T>);
@@ -98,6 +99,7 @@ fn create_seasons<T: Config>(n: usize) -> Result<(), &'static str> {
 				base_prob: 0,
 				per_period: T::BlockNumber::from(10_u32),
 				periods: 12,
+				trade_filters: BoundedVec::default(),
 			},
 		);
 	}
@@ -412,6 +414,7 @@ benchmarks! {
 			base_prob: 99,
 			per_period: T::BlockNumber::from(1_u32),
 			periods: u16::MAX,
+			trade_filters: BoundedVec::default(),
 		};
 	}: _(RawOrigin::Signed(organizer), season_id, season.clone())
 	verify {

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -386,6 +386,8 @@ pub mod pallet {
 		TooManySacrifices,
 		/// Leader is being sacrificed.
 		LeaderSacrificed,
+		/// This avatar cannot be used in trades.
+		AvatarCannotBeTraded,
 		/// An avatar listed for trade is used to forge.
 		AvatarInTrade,
 		/// The avatar is currently locked and cannot be used.
@@ -569,6 +571,7 @@ pub mod pallet {
 			let avatar = Self::ensure_ownership(&seller, &avatar_id)?;
 			Self::ensure_unlocked(&avatar_id)?;
 			Self::ensure_unprepared(&avatar_id)?;
+			Self::ensure_can_be_traded(&avatar)?;
 			Trade::<T>::insert(avatar.season_id, avatar_id, price);
 			Self::deposit_event(Event::AvatarPriceSet { avatar_id, price });
 			Ok(())
@@ -1446,6 +1449,14 @@ pub mod pallet {
 
 		fn ensure_unprepared(avatar_id: &AvatarIdOf<T>) -> DispatchResult {
 			ensure!(!Preparation::<T>::contains_key(avatar_id), Error::<T>::AlreadyPrepared);
+			Ok(())
+		}
+
+		fn ensure_can_be_traded(avatar: &Avatar) -> DispatchResult {
+			let current_season_id = CurrentSeasonStatus::<T>::get().season_id;
+			let season = Seasons::<T>::get(current_season_id).ok_or(Error::<T>::UnknownSeason)?;
+
+			ensure!(season.apply_trade_filters_on(avatar), Error::<T>::AvatarCannotBeTraded);
 			Ok(())
 		}
 

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -2484,14 +2484,17 @@ mod transferring {
 
 	#[test]
 	fn transfer_avatar_rejects_avatar_in_trade() {
-		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(SEASON_ID, CHARLIE, 1)[0];
-			assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(CHARLIE), avatar_id, 999));
-			assert_noop!(
-				AAvatars::transfer_avatar(RuntimeOrigin::signed(CHARLIE), DAVE, avatar_id),
-				Error::<Test>::AvatarInTrade
-			);
-		});
+		ExtBuilder::default()
+			.seasons(&[(SEASON_ID, Season::default())])
+			.build()
+			.execute_with(|| {
+				let avatar_id = create_avatars(SEASON_ID, CHARLIE, 1)[0];
+				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(CHARLIE), avatar_id, 999));
+				assert_noop!(
+					AAvatars::transfer_avatar(RuntimeOrigin::signed(CHARLIE), DAVE, avatar_id),
+					Error::<Test>::AvatarInTrade
+				);
+			});
 	}
 
 	#[test]
@@ -2595,6 +2598,25 @@ mod trading {
 				assert_noop!(
 					AAvatars::set_price(RuntimeOrigin::signed(CHARLIE), avatar_ids[0], 101),
 					Error::<Test>::Ownership
+				);
+			});
+	}
+
+	#[test]
+	fn set_price_should_reject_avatar_not_matching_trade_filters() {
+		let trade_filters = vec![TradeFilter::default().byte_0_h(Some(0b1000_1000))];
+		let season = Season::default().trade_filters(trade_filters);
+
+		ExtBuilder::default()
+			.seasons(&[(SEASON_ID, season.clone())])
+			.build()
+			.execute_with(|| {
+				run_to_block(season.start);
+				let avatar_ids = create_avatars(SEASON_ID, BOB, 2);
+
+				assert_noop!(
+					AAvatars::set_price(RuntimeOrigin::signed(BOB), avatar_ids[0], 101),
+					Error::<Test>::AvatarCannotBeTraded
 				);
 			});
 	}
@@ -3131,6 +3153,7 @@ mod nft_transfer {
 	#[test]
 	fn cannot_lock_avatar_on_trade() {
 		ExtBuilder::default()
+			.seasons(&[(SEASON_ID, Season::default())])
 			.balances(&[(ALICE, 1_000_000_000_000)])
 			.create_nft_collection(true)
 			.build()
@@ -3467,14 +3490,17 @@ mod ipfs {
 
 	#[test]
 	fn prepare_avatar_rejects_avatars_in_trade() {
-		ExtBuilder::default().build().execute_with(|| {
-			let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
-			assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(ALICE), avatar_id, 1));
-			assert_noop!(
-				AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
-				Error::<Test>::AvatarInTrade
-			);
-		});
+		ExtBuilder::default()
+			.seasons(&[(SEASON_ID, Season::default())])
+			.build()
+			.execute_with(|| {
+				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
+				assert_ok!(AAvatars::set_price(RuntimeOrigin::signed(ALICE), avatar_id, 1));
+				assert_noop!(
+					AAvatars::prepare_avatar(RuntimeOrigin::signed(ALICE), avatar_id),
+					Error::<Test>::AvatarInTrade
+				);
+			});
 	}
 
 	#[test]


### PR DESCRIPTION
## Description

See for details: https://ajunanetwork.atlassian.net/browse/PLAT-801 

In short: Adds the capability to limit which kind of avatars can be traded at the Season level.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
