### PR TITLE
[ABO-64] Remove fix_variation extrinsic

### DIFF
--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -541,21 +541,6 @@ benchmarks! {
 		assert_last_event::<T>(Event::AvatarUnlocked { avatar_id })
 	}
 
-	fix_variation {
-		let name = "player";
-		create_avatars::<T>(name, 1)?;
-
-		let player = account::<T>(name);
-		let season_id = CurrentSeasonStatus::<T>::get().season_id;
-		let avatar_id = Owners::<T>::get(&player, season_id)[0];
-		let (_owner, original_avatar) = Avatars::<T>::get(avatar_id).unwrap();
-	}: _(RawOrigin::Signed(player), avatar_id)
-	verify {
-		let (_owner, updated_avatar) = Avatars::<T>::get(avatar_id).unwrap();
-		assert!(original_avatar.dna[1] & 0b0000_1111 != original_avatar.dna[2] & 0b0000_1111);
-		assert!(updated_avatar.dna[1] & 0b0000_1111 == updated_avatar.dna[2] & 0b0000_1111);
-	}
-
 	set_service_account {
 		let service_account = account::<T>("sa");
 	}: _(RawOrigin::Root, service_account.clone())

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -876,36 +876,13 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Fix the variation of an avatar's DNA affected by a bug.
-		///
-		/// A trivial bug was introduced to incorrectly represent the 3rd component's variation,
-		/// which should be the same as that of the 2nd. Instead of fixing the DNAs via migration,
-		/// we allow players freedom to choose to fix these affected DNAs since they might prefer
-		/// the existing looks.
-		///
-		/// Weight: `O(1)`
-		#[pallet::call_index(17)]
-		#[pallet::weight(T::WeightInfo::fix_variation())]
-		pub fn fix_variation(origin: OriginFor<T>, avatar_id: AvatarIdOf<T>) -> DispatchResult {
-			let account = ensure_signed(origin)?;
-			let mut avatar = Self::ensure_ownership(&account, &avatar_id)?;
-
-			// Update the variation of the 3rd component to be the same as that of the 2nd by
-			// copying the rightmost 4 bits of dna[1] to the dna[2]
-			avatar.dna[2] = (avatar.dna[2] & 0b1111_0000) | (avatar.dna[1] & 0b0000_1111);
-
-			Avatars::<T>::insert(avatar_id, (account, avatar));
-
-			Ok(())
-		}
-
 		/// Set a service account.
 		///
 		/// The origin of this call must be root. A service account has sufficient privilege to call
 		/// the `prepare_ipfs` extrinsic.
 		///
 		/// Weight: `O(1)`
-		#[pallet::call_index(18)]
+		#[pallet::call_index(17)]
 		#[pallet::weight(T::WeightInfo::set_service_account())]
 		pub fn set_service_account(
 			origin: OriginFor<T>,
@@ -924,7 +901,7 @@ pub mod pallet {
 		/// event is emitted to be picked up by our external service that interacts with the IPFS.
 		///
 		/// Weight: `O(1)`
-		#[pallet::call_index(19)]
+		#[pallet::call_index(18)]
 		#[pallet::weight(T::WeightInfo::prepare_avatar())]
 		pub fn prepare_avatar(origin: OriginFor<T>, avatar_id: AvatarIdOf<T>) -> DispatchResult {
 			let player = ensure_signed(origin)?;
@@ -949,7 +926,7 @@ pub mod pallet {
 		/// the IPFS upload process.
 		///
 		/// Weight: `O(1)`
-		#[pallet::call_index(20)]
+		#[pallet::call_index(19)]
 		#[pallet::weight(T::WeightInfo::unprepare_avatar())]
 		pub fn unprepare_avatar(origin: OriginFor<T>, avatar_id: AvatarIdOf<T>) -> DispatchResult {
 			let player = ensure_signed(origin)?;
@@ -970,7 +947,7 @@ pub mod pallet {
 		/// storing their CIDs.
 		//
 		/// Weight: `O(1)`
-		#[pallet::call_index(21)]
+		#[pallet::call_index(20)]
 		#[pallet::weight(T::WeightInfo::prepare_ipfs())]
 		pub fn prepare_ipfs(
 			origin: OriginFor<T>,

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -3457,38 +3457,6 @@ mod nft_transfer {
 	}
 }
 
-mod fix_variation {
-	use super::*;
-
-	#[test]
-	fn fix_variation_successfully() {
-		let season = Season::default();
-
-		ExtBuilder::default()
-			.seasons(&[(SEASON_ID, season.clone())])
-			.balances(&[(ALICE, 1_000_000_000_000)])
-			.build()
-			.execute_with(|| {
-				run_to_block(season.start);
-
-				let avatar_id = create_avatars(SEASON_ID, ALICE, 1)[0];
-
-				let (_, mut avatar_before) = Avatars::<Test>::get(avatar_id).unwrap();
-
-				avatar_before.dna[1] = 0b0001_1100;
-				avatar_before.dna[2] = 0b0100_0010;
-
-				Avatars::<Test>::insert(avatar_id, (ALICE, avatar_before));
-
-				assert_ok!(AAvatars::fix_variation(RuntimeOrigin::signed(ALICE), avatar_id));
-
-				let (_, avatar_after) = Avatars::<Test>::get(avatar_id).unwrap();
-				assert_eq!(avatar_after.dna[1], 0b0001_1100);
-				assert_eq!(avatar_after.dna[2], 0b0100_1100);
-			});
-	}
-}
-
 mod ipfs {
 	use super::*;
 

--- a/pallets/ajuna-awesome-avatars/src/weights.rs
+++ b/pallets/ajuna-awesome-avatars/src/weights.rs
@@ -50,7 +50,6 @@ pub trait WeightInfo {
 	fn set_free_mints() -> Weight;
 	fn lock_avatar(n: u32, ) -> Weight;
 	fn unlock_avatar(n: u32, ) -> Weight;
-	fn fix_variation() -> Weight;
 	fn set_service_account() -> Weight;
 	fn prepare_avatar() -> Weight;
 	fn unprepare_avatar() -> Weight;
@@ -504,17 +503,6 @@ impl<T: frame_system::Config> WeightInfo for AjunaWeight<T> {
 		Weight::from_parts(910_723_452, 18812)
 			.saturating_add(T::DbWeight::get().reads(20_u64))
 			.saturating_add(T::DbWeight::get().writes(19_u64))
-	}
-	/// Storage: AwesomeAvatars Avatars (r:1 w:1)
-	/// Proof: AwesomeAvatars Avatars (max_values: None, max_size: Some(173), added: 2648, mode: MaxEncodedLen)
-	fn fix_variation() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `257`
-		//  Estimated: `3638`
-		// Minimum execution time: 20_578_000 picoseconds.
-		Weight::from_parts(21_552_000, 3638)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	/// Storage: AwesomeAvatars ServiceAccount (r:0 w:1)
 	/// Proof: AwesomeAvatars ServiceAccount (max_values: Some(1), max_size: Some(32), added: 527, mode: MaxEncodedLen)
@@ -1029,17 +1017,6 @@ impl WeightInfo for () {
 		Weight::from_parts(910_723_452, 18812)
 			.saturating_add(RocksDbWeight::get().reads(20_u64))
 			.saturating_add(RocksDbWeight::get().writes(19_u64))
-	}
-	/// Storage: AwesomeAvatars Avatars (r:1 w:1)
-	/// Proof: AwesomeAvatars Avatars (max_values: None, max_size: Some(173), added: 2648, mode: MaxEncodedLen)
-	fn fix_variation() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `257`
-		//  Estimated: `3638`
-		// Minimum execution time: 20_578_000 picoseconds.
-		Weight::from_parts(21_552_000, 3638)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 	/// Storage: AwesomeAvatars ServiceAccount (r:0 w:1)
 	/// Proof: AwesomeAvatars ServiceAccount (max_values: Some(1), max_size: Some(32), added: 527, mode: MaxEncodedLen)


### PR DESCRIPTION
## Description

Removes `fix_variation` extrinsic and all its references.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
