### PR TITLE
[Season 2] Add account activity check for free mint transfer

### DIFF
--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -305,6 +305,11 @@ benchmarks! {
 		let GlobalConfig { transfer, .. } = GlobalConfigs::<T>::get();
 		let free_mint_transfer_fee = transfer.free_mint_transfer_fee;
 		let how_many = MintCount::MAX - free_mint_transfer_fee as MintCount;
+		let season_id = CurrentSeasonStatus::<T>::get().season_id;
+		SeasonStats::<T>::mutate(season_id, &from, |stats| {
+			stats.minted = 1;
+			stats.forged = 1;
+		});
 		PlayerConfigs::<T>::mutate(&from, |account| account.free_mints = MintCount::MAX);
 	}: _(RawOrigin::Signed(from.clone()), to.clone(), how_many)
 	verify {

--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -300,6 +300,7 @@ benchmarks! {
 	}
 
 	transfer_free_mints {
+		create_seasons::<T>(1)?;
 		let from = account::<T>("from");
 		let to = account::<T>("to");
 		let GlobalConfig { transfer, .. } = GlobalConfigs::<T>::get();

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -2371,7 +2371,7 @@ mod transferring {
 			.free_mints(&[(ALICE, 17), (BOB, 4)])
 			.build()
 			.execute_with(|| {
-				SeasonStats::<Test>::mutate(&1, &ALICE, |stats| {
+				SeasonStats::<Test>::mutate(1, ALICE, |stats| {
 					stats.minted = 1;
 					stats.forged = 1;
 				});
@@ -2400,7 +2400,7 @@ mod transferring {
 			.free_mints(&[(ALICE, 11)])
 			.build()
 			.execute_with(|| {
-				SeasonStats::<Test>::mutate(&1, &ALICE, |stats| {
+				SeasonStats::<Test>::mutate(1, ALICE, |stats| {
 					stats.minted = 1;
 					stats.forged = 1;
 				});
@@ -2423,7 +2423,7 @@ mod transferring {
 			.free_mints(&[(ALICE, 7)])
 			.build()
 			.execute_with(|| {
-				SeasonStats::<Test>::mutate(&1, &ALICE, |stats| {
+				SeasonStats::<Test>::mutate(1, ALICE, |stats| {
 					stats.minted = 1;
 					stats.forged = 1;
 				});


### PR DESCRIPTION
## Description

Adds an additional check the the `transfer_free_mints` extrinsic. This check blocks accounts that have neither minted nor forged anything from transferring their free mints.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [x] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
