### PR TITLE
Season 2 - Additional logic/adjustments

### DIFF
--- a/pallets/ajuna-awesome-avatars/src/types/avatar/rarity_tier.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/rarity_tier.rs
@@ -23,13 +23,13 @@ use sp_std::{fmt, prelude::*};
 )]
 pub enum RarityTier {
 	#[default]
-	None,
-	Common,
-	Uncommon,
-	Rare,
-	Epic,
-	Legendary,
-	Mythical,
+	None = 0,
+	Common = 1,
+	Uncommon = 2,
+	Rare = 3,
+	Epic = 4,
+	Legendary = 5,
+	Mythical = 6,
 }
 
 impl fmt::Display for RarityTier {

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/avatar_utils.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/avatar_utils.rs
@@ -1036,7 +1036,7 @@ impl DnaUtils {
 			let variation_2 = Self::read_at(&array_2, i, ByteType::Low);
 
 			let have_same_rarity = rarity_1 == rarity_2 || rarity_2 == 0x0B;
-			let is_maxed = rarity_1 > lowest_1 || lowest_1 == RarityTier::Legendary.as_byte();
+			let is_maxed = rarity_1 > lowest_1;
 			let byte_match = Self::match_progress_byte(variation_1, variation_2);
 
 			if have_same_rarity &&

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/assemble.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/assemble.rs
@@ -867,7 +867,23 @@ mod test {
 				(id, avatar)
 			};
 
-			let sac_2 = create_random_toolbox([0; 32], &ALICE, 100);
+			let sac_2 = {
+				let (id, mut avatar) = create_random_armor_component(
+					[0; 32],
+					&ALICE,
+					&PetType::FoxishDude,
+					&SlotType::Head,
+					&RarityTier::Uncommon,
+					&[EquippableItemType::ArmorBase],
+					&(ColorType::Null, ColorType::Null),
+					&Force::Null,
+					10,
+					&mut hash_generators[1],
+				);
+				avatar.set_progress(progress_arrays[1]);
+				(id, avatar)
+			};
+
 			let sac_3 = create_random_toolbox([0; 32], &ALICE, 100);
 			let sac_4 = create_random_toolbox([0; 32], &ALICE, 100);
 

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/equip.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/equip.rs
@@ -17,8 +17,8 @@ impl<T: Config> AvatarCombinator<T> {
 			.map(|slot| slot.iter().sum::<u8>() == 0)
 			.collect::<Vec<_>>();
 
-		let are_slots_maxed =
-			equipment_slots_state.iter().filter(|slot| !**slot).count() >= MAX_EQUIPPED_SLOTS;
+		let are_slots_maxed = equipment_slots_state.iter().filter(|slot| !**slot).count() >=
+			(MAX_EQUIPPED_SLOTS + leader.get_spec::<u8>(SpecIdx::Byte16) as usize);
 
 		for (_, sacrifice) in input_sacrifices.iter() {
 			new_souls += sacrifice.get_souls();

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/feed.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/combinator/feed.rs
@@ -11,18 +11,29 @@ impl<T: Config> AvatarCombinator<T> {
 				Vec::with_capacity(0),
 			)),
 			sacrifice_count => {
-				let (sacrifice_souls, other_output) = input_sacrifices.into_iter().fold(
-					(0, Vec::with_capacity(sacrifice_count)),
-					|(souls, mut items), (sacrifice_id, sacrifice)| {
-						items.push(ForgeOutput::Consumed(sacrifice_id));
-						(souls + sacrifice.get_souls(), items)
-					},
-				);
-
 				let (leader_id, mut leader) = input_leader;
-				leader.add_souls(sacrifice_souls);
+				let mut sacrifice_output = Vec::with_capacity(sacrifice_count);
 
-				Ok((LeaderForgeOutput::Forged((leader_id, leader.unwrap()), 0), other_output))
+				for (sacrifice_id, sacrifice) in input_sacrifices.into_iter() {
+					leader.add_souls(sacrifice.get_souls());
+
+					let spec_16 = leader.get_spec::<u8>(SpecIdx::Byte16);
+
+					if sacrifice.get_rarity() == RarityTier::Legendary && spec_16 < 11 {
+						let mut progress = leader.get_progress();
+						progress[spec_16 as usize] &= 0x0F;
+						progress[spec_16 as usize] |= RarityTier::Mythical.as_byte() << 4;
+						leader.set_progress(progress);
+						leader.set_spec(SpecIdx::Byte16, spec_16 + 1);
+						if spec_16 == 10 {
+							leader.set_rarity(RarityTier::Mythical);
+						}
+					}
+
+					sacrifice_output.push(ForgeOutput::Consumed(sacrifice_id));
+				}
+
+				Ok((LeaderForgeOutput::Forged((leader_id, leader.unwrap()), 0), sacrifice_output))
 			},
 		}
 	}
@@ -71,6 +82,245 @@ mod test {
 			} else {
 				panic!("LeaderForgeOutput should have been Forged!")
 			}
+		});
+	}
+
+	#[test]
+	fn test_feed_prep_1() {
+		ExtBuilder::default().build().execute_with(|| {
+			let leader_progress_array =
+				[0x53, 0x54, 0x51, 0x52, 0x55, 0x55, 0x54, 0x51, 0x53, 0x55, 0x53];
+			let leader_spec_bytes = [
+				0x97, 0x59, 0x75, 0x97, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x75, 0x97, 0x50,
+				0x00, 0x00,
+			];
+
+			let leader = create_random_pet(
+				&ALICE,
+				&PetType::BigHybrid,
+				0b0001_1001,
+				leader_spec_bytes,
+				leader_progress_array,
+				1000,
+			);
+
+			let sacrifice_1 = create_random_egg(
+				None,
+				&ALICE,
+				&RarityTier::Legendary,
+				0b0000_0000,
+				100,
+				[0x00; 11],
+			);
+
+			let total_soul_points = leader.1.get_souls() + sacrifice_1.1.get_souls();
+
+			assert_eq!(leader.1.get_spec::<u8>(SpecIdx::Byte16), 0);
+
+			let (leader_output, sacrifice_output) =
+				AvatarCombinator::<Test>::feed_avatars(leader, vec![sacrifice_1])
+					.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 1);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 1);
+
+			let leader = if let LeaderForgeOutput::Forged((leader_id, leader_avatar), _) =
+				leader_output
+			{
+				assert_eq!(leader_avatar.souls, total_soul_points);
+				assert_eq!(DnaUtils::read_spec::<u8>(&leader_avatar, SpecIdx::Byte16), 1);
+				assert_eq!(
+					DnaUtils::read_attribute::<RarityTier>(&leader_avatar, AvatarAttr::RarityTier),
+					RarityTier::Legendary
+				);
+				let expected_progress_array =
+					[0x63, 0x54, 0x51, 0x52, 0x55, 0x55, 0x54, 0x51, 0x53, 0x55, 0x53];
+				assert_eq!(DnaUtils::read_progress(&leader_avatar), expected_progress_array);
+
+				(leader_id, WrappedAvatar::new(leader_avatar))
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			};
+
+			let sacrifice_2 = create_random_egg(
+				None,
+				&ALICE,
+				&RarityTier::Legendary,
+				0b0000_0000,
+				100,
+				[0x00; 11],
+			);
+
+			let sacrifice_3 = create_random_egg(
+				None,
+				&ALICE,
+				&RarityTier::Legendary,
+				0b0000_0000,
+				100,
+				[0x00; 11],
+			);
+
+			let sacrifice_4 = create_random_egg(
+				None,
+				&ALICE,
+				&RarityTier::Legendary,
+				0b0000_0000,
+				100,
+				[0x00; 11],
+			);
+
+			let sacrifice_5 = create_random_egg(
+				None,
+				&ALICE,
+				&RarityTier::Legendary,
+				0b0000_0000,
+				100,
+				[0x00; 11],
+			);
+
+			let total_soul_points = leader.1.get_souls() +
+				sacrifice_2.1.get_souls() +
+				sacrifice_3.1.get_souls() +
+				sacrifice_4.1.get_souls() +
+				sacrifice_5.1.get_souls();
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::feed_avatars(
+				leader,
+				vec![sacrifice_2, sacrifice_3, sacrifice_4, sacrifice_5],
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 4);
+
+			let leader = if let LeaderForgeOutput::Forged((leader_id, leader_avatar), _) =
+				leader_output
+			{
+				assert_eq!(leader_avatar.souls, total_soul_points);
+				assert_eq!(DnaUtils::read_spec::<u8>(&leader_avatar, SpecIdx::Byte16), 5);
+				assert_eq!(
+					DnaUtils::read_attribute::<RarityTier>(&leader_avatar, AvatarAttr::RarityTier),
+					RarityTier::Legendary
+				);
+				let expected_progress_array =
+					[0x63, 0x64, 0x61, 0x62, 0x65, 0x55, 0x54, 0x51, 0x53, 0x55, 0x53];
+				assert_eq!(DnaUtils::read_progress(&leader_avatar), expected_progress_array);
+
+				(leader_id, WrappedAvatar::new(leader_avatar))
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			};
+
+			let sacrifice_6 = create_random_egg(
+				None,
+				&ALICE,
+				&RarityTier::Legendary,
+				0b0000_0000,
+				100,
+				[0x00; 11],
+			);
+
+			let sacrifice_7 = create_random_egg(
+				None,
+				&ALICE,
+				&RarityTier::Legendary,
+				0b0000_0000,
+				100,
+				[0x00; 11],
+			);
+
+			let sacrifice_8 = create_random_egg(
+				None,
+				&ALICE,
+				&RarityTier::Legendary,
+				0b0000_0000,
+				100,
+				[0x00; 11],
+			);
+
+			let sacrifice_9 = create_random_egg(
+				None,
+				&ALICE,
+				&RarityTier::Legendary,
+				0b0000_0000,
+				100,
+				[0x00; 11],
+			);
+
+			let total_soul_points = leader.1.get_souls() +
+				sacrifice_6.1.get_souls() +
+				sacrifice_7.1.get_souls() +
+				sacrifice_8.1.get_souls() +
+				sacrifice_9.1.get_souls();
+
+			let (leader_output, sacrifice_output) = AvatarCombinator::<Test>::feed_avatars(
+				leader,
+				vec![sacrifice_6, sacrifice_7, sacrifice_8, sacrifice_9],
+			)
+			.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 4);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 4);
+
+			let leader = if let LeaderForgeOutput::Forged((leader_id, leader_avatar), _) =
+				leader_output
+			{
+				assert_eq!(leader_avatar.souls, total_soul_points);
+				assert_eq!(DnaUtils::read_spec::<u8>(&leader_avatar, SpecIdx::Byte16), 9);
+				assert_eq!(
+					DnaUtils::read_attribute::<RarityTier>(&leader_avatar, AvatarAttr::RarityTier),
+					RarityTier::Legendary
+				);
+				let expected_progress_array =
+					[0x63, 0x64, 0x61, 0x62, 0x65, 0x65, 0x64, 0x61, 0x63, 0x55, 0x53];
+				assert_eq!(DnaUtils::read_progress(&leader_avatar), expected_progress_array);
+
+				(leader_id, WrappedAvatar::new(leader_avatar))
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			};
+
+			let sacrifice_10 = create_random_egg(
+				None,
+				&ALICE,
+				&RarityTier::Legendary,
+				0b0000_0000,
+				100,
+				[0x00; 11],
+			);
+
+			let sacrifice_11 = create_random_egg(
+				None,
+				&ALICE,
+				&RarityTier::Legendary,
+				0b0000_0000,
+				100,
+				[0x00; 11],
+			);
+
+			let total_soul_points =
+				leader.1.get_souls() + sacrifice_10.1.get_souls() + sacrifice_11.1.get_souls();
+
+			let (leader_output, sacrifice_output) =
+				AvatarCombinator::<Test>::feed_avatars(leader, vec![sacrifice_10, sacrifice_11])
+					.expect("Should succeed in forging");
+
+			assert_eq!(sacrifice_output.len(), 2);
+			assert_eq!(sacrifice_output.iter().filter(|output| is_consumed(output)).count(), 2);
+
+			if let LeaderForgeOutput::Forged((_, leader_avatar), _) = leader_output {
+				assert_eq!(leader_avatar.souls, total_soul_points);
+				assert_eq!(DnaUtils::read_spec::<u8>(&leader_avatar, SpecIdx::Byte16), 11);
+				assert_eq!(
+					DnaUtils::read_attribute::<RarityTier>(&leader_avatar, AvatarAttr::RarityTier),
+					RarityTier::Mythical
+				);
+				let expected_progress_array =
+					[0x63, 0x64, 0x61, 0x62, 0x65, 0x65, 0x64, 0x61, 0x63, 0x65, 0x63];
+				assert_eq!(DnaUtils::read_progress(&leader_avatar), expected_progress_array);
+			} else {
+				panic!("LeaderForgeOutput should have been Forged!")
+			};
 		});
 	}
 }

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/constants.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/constants.rs
@@ -12,6 +12,7 @@ pub(crate) const PROGRESS_PROBABILITY_PERC: u32 = 15;
 pub(crate) const PROGRESS_VARIATIONS: u8 = 6;
 pub(crate) const BASE_PROGRESS_PROB_PERC: u32 = 20;
 pub(crate) const MAX_EQUIPPED_SLOTS: usize = 5;
+pub(crate) const MAX_TOOLBOXES: usize = 2;
 pub(crate) const GLIMMER_PROB_PERC: u32 = 15;
 pub(crate) const COLOR_GLOW_SPARK: u32 = 52;
 pub(crate) const SPARK_PROGRESS_PROB_PERC: u32 = 25;

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/mod.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/versions/v2/mod.rs
@@ -330,7 +330,17 @@ impl<T: Config> ForgerV2<T> {
 					(same_assemble_version && equipable_sacrifice_item.is_armor()) || is_toolbox
 				});
 
-				if leader_sub_type.is_armor() && all_sacrifice_are_armor_or_toolbox {
+				let sacrificed_toolboxes = sacrifices
+					.iter()
+					.filter(|sacrifice| {
+						sacrifice.has_full_type(ItemType::Special, SpecialItemType::ToolBox)
+					})
+					.count();
+
+				if leader_sub_type.is_armor() &&
+					all_sacrifice_are_armor_or_toolbox &&
+					sacrificed_toolboxes <= MAX_TOOLBOXES
+				{
 					ForgeType::Assemble
 				} else if leader_rarity == RarityTier::Epic && leader_sub_type.is_armor_base() {
 					let has_one_paint_flask_or_glow = sacrifices


### PR DESCRIPTION
## Description

* Adds moon clock logic for `ForgeType::Mate`
* Restricts to maximum of 2 Toolbox uses per Assembly run
* Adds additional logic to `ForgeType::Feed`

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [x] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
