### PR TITLE
[Staking] Match NFT attribute key/value to pallet-nfts spec

### DIFF
--- a/pallets/ajuna-nft-staking/benchmarking/src/lib.rs
+++ b/pallets/ajuna-nft-staking/benchmarking/src/lib.rs
@@ -77,7 +77,8 @@ type ContractOf<T> = Contract<
 	CollectionIdOf<T>,
 	<T as NftStakingConfig>::ItemId,
 	<T as frame_system::Config>::BlockNumber,
-	<T as NftStakingConfig>::AttributeKey,
+	<T as NftStakingConfig>::KeyLimit,
+	<T as NftStakingConfig>::ValueLimit,
 >;
 
 type NftCurrencyOf<T> = <T as pallet_nfts::Config>::Currency;
@@ -182,7 +183,7 @@ fn mint_item<T: Config>(owner: &T::AccountId, collection_id: u16, item_id: u16) 
 fn set_attribute<T: Config>(
 	collection_id: u16,
 	item_id: u16,
-	key: u32,
+	key: u8,
 	value: u8,
 ) -> DispatchResult {
 	let collection_id = &T::Helper::collection(collection_id);
@@ -190,7 +191,7 @@ fn set_attribute<T: Config>(
 	<pallet_nfts::Pallet<T> as Mutate<T::AccountId, ItemConfig>>::set_attribute(
 		collection_id,
 		item_id,
-		key.encode().as_slice(),
+		&[key],
 		&[value],
 	)?;
 	Ok(())
@@ -209,7 +210,7 @@ fn stakes_and_fees<T: Config>(
 		let item_id = i as u16;
 		let attr_key = i;
 		mint_item::<T>(who, stake_collection, item_id)?;
-		set_attribute::<T>(stake_collection, item_id, attr_key, ATTRIBUTE_VALUE)?;
+		set_attribute::<T>(stake_collection, item_id, attr_key as u8, ATTRIBUTE_VALUE)?;
 		stakes.push(NftId(
 			CollectionIdOf::<T>::unique_saturated_from(stake_collection),
 			T::BenchmarkHelper::item_id(item_id),
@@ -219,7 +220,7 @@ fn stakes_and_fees<T: Config>(
 		let item_id = i as u16;
 		let attr_key = i;
 		mint_item::<T>(who, fee_collection, item_id)?;
-		set_attribute::<T>(fee_collection, item_id, attr_key, ATTRIBUTE_VALUE)?;
+		set_attribute::<T>(fee_collection, item_id, attr_key as u8, ATTRIBUTE_VALUE)?;
 		fees.push(NftId(
 			CollectionIdOf::<T>::unique_saturated_from(fee_collection),
 			T::BenchmarkHelper::item_id(item_id),
@@ -246,7 +247,7 @@ fn contract_with<T: Config>(
 				target_index: i as u8,
 				clause: Clause::HasAttributeWithValue(
 					CollectionIdOf::<T>::unique_saturated_from(stake_collection),
-					T::BenchmarkHelper::contract_key(i),
+					T::BenchmarkHelper::contract_key(i as u8),
 					T::BenchmarkHelper::contract_value(ATTRIBUTE_VALUE),
 				),
 			})
@@ -259,7 +260,7 @@ fn contract_with<T: Config>(
 				target_index: (i - num_stake_clauses) as u8,
 				clause: Clause::HasAttributeWithValue(
 					CollectionIdOf::<T>::unique_saturated_from(fee_collection),
-					T::BenchmarkHelper::contract_key(i),
+					T::BenchmarkHelper::contract_key(i as u8),
 					T::BenchmarkHelper::contract_value(ATTRIBUTE_VALUE),
 				),
 			})

--- a/pallets/ajuna-nft-staking/benchmarking/src/mock.rs
+++ b/pallets/ajuna-nft-staking/benchmarking/src/mock.rs
@@ -16,12 +16,14 @@
 
 #![cfg(test)]
 
-use frame_support::{parameter_types, traits::AsEnsureOriginWithArg, PalletId};
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::{dispatch::TypeInfo, parameter_types, traits::AsEnsureOriginWithArg, PalletId};
 use frame_system::{
 	mocking::{MockBlock, MockUncheckedExtrinsic},
 	EnsureRoot, EnsureSigned,
 };
 use pallet_nfts::PalletFeatures;
+use sp_core::Get;
 use sp_runtime::{
 	testing::{Header, H256},
 	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
@@ -106,8 +108,6 @@ parameter_types! {
 	pub const AttributeDepositBase: MockBalance = 0;
 	pub const DepositPerByte: MockBalance = 0;
 	pub const StringLimit: u32 = 128;
-	pub const KeyLimit: u32 = 32;
-	pub const ValueLimit: u32 = 64;
 	pub const ApprovalsLimit: u32 = 1;
 	pub const ItemAttributesApprovalsLimit: u32 = 10;
 	pub const MaxTips: u32 = 1;
@@ -132,6 +132,18 @@ impl<CollectionId: From<u16>, ItemId: From<[u8; 32]>>
 		id.into()
 	}
 }
+
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, MaxEncodedLen, TypeInfo)]
+pub struct ParameterGet<const N: u32>;
+
+impl<const N: u32> Get<u32> for ParameterGet<N> {
+	fn get() -> u32 {
+		N
+	}
+}
+
+pub type KeyLimit = ParameterGet<8>;
+pub type ValueLimit = ParameterGet<32>;
 
 impl pallet_nfts::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
@@ -171,8 +183,6 @@ parameter_types! {
 	pub const MaxMetadataLenght: u32 = 100;
 }
 
-pub type AttributeKey = u32;
-
 impl pallet_ajuna_nft_staking::Config for Runtime {
 	type PalletId = NftStakingPalletId;
 	type RuntimeEvent = RuntimeEvent;
@@ -185,7 +195,8 @@ impl pallet_ajuna_nft_staking::Config for Runtime {
 	type MaxStakingClauses = MaxStakingClauses;
 	type MaxFeeClauses = MaxFeeClauses;
 	type MaxMetadataLength = MaxMetadataLenght;
-	type AttributeKey = AttributeKey;
+	type KeyLimit = KeyLimit;
+	type ValueLimit = ValueLimit;
 	pallet_ajuna_nft_staking::runtime_benchmarks_enabled! {
 		type BenchmarkHelper = ();
 	}

--- a/pallets/ajuna-nft-staking/src/tests/ext/cancel.rs
+++ b/pallets/ajuna-nft-staking/src/tests/ext/cancel.rs
@@ -19,10 +19,10 @@ use super::*;
 #[test]
 fn works_with_token_reward() {
 	let stake_clauses = vec![
-		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, 1)),
-		(1, Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 3, bounded_vec![4])),
+		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, bounded_vec![1])),
+		(1, Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, bounded_vec![3], bounded_vec![4])),
 	];
-	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_1, 11))];
+	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_1, bounded_vec![11]))];
 	let stake_duration = 4;
 	let reward = 135;
 	let cancellation_fee = 111;
@@ -78,10 +78,10 @@ fn works_with_token_reward() {
 #[test]
 fn works_with_nft_reward() {
 	let stake_clauses = vec![
-		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, 1)),
-		(1, Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 3, bounded_vec![4])),
+		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, bounded_vec![1])),
+		(1, Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, bounded_vec![3], bounded_vec![4])),
 	];
-	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_1, 11))];
+	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_1, bounded_vec![11]))];
 	let stake_duration = 4;
 	let reward_addr = NftId(RESERVED_COLLECTION_2, H256::random());
 	let cancellation_fee = 111;

--- a/pallets/ajuna-nft-staking/src/tests/ext/claim.rs
+++ b/pallets/ajuna-nft-staking/src/tests/ext/claim.rs
@@ -19,11 +19,11 @@ use super::*;
 #[test]
 fn works_with_token_reward() {
 	let stake_clauses = vec![
-		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, 4)),
-		(1, Clause::HasAttribute(RESERVED_COLLECTION_1, 5)),
-		(2, Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 6, bounded_vec![7])),
+		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, bounded_vec![4])),
+		(1, Clause::HasAttribute(RESERVED_COLLECTION_1, bounded_vec![5])),
+		(2, Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, bounded_vec![6], bounded_vec![7])),
 	];
-	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_2, 33))];
+	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_2, bounded_vec![33]))];
 	let stake_duration = 4;
 	let reward_amount = 135;
 	let contract = Contract::default()
@@ -78,11 +78,11 @@ fn works_with_token_reward() {
 #[test]
 fn works_with_nft_reward() {
 	let stake_clauses = vec![
-		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, 4)),
-		(1, Clause::HasAttribute(RESERVED_COLLECTION_0, 5)),
-		(2, Clause::HasAttributeWithValue(RESERVED_COLLECTION_1, 6, bounded_vec![7])),
+		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, bounded_vec![4])),
+		(1, Clause::HasAttribute(RESERVED_COLLECTION_0, bounded_vec![5])),
+		(2, Clause::HasAttributeWithValue(RESERVED_COLLECTION_1, bounded_vec![6], bounded_vec![7])),
 	];
-	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_1, 1))];
+	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_1, bounded_vec![1]))];
 	let stake_duration = 8;
 	let reward_addr = NftId(RESERVED_COLLECTION_2, H256::random());
 	let contract = Contract::default()

--- a/pallets/ajuna-nft-staking/src/tests/ext/create.rs
+++ b/pallets/ajuna-nft-staking/src/tests/ext/create.rs
@@ -128,7 +128,7 @@ fn rejects_when_pallet_is_locked() {
 fn rejects_out_of_bound_staking_clauses() {
 	ExtBuilder::default().set_creator(ALICE).build().execute_with(|| {
 		let staking_clauses = (0..MaxStakingClauses::get() + 1)
-			.map(|i| (i as u8, Clause::HasAttribute(RESERVED_COLLECTION_0, i)))
+			.map(|i| (i as u8, Clause::HasAttribute(RESERVED_COLLECTION_0, bounded_vec![i as u8])))
 			.collect::<Vec<_>>();
 		assert!(staking_clauses.len() as u32 > MaxStakingClauses::get());
 		assert_noop!(
@@ -149,7 +149,7 @@ fn rejects_out_of_bound_staking_clauses() {
 fn rejects_out_of_bound_fee_clauses() {
 	ExtBuilder::default().set_creator(ALICE).build().execute_with(|| {
 		let fee_clauses = (0..MaxFeeClauses::get() + 1)
-			.map(|i| (i as u8, Clause::HasAttribute(RESERVED_COLLECTION_0, i)))
+			.map(|i| (i as u8, Clause::HasAttribute(RESERVED_COLLECTION_0, bounded_vec![i as u8])))
 			.collect::<Vec<_>>();
 		assert!(fee_clauses.len() as u32 > MaxFeeClauses::get());
 		assert_noop!(

--- a/pallets/ajuna-nft-staking/src/tests/ext/snipe.rs
+++ b/pallets/ajuna-nft-staking/src/tests/ext/snipe.rs
@@ -19,11 +19,11 @@ use super::*;
 #[test]
 fn works_with_token_reward() {
 	let stake_clauses = vec![
-		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, 4)),
-		(1, Clause::HasAttribute(RESERVED_COLLECTION_1, 5)),
-		(2, Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, 6, bounded_vec![7])),
+		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, bounded_vec![4])),
+		(1, Clause::HasAttribute(RESERVED_COLLECTION_1, bounded_vec![5])),
+		(2, Clause::HasAttributeWithValue(RESERVED_COLLECTION_2, bounded_vec![6], bounded_vec![7])),
 	];
-	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_2, 33))];
+	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_2, bounded_vec![33]))];
 	let (stake_duration, claim_duration) = (4, 3);
 	let reward = 135;
 	let contract = Contract::default()
@@ -82,11 +82,11 @@ fn works_with_token_reward() {
 #[test]
 fn works_with_nft_reward() {
 	let stake_clauses = vec![
-		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, 4)),
-		(1, Clause::HasAttribute(RESERVED_COLLECTION_0, 5)),
-		(2, Clause::HasAttributeWithValue(RESERVED_COLLECTION_1, 6, bounded_vec![7])),
+		(0, Clause::HasAttribute(RESERVED_COLLECTION_0, bounded_vec![4])),
+		(1, Clause::HasAttribute(RESERVED_COLLECTION_0, bounded_vec![5])),
+		(2, Clause::HasAttributeWithValue(RESERVED_COLLECTION_1, bounded_vec![6], bounded_vec![7])),
 	];
-	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_1, 1))];
+	let fee_clauses = vec![(0, Clause::HasAttribute(RESERVED_COLLECTION_1, bounded_vec![1]))];
 	let (stake_duration, claim_duration) = (2, 3);
 	let reward_addr = NftId(RESERVED_COLLECTION_2, H256::random());
 	let contract = Contract::default()


### PR DESCRIPTION
## Description

This pallet replaces both NFT attribute key and value for `BoundedVec` with configurable bound limits, like `pallet-nfts`.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
