### PR TITLE
[NFT-Staking] Attribute namespace support

### DIFF
--- a/pallets/ajuna-nft-staking/benchmarking/src/lib.rs
+++ b/pallets/ajuna-nft-staking/benchmarking/src/lib.rs
@@ -241,23 +241,25 @@ fn contract_with<T: Config>(
 		claim_duration: 1_u32.unique_saturated_into(),
 		stake_duration: 1_u32.unique_saturated_into(),
 		stake_clauses: (0..num_stake_clauses)
-			.map(|i| {
-				Clause::HasAttributeWithValue(
+			.map(|i| ContractClause {
+				namespace: AttributeNamespace::Pallet,
+				clause: Clause::HasAttributeWithValue(
 					CollectionIdOf::<T>::unique_saturated_from(stake_collection),
 					T::BenchmarkHelper::contract_key(i),
 					T::BenchmarkHelper::contract_value(ATTRIBUTE_VALUE),
-				)
+				),
 			})
 			.collect::<Vec<_>>()
 			.try_into()
 			.unwrap(),
 		fee_clauses: (num_stake_clauses..num_stake_clauses + num_fee_clauses)
-			.map(|i| {
-				Clause::HasAttributeWithValue(
+			.map(|i| ContractClause {
+				namespace: AttributeNamespace::Pallet,
+				clause: Clause::HasAttributeWithValue(
 					CollectionIdOf::<T>::unique_saturated_from(fee_collection),
 					T::BenchmarkHelper::contract_key(i),
 					T::BenchmarkHelper::contract_value(ATTRIBUTE_VALUE),
-				)
+				),
 			})
 			.collect::<Vec<_>>()
 			.try_into()

--- a/pallets/ajuna-nft-staking/src/contracts.rs
+++ b/pallets/ajuna-nft-staking/src/contracts.rs
@@ -41,8 +41,8 @@ pub enum Reward<Balance, CollectionId, ItemId> {
 
 #[derive(Debug, Clone, Eq, PartialEq, Encode, Decode, MaxEncodedLen, TypeInfo)]
 pub struct ContractClause<CollectionId, AttributeKey, AttributeValue> {
-	pub(crate) namespace: AttributeNamespace,
-	pub(crate) clause: Clause<CollectionId, AttributeKey, AttributeValue>,
+	pub namespace: AttributeNamespace,
+	pub clause: Clause<CollectionId, AttributeKey, AttributeValue>,
 }
 
 impl<CollectionId, AttributeKey, AttributeValue>

--- a/pallets/ajuna-nft-staking/src/tests/ext/accept.rs
+++ b/pallets/ajuna-nft-staking/src/tests/ext/accept.rs
@@ -28,8 +28,8 @@ fn works() {
 	let contract = Contract::default()
 		.reward(Reward::Tokens(123))
 		.stake_duration(stake_duration)
-		.stake_clauses(stake_clauses.clone())
-		.fee_clauses(fee_clauses.clone());
+		.stake_clauses(AttributeNamespace::Pallet, stake_clauses.clone())
+		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone());
 	let contract_id = H256::random();
 
 	let stakes = MockMints::from(MockClauses(stake_clauses));
@@ -165,8 +165,8 @@ fn rejects_when_contract_is_already_accepted() {
 	let contract = Contract::default()
 		.reward(Reward::Tokens(123))
 		.stake_duration(123)
-		.stake_clauses(stake_clauses.clone())
-		.fee_clauses(fee_clauses.clone());
+		.stake_clauses(AttributeNamespace::Pallet, stake_clauses.clone())
+		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone());
 	let contract_id = H256::random();
 
 	let alice_stakes = MockMints::from(MockClauses(stake_clauses));
@@ -255,8 +255,8 @@ fn rejects_unowned_stakes() {
 	let contract = Contract::default()
 		.reward(Reward::Tokens(123))
 		.stake_duration(123)
-		.stake_clauses(stake_clauses.clone())
-		.fee_clauses(fee_clauses.clone());
+		.stake_clauses(AttributeNamespace::Pallet, stake_clauses.clone())
+		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone());
 	let contract_id = H256::random();
 
 	let stakes = MockMints::from(MockClauses(stake_clauses));
@@ -315,7 +315,7 @@ fn rejects_unfulfilling_stakes() {
 	let contract = Contract::default()
 		.reward(Reward::Tokens(123))
 		.stake_duration(123)
-		.stake_clauses(stake_clauses.clone());
+		.stake_clauses(AttributeNamespace::Pallet, stake_clauses.clone());
 	let contract_id = H256::random();
 
 	let mut stakes = MockMints::from(MockClauses(stake_clauses));
@@ -350,7 +350,7 @@ fn rejects_unfulfilling_fees() {
 	let contract = Contract::default()
 		.reward(Reward::Tokens(123))
 		.stake_duration(123)
-		.fee_clauses(fee_clauses.clone());
+		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone());
 	let contract_id = H256::random();
 
 	let mut fees = MockMints::from(MockClauses(fee_clauses));

--- a/pallets/ajuna-nft-staking/src/tests/ext/cancel.rs
+++ b/pallets/ajuna-nft-staking/src/tests/ext/cancel.rs
@@ -29,8 +29,8 @@ fn works_with_token_reward() {
 	let contract = Contract::default()
 		.reward(Reward::Tokens(reward))
 		.stake_duration(stake_duration)
-		.stake_clauses(stake_clauses.clone())
-		.fee_clauses(fee_clauses.clone())
+		.stake_clauses(AttributeNamespace::Pallet, stake_clauses.clone())
+		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone())
 		.cancel_fee(cancellation_fee);
 	let contract_id = H256::random();
 
@@ -88,8 +88,8 @@ fn works_with_nft_reward() {
 	let contract = Contract::default()
 		.reward(Reward::Nft(reward_addr.clone()))
 		.stake_duration(stake_duration)
-		.stake_clauses(stake_clauses.clone())
-		.fee_clauses(fee_clauses.clone())
+		.stake_clauses(AttributeNamespace::Pallet, stake_clauses.clone())
+		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone())
 		.cancel_fee(cancellation_fee);
 	let contract_id = H256::random();
 

--- a/pallets/ajuna-nft-staking/src/tests/ext/claim.rs
+++ b/pallets/ajuna-nft-staking/src/tests/ext/claim.rs
@@ -29,8 +29,8 @@ fn works_with_token_reward() {
 	let contract = Contract::default()
 		.reward(Reward::Tokens(reward_amount))
 		.stake_duration(stake_duration)
-		.stake_clauses(stake_clauses.clone())
-		.fee_clauses(fee_clauses.clone());
+		.stake_clauses(AttributeNamespace::Pallet, stake_clauses.clone())
+		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone());
 	let contract_id = H256::random();
 
 	let stakes = MockMints::from(MockClauses(stake_clauses));
@@ -88,8 +88,8 @@ fn works_with_nft_reward() {
 	let contract = Contract::default()
 		.reward(Reward::Nft(reward_addr.clone()))
 		.stake_duration(stake_duration)
-		.stake_clauses(stake_clauses.clone())
-		.fee_clauses(fee_clauses.clone());
+		.stake_clauses(AttributeNamespace::Pallet, stake_clauses.clone())
+		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone());
 	let contract_id = H256::random();
 
 	let stakes = MockMints::from(MockClauses(stake_clauses));

--- a/pallets/ajuna-nft-staking/src/tests/ext/create.rs
+++ b/pallets/ajuna-nft-staking/src/tests/ext/create.rs
@@ -123,7 +123,9 @@ fn rejects_out_of_bound_staking_clauses() {
 			NftStake::create(
 				RuntimeOrigin::signed(ALICE),
 				H256::random(),
-				Contract::default().reward(Reward::Tokens(1)).stake_clauses(staking_clauses)
+				Contract::default()
+					.reward(Reward::Tokens(1))
+					.stake_clauses(AttributeNamespace::Pallet, staking_clauses)
 			),
 			Error::<Test>::MaxStakingClauses
 		);
@@ -141,7 +143,9 @@ fn rejects_out_of_bound_fee_clauses() {
 			NftStake::create(
 				RuntimeOrigin::signed(ALICE),
 				H256::random(),
-				Contract::default().reward(Reward::Tokens(1)).fee_clauses(fee_clauses)
+				Contract::default()
+					.reward(Reward::Tokens(1))
+					.fee_clauses(AttributeNamespace::Pallet, fee_clauses)
 			),
 			Error::<Test>::MaxFeeClauses
 		);

--- a/pallets/ajuna-nft-staking/src/tests/ext/snipe.rs
+++ b/pallets/ajuna-nft-staking/src/tests/ext/snipe.rs
@@ -30,8 +30,8 @@ fn works_with_token_reward() {
 		.reward(Reward::Tokens(reward))
 		.stake_duration(stake_duration)
 		.claim_duration(claim_duration)
-		.stake_clauses(stake_clauses.clone())
-		.fee_clauses(fee_clauses.clone());
+		.stake_clauses(AttributeNamespace::Pallet, stake_clauses.clone())
+		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone());
 	let contract_id = H256::random();
 
 	let stakes = MockMints::from(MockClauses(stake_clauses));
@@ -93,8 +93,8 @@ fn works_with_nft_reward() {
 		.reward(Reward::Nft(reward_addr.clone()))
 		.stake_duration(stake_duration)
 		.claim_duration(claim_duration)
-		.stake_clauses(stake_clauses.clone())
-		.fee_clauses(fee_clauses.clone());
+		.stake_clauses(AttributeNamespace::Pallet, stake_clauses.clone())
+		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone());
 	let contract_id = H256::random();
 
 	let stakes = MockMints::from(MockClauses(stake_clauses));

--- a/pallets/ajuna-nft-staking/src/tests/mock.rs
+++ b/pallets/ajuna-nft-staking/src/tests/mock.rs
@@ -243,12 +243,22 @@ impl ContractOf<Test> {
 		self.stake_duration = stake_duration;
 		self
 	}
-	pub fn stake_clauses(mut self, clauses: Vec<MockClause>) -> Self {
-		self.stake_clauses = clauses.try_into().unwrap();
+	pub fn stake_clauses(mut self, ns: AttributeNamespace, clauses: Vec<MockClause>) -> Self {
+		self.stake_clauses = clauses
+			.into_iter()
+			.map(|clause| MockContractClause { namespace: ns, clause })
+			.collect::<Vec<_>>()
+			.try_into()
+			.unwrap();
 		self
 	}
-	pub fn fee_clauses(mut self, clauses: Vec<MockClause>) -> Self {
-		self.fee_clauses = clauses.try_into().unwrap();
+	pub fn fee_clauses(mut self, ns: AttributeNamespace, clauses: Vec<MockClause>) -> Self {
+		self.fee_clauses = clauses
+			.into_iter()
+			.map(|clause| MockContractClause { namespace: ns, clause })
+			.collect::<Vec<_>>()
+			.try_into()
+			.unwrap();
 		self
 	}
 	pub fn reward(mut self, reward: RewardOf<Test>) -> Self {
@@ -262,6 +272,7 @@ impl ContractOf<Test> {
 }
 
 pub type MockClause = Clause<MockCollectionId, AttributeKey, AttributeValue>;
+pub type MockContractClause = ContractClause<MockCollectionId, AttributeKey, AttributeValue>;
 pub struct MockClauses(pub Vec<MockClause>);
 pub type MockMints = Vec<(NftId<MockCollectionId, MockItemId>, AttributeKey, AttributeValue)>;
 


### PR DESCRIPTION
## Description

This PR adds limited AttributeNamespace support similar to what https://github.com/paritytech/substrate/blob/polkadot-v0.9.42/frame/nfts/src/types.rs#L326 accomplishes.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
