### PR TITLE
[PLAT-803] Split AvatarVersion

### DIFF
--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -112,6 +112,8 @@ fn create_seasons<T: Config>(n: usize) -> Result<(), &'static str> {
 					upgrade_storage: 1_000_000_000_000_u64.unique_saturated_into(), // 1 BAJU
 					prepare_avatar: 5_000_000_000_000_u64.unique_saturated_into(),  // 5 BAJU
 				},
+				mint_logic: LogicGeneration::First,
+				forge_logic: LogicGeneration::First,
 			},
 		);
 	}
@@ -151,7 +153,6 @@ fn create_avatars<T: Config>(name: &'static str, n: u32) -> Result<(), &'static 
 				payment: MintPayment::Free,
 				pack_size: MintPackSize::One,
 				pack_type: PackType::Material,
-				version: AvatarVersion::V1,
 			},
 		)?;
 	}
@@ -211,7 +212,7 @@ benchmarks! {
 		PlayerConfigs::<T>::mutate(&caller, |account| account.free_mints = MintCount::MAX);
 
 		let mint_option = MintOption { payment: MintPayment::Free, pack_size: MintPackSize::Six,
-			pack_type: PackType::Material, version: AvatarVersion::V1 };
+			pack_type: PackType::Material, logic_gen: LogicGeneration::First };
 	}: mint(RawOrigin::Signed(caller.clone()), mint_option)
 	verify {
 		let n = n as usize;

--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -212,7 +212,7 @@ benchmarks! {
 		PlayerConfigs::<T>::mutate(&caller, |account| account.free_mints = MintCount::MAX);
 
 		let mint_option = MintOption { payment: MintPayment::Free, pack_size: MintPackSize::Six,
-			pack_type: PackType::Material, logic_gen: LogicGeneration::First };
+			pack_type: PackType::Material, };
 	}: mint(RawOrigin::Signed(caller.clone()), mint_option)
 	verify {
 		let n = n as usize;
@@ -232,7 +232,7 @@ benchmarks! {
 		CurrencyOf::<T>::make_free_balance_be(&caller, mint_fee);
 
 		let mint_option = MintOption { payment: MintPayment::Normal, pack_size: MintPackSize::Six,
-			pack_type: PackType::Material, version: AvatarVersion::V1 };
+			pack_type: PackType::Material };
 	}: mint(RawOrigin::Signed(caller.clone()), mint_option)
 	verify {
 		let n = n as usize;
@@ -447,6 +447,8 @@ benchmarks! {
 				upgrade_storage: BalanceOf::<T>::unique_saturated_from(u128::MAX),
 				prepare_avatar: BalanceOf::<T>::unique_saturated_from(u128::MAX),
 			},
+			mint_logic: LogicGeneration::First,
+			forge_logic: LogicGeneration::First,
 		};
 	}: _(RawOrigin::Signed(organizer), season_id, season.clone())
 	verify {

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -1121,7 +1121,7 @@ pub mod pallet {
 			let (leader, sacrifice_ids, sacrifices) =
 				Self::ensure_for_forge(player, leader_id, sacrifice_ids, &season_id, &season)?;
 
-			let input_leader = (*leader_id, leader.clone());
+			let input_leader = (*leader_id, leader);
 			let input_sacrifices =
 				sacrifice_ids.into_iter().zip(sacrifices).collect::<Vec<ForgeItem<T>>>();
 			let (output_leader, output_other) = match season.forge_logic {

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -1054,20 +1054,19 @@ pub mod pallet {
 
 		/// Mint a new avatar.
 		pub(crate) fn do_mint(player: &T::AccountId, mint_option: &MintOption) -> DispatchResult {
-			let season_id = CurrentSeasonStatus::<T>::get().season_id;
+			let (season_id, season) = Self::current_season_with_id()?;
 
 			Self::ensure_for_mint(player, &season_id, mint_option)?;
 
-			let generated_avatar_ids = match mint_option.version {
-				AvatarVersion::V1 => MinterV1::<T>::mint(player, &season_id, mint_option),
-				AvatarVersion::V2 => MinterV2::<T>::mint(player, &season_id, mint_option),
+			let generated_avatar_ids = match season.mint_logic {
+				LogicGeneration::First => MinterV1::<T>::mint(player, &season_id, mint_option),
+				LogicGeneration::Second => MinterV2::<T>::mint(player, &season_id, mint_option),
 			}?;
 
 			let GlobalConfig { mint, .. } = GlobalConfigs::<T>::get();
-			let (_, Season { fee, .. }) = Self::current_season_with_id()?;
 			match mint_option.payment {
 				MintPayment::Normal => {
-					let fee = fee.mint.fee_for(&mint_option.pack_size);
+					let fee = season.fee.mint.fee_for(&mint_option.pack_size);
 					T::Currency::withdraw(player, fee, WithdrawReasons::FEE, AllowDeath)?;
 					Self::deposit_into_treasury(&season_id, fee);
 				},
@@ -1125,15 +1124,15 @@ pub mod pallet {
 			let input_leader = (*leader_id, leader.clone());
 			let input_sacrifices =
 				sacrifice_ids.into_iter().zip(sacrifices).collect::<Vec<ForgeItem<T>>>();
-			let (output_leader, output_other) = match leader.version {
-				AvatarVersion::V1 => ForgerV1::<T>::forge(
+			let (output_leader, output_other) = match season.forge_logic {
+				LogicGeneration::First => ForgerV1::<T>::forge(
 					player,
 					season_id,
 					&season,
 					input_leader.clone(),
 					input_sacrifices,
 				),
-				AvatarVersion::V2 => ForgerV2::<T>::forge(
+				LogicGeneration::Second => ForgerV2::<T>::forge(
 					player,
 					season_id,
 					&season,
@@ -1290,7 +1289,7 @@ pub mod pallet {
 					let avatar = Self::ensure_ownership(player, id)?;
 					ensure!(avatar.season_id == *season_id, Error::<T>::IncorrectAvatarSeason);
 					ensure!(
-						avatar.version == leader.version,
+						avatar.encoding == leader.encoding,
 						Error::<T>::IncompatibleAvatarVersions
 					);
 					Self::ensure_unlocked(id)?;

--- a/pallets/ajuna-awesome-avatars/src/migration/v5.rs
+++ b/pallets/ajuna-awesome-avatars/src/migration/v5.rs
@@ -48,7 +48,7 @@ impl OldAvatar {
 	fn migrate_to_v5(self) -> Avatar {
 		Avatar {
 			season_id: self.season_id,
-			version: AvatarVersion::V1,
+			encoding: DnaEncoding::V1,
 			dna: self.dna,
 			souls: self.souls,
 		}
@@ -107,6 +107,8 @@ impl<T: Config> OldSeason<T> {
 				upgrade_storage: 1_000_000_000_000_u64.unique_saturated_into(), // 1 BAJU
 				prepare_avatar: 5_000_000_000_000_u64.unique_saturated_into(),  // 5 BAJU
 			},
+			mint_logic: LogicGeneration::First,
+			forge_logic: LogicGeneration::First,
 		}
 	}
 }
@@ -299,7 +301,7 @@ impl<T: Config> OnRuntimeUpgrade for MigrateToV5<T> {
 
 		// Check all migrated avatars are of version 1.
 		assert!(Avatars::<T>::iter_values()
-			.all(|(_account, avatar)| avatar.version == AvatarVersion::V1));
+			.all(|(_account, avatar)| avatar.encoding == DnaEncoding::V1));
 
 		assert!(Seasons::<T>::get(1).unwrap().trade_filters.is_empty());
 

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -804,13 +804,11 @@ mod minting {
 			payment: MintPayment::Normal,
 			pack_size: MintPackSize::One,
 			pack_type: PackType::Material,
-			version: AvatarVersion::V1,
 		};
 		let free_mint = MintOption {
 			payment: MintPayment::Free,
 			pack_size: MintPackSize::One,
 			pack_type: PackType::Material,
-			version: AvatarVersion::V1,
 		};
 
 		ExtBuilder::default()
@@ -988,7 +986,6 @@ mod minting {
 							pack_size: MintPackSize::One,
 							payment: payment.clone(),
 							pack_type: PackType::Material,
-							version: AvatarVersion::V1
 						}
 					));
 					match payment {
@@ -1036,7 +1033,6 @@ mod minting {
 							pack_size: MintPackSize::Three,
 							payment: payment.clone(),
 							pack_type: PackType::Material,
-							version: AvatarVersion::V1
 						}
 					));
 					match payment {
@@ -1078,7 +1074,6 @@ mod minting {
 							pack_size: MintPackSize::Six,
 							payment: payment.clone(),
 							pack_type: PackType::Material,
-							version: AvatarVersion::V1
 						}
 					));
 					match payment {
@@ -1125,7 +1120,6 @@ mod minting {
 									pack_size: MintPackSize::One,
 									payment: payment.clone(),
 									pack_type: PackType::Material,
-									version: AvatarVersion::V1,
 								}
 							));
 							minted_count += 1;
@@ -1148,7 +1142,6 @@ mod minting {
 								pack_size: MintPackSize::One,
 								payment: payment.clone(),
 								pack_type: PackType::Material,
-								version: AvatarVersion::V1
 							}
 						),
 						Error::<Test>::SeasonClosed
@@ -1204,7 +1197,6 @@ mod minting {
 								pack_size: count.clone(),
 								payment,
 								pack_type: PackType::Material,
-								version: AvatarVersion::V1
 							}
 						),
 						Error::<Test>::MintClosed
@@ -1226,7 +1218,6 @@ mod minting {
 								pack_size: count.clone(),
 								payment,
 								pack_type: PackType::Material,
-								version: AvatarVersion::V1
 							}
 						),
 						DispatchError::BadOrigin
@@ -1238,7 +1229,10 @@ mod minting {
 
 	#[test]
 	fn mint_should_reject_non_whitelisted_accounts_when_season_is_inactive() {
+		let season = Season::default();
+
 		ExtBuilder::default()
+			.seasons(&[(SEASON_ID, season)])
 			.balances(&[(ALICE, 1_234_567_890_123_456)])
 			.free_mints(&[(ALICE, 0)])
 			.build()
@@ -1252,7 +1246,6 @@ mod minting {
 									pack_size: count.clone(),
 									payment,
 									pack_type: PackType::Material,
-									version: AvatarVersion::V1
 								}
 							),
 							Error::<Test>::SeasonClosed
@@ -1292,7 +1285,6 @@ mod minting {
 									pack_size: count.clone(),
 									payment,
 									pack_type: PackType::Material,
-									version: AvatarVersion::V1
 								}
 							),
 							Error::<Test>::MaxOwnershipReached
@@ -1361,7 +1353,6 @@ mod minting {
 							pack_size: MintPackSize::One,
 							payment: payment.clone(),
 							pack_type: PackType::Material,
-							version: AvatarVersion::V1
 						}
 					));
 
@@ -1374,7 +1365,6 @@ mod minting {
 									pack_size: MintPackSize::One,
 									payment: payment.clone(),
 									pack_type: PackType::Material,
-									version: AvatarVersion::V1,
 								}
 							),
 							Error::<Test>::MintCooldown
@@ -1389,7 +1379,6 @@ mod minting {
 							pack_size: MintPackSize::One,
 							payment: MintPayment::Normal,
 							pack_type: PackType::Material,
-							version: AvatarVersion::V1
 						}
 					));
 
@@ -1420,7 +1409,6 @@ mod minting {
 								pack_size: mint_count,
 								payment: MintPayment::Normal,
 								pack_type: PackType::Material,
-								version: AvatarVersion::V1
 							}
 						),
 						Error::<Test>::InsufficientBalance
@@ -1435,7 +1423,6 @@ mod minting {
 								pack_size: mint_count,
 								payment: MintPayment::Free,
 								pack_type: PackType::Material,
-								version: AvatarVersion::V1
 							}
 						),
 						Error::<Test>::InsufficientFreeMints
@@ -1574,7 +1561,6 @@ mod forging {
 						pack_size: MintPackSize::Three,
 						payment: MintPayment::Normal,
 						pack_type: PackType::Material,
-						version: AvatarVersion::V1
 					}
 				));
 				assert_ok!(AAvatars::mint(
@@ -1583,7 +1569,6 @@ mod forging {
 						pack_size: MintPackSize::One,
 						payment: MintPayment::Normal,
 						pack_type: PackType::Material,
-						version: AvatarVersion::V1
 					}
 				));
 
@@ -1648,7 +1633,6 @@ mod forging {
 						pack_size: MintPackSize::One,
 						payment: MintPayment::Normal,
 						pack_type: PackType::Material,
-						version: AvatarVersion::V1
 					}
 				));
 				let leader_id = Owners::<Test>::get(BOB, SEASON_ID)[0];
@@ -1700,7 +1684,6 @@ mod forging {
 							pack_size: MintPackSize::One,
 							payment: MintPayment::Normal,
 							pack_type: PackType::Material,
-							version: AvatarVersion::V1
 						}
 					),
 					Error::<Test>::PrematureSeasonEnd
@@ -1815,7 +1798,6 @@ mod forging {
 						pack_size: MintPackSize::Six,
 						payment: MintPayment::Free,
 						pack_type: PackType::Material,
-						version: AvatarVersion::V1
 					}
 				));
 
@@ -1895,7 +1877,6 @@ mod forging {
 						pack_size: MintPackSize::Six,
 						payment: MintPayment::Free,
 						pack_type: PackType::Material,
-						version: AvatarVersion::V1
 					}
 				));
 
@@ -1953,7 +1934,6 @@ mod forging {
 						pack_size: MintPackSize::Six,
 						payment: MintPayment::Free,
 						pack_type: PackType::Material,
-						version: AvatarVersion::V1
 					}
 				));
 				let leader_id = Owners::<Test>::get(ALICE, SEASON_ID)[0];
@@ -2072,7 +2052,6 @@ mod forging {
 							pack_size: MintPackSize::Three,
 							payment: MintPayment::Free,
 							pack_type: PackType::Material,
-							version: AvatarVersion::V1
 						}
 					));
 				}
@@ -2129,7 +2108,6 @@ mod forging {
 							pack_size: MintPackSize::One,
 							payment: MintPayment::Free,
 							pack_type: PackType::Material,
-							version: AvatarVersion::V1
 						}
 					));
 				}
@@ -2167,7 +2145,6 @@ mod forging {
 								pack_size: MintPackSize::One,
 								payment: MintPayment::Free,
 								pack_type: PackType::Material,
-								version: AvatarVersion::V1
 							}
 						));
 					}
@@ -2216,7 +2193,6 @@ mod forging {
 							pack_size: MintPackSize::One,
 							payment: MintPayment::Free,
 							pack_type: PackType::Material,
-							version: AvatarVersion::V1
 						}
 					));
 				}
@@ -2259,7 +2235,6 @@ mod forging {
 						pack_size: MintPackSize::Six,
 						payment: MintPayment::Normal,
 						pack_type: PackType::Material,
-						version: AvatarVersion::V1
 					}
 				));
 				assert_ok!(AAvatars::mint(
@@ -2268,7 +2243,6 @@ mod forging {
 						pack_size: MintPackSize::Six,
 						payment: MintPayment::Normal,
 						pack_type: PackType::Material,
-						version: AvatarVersion::V1
 					}
 				));
 
@@ -3104,7 +3078,6 @@ mod nft_transfer {
 						pack_size: MintPackSize::Three,
 						payment: MintPayment::Normal,
 						pack_type: PackType::Material,
-						version: AvatarVersion::V1
 					}
 				));
 				let avatar_ids = Owners::<Test>::get(ALICE, SEASON_ID);
@@ -3131,7 +3104,7 @@ mod nft_transfer {
 						season_id: 1,
 						dna: bounded_vec![0x20, 0x20, 0x23, 0x22, 0x10, 0x32, 0x12, 0x10],
 						souls: 34,
-						version: AvatarVersion::V1,
+						encoding: DnaEncoding::V1,
 					}
 				);
 

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/mod.rs
@@ -41,7 +41,15 @@ pub type SoulCount = u32;
 
 /// Used to indicate which version of the forging and/or mint logic should be used.
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
-pub enum AvatarVersion {
+pub enum LogicGeneration {
+	#[default]
+	First,
+	Second,
+}
+
+/// Used to indicate the layout of an avatars DNA byte sequence.
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
+pub enum DnaEncoding {
 	#[default]
 	V1,
 	V2,
@@ -50,23 +58,23 @@ pub enum AvatarVersion {
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Debug, Default, PartialEq)]
 pub struct Avatar {
 	pub season_id: SeasonId,
-	pub version: AvatarVersion,
+	pub encoding: DnaEncoding,
 	pub dna: Dna,
 	pub souls: SoulCount,
 }
 
 impl Avatar {
 	pub(crate) fn rarity(&self) -> u8 {
-		match self.version {
-			AvatarVersion::V1 => AttributeMapperV1::rarity(self),
-			AvatarVersion::V2 => AttributeMapperV2::rarity(self),
+		match self.encoding {
+			DnaEncoding::V1 => AttributeMapperV1::rarity(self),
+			DnaEncoding::V2 => AttributeMapperV2::rarity(self),
 		}
 	}
 
 	pub(crate) fn force(&self) -> u8 {
-		match self.version {
-			AvatarVersion::V1 => AttributeMapperV1::force(self),
-			AvatarVersion::V2 => AttributeMapperV2::force(self),
+		match self.encoding {
+			DnaEncoding::V1 => AttributeMapperV1::force(self),
+			DnaEncoding::V2 => AttributeMapperV2::force(self),
 		}
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v1.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v1.rs
@@ -30,7 +30,7 @@ impl<T: Config> Minter<T> for MinterV1<T> {
 				let dna = Self::random_dna(&avatar_id, &season, is_batched)?;
 				let souls = (dna.iter().map(|x| *x as SoulCount).sum::<SoulCount>() % 100) + 1;
 				let avatar =
-					Avatar { season_id: *season_id, version: AvatarVersion::V1, dna, souls };
+					Avatar { season_id: *season_id, encoding: DnaEncoding::V1, dna, souls };
 				Avatars::<T>::insert(avatar_id, (player, avatar));
 				Owners::<T>::try_append(&player, &season_id, avatar_id)
 					.map_err(|_| Error::<T>::MaxOwnershipReached)?;
@@ -454,7 +454,6 @@ mod test {
 					MintOption {
 						pack_size: MintPackSize::Six,
 						payment: MintPayment::Free,
-						version: AvatarVersion::V1,
 						pack_type: PackType::default(),
 					}
 				));
@@ -556,7 +555,6 @@ mod test {
 					MintOption {
 						pack_size: MintPackSize::Six,
 						payment: MintPayment::Free,
-						version: AvatarVersion::V1,
 						pack_type: PackType::default(),
 					}
 				));

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/avatar_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/avatar_utils.rs
@@ -1,6 +1,6 @@
 use super::{constants::*, types::*, ByteType};
 use crate::{
-	types::{Avatar, AvatarVersion, Dna, SeasonId, SoulCount},
+	types::{Avatar, Dna, DnaEncoding, SeasonId, SoulCount},
 	ByteConvertible, Config, Force, Ranged, RarityTier,
 };
 use core::cmp::Ordering;
@@ -61,7 +61,7 @@ pub(crate) struct AvatarBuilder {
 
 impl AvatarBuilder {
 	pub fn with_dna(season_id: SeasonId, dna: Dna) -> Self {
-		Self { inner: Avatar { season_id, version: AvatarVersion::V2, dna, souls: 0 } }
+		Self { inner: Avatar { season_id, encoding: DnaEncoding::V2, dna, souls: 0 } }
 	}
 
 	pub fn with_base_avatar(avatar: Avatar) -> Self {

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/mod.rs
@@ -65,7 +65,7 @@ impl<T: Config> Minter<T> for MinterV2<T> {
 				let base_dna = Self::generate_empty_dna::<32>()?;
 				let base_avatar = Avatar {
 					season_id: *season_id,
-					version: AvatarVersion::V2,
+					encoding: DnaEncoding::V2,
 					dna: base_dna,
 					souls: SoulCount::zero(),
 				};

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/test_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/test_utils.rs
@@ -9,7 +9,7 @@ use crate::{
 				SlotType,
 			},
 		},
-		Avatar, AvatarVersion, ForgeOutput, LeaderForgeOutput, RarityTier, SoulCount,
+		Avatar, DnaEncoding, ForgeOutput, LeaderForgeOutput, RarityTier, SoulCount,
 	},
 	Config, Force, Pallet,
 };
@@ -31,7 +31,7 @@ where
 {
 	let base_avatar = Avatar {
 		season_id: 0,
-		version: AvatarVersion::V2,
+		encoding: DnaEncoding::V2,
 		dna: BoundedVec::try_from(initial_dna.unwrap_or([0_u8; 32]).to_vec())
 			.expect("Should create DNA!"),
 		souls: 0,

--- a/pallets/ajuna-awesome-avatars/src/types/config.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/config.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::types::AvatarVersion;
 use frame_support::pallet_prelude::*;
 
 pub type MintCount = u16;
@@ -65,8 +64,6 @@ pub struct MintOption {
 	pub payment: MintPayment,
 	/// The choice of pack to mint.
 	pub pack_type: PackType,
-	/// The version of avatar to mint.
-	pub version: AvatarVersion,
 	/// The number of avatars to mint.
 	pub pack_size: MintPackSize,
 }

--- a/pallets/ajuna-awesome-avatars/src/types/season.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/season.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-	types::{fee::Fee, Avatar, RarityTier, SeasonId},
+	types::{fee::Fee, Avatar, LogicGeneration, RarityTier, SeasonId},
 	Config, Error, MAX_PERCENTAGE,
 };
 use frame_support::pallet_prelude::*;
@@ -60,6 +60,8 @@ pub struct Season<BlockNumber, Balance> {
 	pub periods: u16,
 	pub trade_filters: BoundedVec<TradeFilter, ConstU32<100>>,
 	pub fee: Fee<Balance>,
+	pub mint_logic: LogicGeneration,
+	pub forge_logic: LogicGeneration,
 }
 
 impl<BlockNumber: AtLeast32Bit, Balance> Season<BlockNumber, Balance> {
@@ -246,6 +248,8 @@ mod test {
 					upgrade_storage: Default::default(),
 					prepare_avatar: Default::default(),
 				},
+				mint_logic: LogicGeneration::First,
+				forge_logic: LogicGeneration::First,
 			}
 		}
 	}


### PR DESCRIPTION
## Description

This PR splits the `AvatarVersion` enum into two separate enums with new meanings:
* `DnaEncoding` represents how the bytes in the Avatar's DNA are encoded and what each byte represents.
* `LogicGeneration` represents which of the available Mint/Forge logics is used

Each `LogicGeneration` produces avatars with a given `DnaEncoding`, but a given `DnaEncoding` version could be produced/manipulated by different `LogicGeneration` generations.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
