### PR TITLE
[Staking] Pallet enhancements

### DIFF
--- a/pallets/ajuna-nft-staking/benchmarking/src/lib.rs
+++ b/pallets/ajuna-nft-staking/benchmarking/src/lib.rs
@@ -146,6 +146,7 @@ fn create_contract<T: Config>(
 		RawOrigin::Signed(creator).into(),
 		contract_id,
 		contract,
+		None,
 	)
 }
 
@@ -243,6 +244,7 @@ fn contract_with<T: Config>(
 		stake_clauses: (0..num_stake_clauses)
 			.map(|i| ContractClause {
 				namespace: AttributeNamespace::Pallet,
+				target_index: i as u8,
 				clause: Clause::HasAttributeWithValue(
 					CollectionIdOf::<T>::unique_saturated_from(stake_collection),
 					T::BenchmarkHelper::contract_key(i),
@@ -255,6 +257,7 @@ fn contract_with<T: Config>(
 		fee_clauses: (num_stake_clauses..num_stake_clauses + num_fee_clauses)
 			.map(|i| ContractClause {
 				namespace: AttributeNamespace::Pallet,
+				target_index: (i - num_stake_clauses) as u8,
 				clause: Clause::HasAttributeWithValue(
 					CollectionIdOf::<T>::unique_saturated_from(fee_collection),
 					T::BenchmarkHelper::contract_key(i),
@@ -266,6 +269,8 @@ fn contract_with<T: Config>(
 			.unwrap(),
 		reward,
 		cancel_fee: 333_u64.unique_saturated_into(),
+		nft_stake_amount: num_stake_clauses as u8,
+		nft_fee_amount: num_fee_clauses as u8,
 	}
 }
 
@@ -301,7 +306,7 @@ benchmarks! {
 		let reward = Reward::Tokens(123_u64.unique_saturated_into());
 		let contract = contract_with::<T>(m, n, reward, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
-	}: create(RawOrigin::Signed(creator), contract_id, contract)
+	}: create(RawOrigin::Signed(creator), contract_id, contract, None)
 	verify {
 		assert_last_event::<T>(Event::Created { contract_id })
 	}
@@ -317,7 +322,7 @@ benchmarks! {
 		let contract = contract_with::<T>(m, n, reward, Mode::Staker);
 		let contract_id = T::BenchmarkHelper::item_id(0_u16);
 		let creator = create_creator::<T>(Some(vec![reward_nft_item]))?;
-	}: create(RawOrigin::Signed(creator), contract_id, contract)
+	}: create(RawOrigin::Signed(creator), contract_id, contract, None)
 	verify {
 		assert_last_event::<T>(Event::Created { contract_id })
 	}

--- a/pallets/ajuna-nft-staking/benchmarking/src/mock.rs
+++ b/pallets/ajuna-nft-staking/benchmarking/src/mock.rs
@@ -168,6 +168,7 @@ parameter_types! {
 	pub const MaxContracts: u32 = 100;
 	pub const MaxStakingClauses: u32 = 10;
 	pub const MaxFeeClauses: u32 = 1;
+	pub const MaxMetadataLenght: u32 = 100;
 }
 
 pub type AttributeKey = u32;
@@ -184,6 +185,7 @@ impl pallet_ajuna_nft_staking::Config for Runtime {
 	type MaxContracts = MaxContracts;
 	type MaxStakingClauses = MaxStakingClauses;
 	type MaxFeeClauses = MaxFeeClauses;
+	type MaxMetadataLength = MaxMetadataLenght;
 	type AttributeKey = AttributeKey;
 	type AttributeValue = AttributeValue;
 	pallet_ajuna_nft_staking::runtime_benchmarks_enabled! {

--- a/pallets/ajuna-nft-staking/src/tests/ext/cancel.rs
+++ b/pallets/ajuna-nft-staking/src/tests/ext/cancel.rs
@@ -19,10 +19,10 @@ use super::*;
 #[test]
 fn works_with_token_reward() {
 	let stake_clauses = vec![
-		Clause::HasAttribute(RESERVED_COLLECTION_0, 1),
-		Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 3, 4),
+		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, 1)),
+		(1, Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 3, 4)),
 	];
-	let fee_clauses = vec![Clause::HasAttribute(RESERVED_COLLECTION_1, 11)];
+	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_1, 11))];
 	let stake_duration = 4;
 	let reward = 135;
 	let cancellation_fee = 111;
@@ -34,10 +34,10 @@ fn works_with_token_reward() {
 		.cancel_fee(cancellation_fee);
 	let contract_id = H256::random();
 
-	let stakes = MockMints::from(MockClauses(stake_clauses));
+	let stakes = MockMints::from(MockClauses(stake_clauses.into_iter().map(|(_, c)| c).collect()));
 	let stake_addresses =
 		stakes.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
-	let fees = MockMints::from(MockClauses(fee_clauses));
+	let fees = MockMints::from(MockClauses(fee_clauses.into_iter().map(|(_, c)| c).collect()));
 	let fee_addresses = fees.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
 
 	ExtBuilder::default()
@@ -78,10 +78,10 @@ fn works_with_token_reward() {
 #[test]
 fn works_with_nft_reward() {
 	let stake_clauses = vec![
-		Clause::HasAttribute(RESERVED_COLLECTION_0, 1),
-		Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 3, 4),
+		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, 1)),
+		(1, Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 3, 4)),
 	];
-	let fee_clauses = vec![Clause::HasAttribute(RESERVED_COLLECTION_1, 11)];
+	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_1, 11))];
 	let stake_duration = 4;
 	let reward_addr = NftId(RESERVED_COLLECTION_2, H256::random());
 	let cancellation_fee = 111;
@@ -93,10 +93,10 @@ fn works_with_nft_reward() {
 		.cancel_fee(cancellation_fee);
 	let contract_id = H256::random();
 
-	let stakes = MockMints::from(MockClauses(stake_clauses));
+	let stakes = MockMints::from(MockClauses(stake_clauses.into_iter().map(|(_, c)| c).collect()));
 	let stake_addresses =
 		stakes.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
-	let fees = MockMints::from(MockClauses(fee_clauses));
+	let fees = MockMints::from(MockClauses(fee_clauses.into_iter().map(|(_, c)| c).collect()));
 	let fee_addresses = fees.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
 
 	ExtBuilder::default()

--- a/pallets/ajuna-nft-staking/src/tests/ext/claim.rs
+++ b/pallets/ajuna-nft-staking/src/tests/ext/claim.rs
@@ -19,11 +19,11 @@ use super::*;
 #[test]
 fn works_with_token_reward() {
 	let stake_clauses = vec![
-		Clause::HasAttribute(RESERVED_COLLECTION_0, 4),
-		Clause::HasAttribute(RESERVED_COLLECTION_1, 5),
-		Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 6, 7),
+		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, 4)),
+		(1, Clause::HasAttribute(RESERVED_COLLECTION_1, 5)),
+		(2, Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 6, 7)),
 	];
-	let fee_clauses = vec![Clause::HasAttribute(RESERVED_COLLECTION_2, 33)];
+	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_2, 33))];
 	let stake_duration = 4;
 	let reward_amount = 135;
 	let contract = Contract::default()
@@ -33,10 +33,10 @@ fn works_with_token_reward() {
 		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone());
 	let contract_id = H256::random();
 
-	let stakes = MockMints::from(MockClauses(stake_clauses));
+	let stakes = MockMints::from(MockClauses(stake_clauses.into_iter().map(|(_, c)| c).collect()));
 	let stake_addresses =
 		stakes.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
-	let fees = MockMints::from(MockClauses(fee_clauses));
+	let fees = MockMints::from(MockClauses(fee_clauses.into_iter().map(|(_, c)| c).collect()));
 	let fee_addresses = fees.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
 
 	ExtBuilder::default()
@@ -78,11 +78,11 @@ fn works_with_token_reward() {
 #[test]
 fn works_with_nft_reward() {
 	let stake_clauses = vec![
-		Clause::HasAttribute(RESERVED_COLLECTION_0, 4),
-		Clause::HasAttribute(RESERVED_COLLECTION_0, 5),
-		Clause::HasAttributeWithValue(RESERVED_COLLECTION_1, 6, 7),
+		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, 4)),
+		(1, Clause::HasAttribute(RESERVED_COLLECTION_0, 5)),
+		(2, Clause::HasAttributeWithValue(RESERVED_COLLECTION_1, 6, 7)),
 	];
-	let fee_clauses = vec![Clause::HasAttribute(RESERVED_COLLECTION_1, 1)];
+	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_1, 1))];
 	let stake_duration = 8;
 	let reward_addr = NftId(RESERVED_COLLECTION_2, H256::random());
 	let contract = Contract::default()
@@ -92,10 +92,10 @@ fn works_with_nft_reward() {
 		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone());
 	let contract_id = H256::random();
 
-	let stakes = MockMints::from(MockClauses(stake_clauses));
+	let stakes = MockMints::from(MockClauses(stake_clauses.into_iter().map(|(_, c)| c).collect()));
 	let stake_addresses =
 		stakes.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
-	let fees = MockMints::from(MockClauses(fee_clauses));
+	let fees = MockMints::from(MockClauses(fee_clauses.into_iter().map(|(_, c)| c).collect()));
 	let fee_addresses = fees.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
 
 	ExtBuilder::default()

--- a/pallets/ajuna-nft-staking/src/tests/ext/snipe.rs
+++ b/pallets/ajuna-nft-staking/src/tests/ext/snipe.rs
@@ -19,11 +19,11 @@ use super::*;
 #[test]
 fn works_with_token_reward() {
 	let stake_clauses = vec![
-		Clause::HasAttribute(RESERVED_COLLECTION_0, 4),
-		Clause::HasAttribute(RESERVED_COLLECTION_1, 5),
-		Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 6, 7),
+		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, 4)),
+		(1, Clause::HasAttribute(RESERVED_COLLECTION_1, 5)),
+		(2, Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 6, 7)),
 	];
-	let fee_clauses = vec![Clause::HasAttribute(RESERVED_COLLECTION_2, 33)];
+	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_2, 33))];
 	let (stake_duration, claim_duration) = (4, 3);
 	let reward = 135;
 	let contract = Contract::default()
@@ -34,10 +34,10 @@ fn works_with_token_reward() {
 		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone());
 	let contract_id = H256::random();
 
-	let stakes = MockMints::from(MockClauses(stake_clauses));
+	let stakes = MockMints::from(MockClauses(stake_clauses.into_iter().map(|(_, c)| c).collect()));
 	let stake_addresses =
 		stakes.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
-	let fees = MockMints::from(MockClauses(fee_clauses));
+	let fees = MockMints::from(MockClauses(fee_clauses.into_iter().map(|(_, c)| c).collect()));
 	let fee_addresses = fees.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
 
 	ExtBuilder::default()
@@ -82,11 +82,11 @@ fn works_with_token_reward() {
 #[test]
 fn works_with_nft_reward() {
 	let stake_clauses = vec![
-		Clause::HasAttribute(RESERVED_COLLECTION_0, 4),
-		Clause::HasAttribute(RESERVED_COLLECTION_0, 5),
-		Clause::HasAttributeWithValue(RESERVED_COLLECTION_1, 6, 7),
+		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, 4)),
+		(1, Clause::HasAttribute(RESERVED_COLLECTION_0, 5)),
+		(2, Clause::HasAttributeWithValue(RESERVED_COLLECTION_1, 6, 7)),
 	];
-	let fee_clauses = vec![Clause::HasAttribute(RESERVED_COLLECTION_1, 1)];
+	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_1, 1))];
 	let (stake_duration, claim_duration) = (2, 3);
 	let reward_addr = NftId(RESERVED_COLLECTION_2, H256::random());
 	let contract = Contract::default()
@@ -97,10 +97,10 @@ fn works_with_nft_reward() {
 		.fee_clauses(AttributeNamespace::Pallet, fee_clauses.clone());
 	let contract_id = H256::random();
 
-	let stakes = MockMints::from(MockClauses(stake_clauses));
+	let stakes = MockMints::from(MockClauses(stake_clauses.into_iter().map(|(_, c)| c).collect()));
 	let stake_addresses =
 		stakes.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
-	let fees = MockMints::from(MockClauses(fee_clauses));
+	let fees = MockMints::from(MockClauses(fee_clauses.into_iter().map(|(_, c)| c).collect()));
 	let fee_addresses = fees.clone().into_iter().map(|(address, _, _)| address).collect::<Vec<_>>();
 
 	ExtBuilder::default()

--- a/runtime/solo/src/lib.rs
+++ b/runtime/solo/src/lib.rs
@@ -637,6 +637,7 @@ parameter_types! {
 	pub const MaxContracts: u32 = 100;
 	pub const MaxStakingClauses: u32 = 10;
 	pub const MaxFeeClauses: u32 = 5;
+	pub const MaxMetadataLenght: u32 = 100;
 }
 
 type AttributeKey = u32;
@@ -655,6 +656,7 @@ impl pallet_ajuna_nft_staking::Config for Runtime {
 	type MaxFeeClauses = MaxFeeClauses;
 	type AttributeKey = AttributeKey;
 	type AttributeValue = AttributeValue;
+	type MaxMetadataLength = MaxMetadataLenght;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
 	type WeightInfo = ();


### PR DESCRIPTION
## Description

This PR adds the following features to the `nft-staking` pallet:

* Adds `target_index` to the `ContractClause` struct
* Adds `nft_staking_amount` and `nft_fee_amount` to the `Contract` struct
* Adds checks for both stake and fee NFTs to check the amount of unique values in the extrinsic call of `accept`
* Adds `ContractsMetadata` storage, used to pair each contract with a string bytes of metadata.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [x] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
