### PR TITLE
[Staking] Adjusting types of Avatar attributes on NFT conversion

### DIFF
--- a/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/lib.rs
@@ -40,9 +40,14 @@ type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 type AvatarIdOf<T> = <T as frame_system::Config>::Hash;
 type BalanceOf<T> = <CurrencyOf<T> as Currency<AccountIdOf<T>>>::Balance;
 type CurrencyOf<T> = <T as AvatarsConfig>::Currency;
+type KeyLimitOf<T> = <T as AvatarsConfig>::KeyLimit;
+type ValueLimitOf<T> = <T as AvatarsConfig>::ValueLimit;
+
 type CollectionIdOf<T> = <<T as AvatarsConfig>::NftHandler as NftHandler<
 	AccountIdOf<T>,
 	AvatarIdOf<T>,
+	KeyLimitOf<T>,
+	ValueLimitOf<T>,
 	Avatar,
 >>::CollectionId;
 

--- a/pallets/ajuna-awesome-avatars/benchmarking/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/benchmarking/src/mock.rs
@@ -16,7 +16,9 @@
 
 #![cfg(test)]
 
+use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
+	dispatch::TypeInfo,
 	parameter_types,
 	traits::{AsEnsureOriginWithArg, ConstU16, ConstU64},
 	PalletId,
@@ -27,7 +29,7 @@ use frame_system::{
 };
 use sp_runtime::{
 	testing::{Header, H256},
-	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
+	traits::{BlakeTwo256, Get, IdentifyAccount, IdentityLookup, Verify},
 	MultiSignature,
 };
 
@@ -109,8 +111,6 @@ parameter_types! {
 	pub const CollectionDeposit: MockBalance = 1;
 	pub const ItemDeposit: MockBalance = 1;
 	pub const StringLimit: u32 = 128;
-	pub const KeyLimit: u32 = 32;
-	pub static MockValueLimit: u32 = 200;
 	pub const MetadataDepositBase: MockBalance = 1;
 	pub const AttributeDepositBase: MockBalance = 1;
 	pub const DepositPerByte: MockBalance = 1;
@@ -140,6 +140,18 @@ impl<CollectionId: From<u16>, ItemId: From<[u8; 32]>>
 	}
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, MaxEncodedLen, TypeInfo)]
+pub struct ParameterGet<const N: u32>;
+
+impl<const N: u32> Get<u32> for ParameterGet<N> {
+	fn get() -> u32 {
+		N
+	}
+}
+
+pub type KeyLimit = ParameterGet<32>;
+pub type ValueLimit = ParameterGet<64>;
+
 impl pallet_nfts::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type CollectionId = MockCollectionId;
@@ -155,7 +167,7 @@ impl pallet_nfts::Config for Runtime {
 	type DepositPerByte = DepositPerByte;
 	type StringLimit = StringLimit;
 	type KeyLimit = KeyLimit;
-	type ValueLimit = MockValueLimit;
+	type ValueLimit = ValueLimit;
 	type ApprovalsLimit = ApprovalsLimit;
 	type ItemAttributesApprovalsLimit = ItemAttributesApprovalsLimit;
 	type MaxTips = MaxTips;
@@ -179,6 +191,8 @@ impl pallet_ajuna_awesome_avatars::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type Randomness = Randomness;
+	type KeyLimit = KeyLimit;
+	type ValueLimit = ValueLimit;
 	type NftHandler = NftTransfer;
 	type WeightInfo = ();
 }
@@ -193,6 +207,8 @@ impl pallet_ajuna_nft_transfer::Config for Runtime {
 	type CollectionId = MockCollectionId;
 	type ItemId = H256;
 	type ItemConfig = pallet_nfts::ItemConfig;
+	type KeyLimit = KeyLimit;
+	type ValueLimit = ValueLimit;
 	type NftHelper = Nft;
 }
 

--- a/pallets/ajuna-awesome-avatars/src/lib.rs
+++ b/pallets/ajuna-awesome-avatars/src/lib.rs
@@ -97,9 +97,13 @@ pub mod pallet {
 	pub(crate) type AvatarIdOf<T> = <T as frame_system::Config>::Hash;
 	pub(crate) type BoundedAvatarIdsOf<T> = BoundedVec<AvatarIdOf<T>, MaxAvatarsPerPlayer>;
 	pub(crate) type GlobalConfigOf<T> = GlobalConfig<BlockNumberFor<T>>;
+	pub(crate) type KeyLimitOf<T> = <T as Config>::KeyLimit;
+	pub(crate) type ValueLimitOf<T> = <T as Config>::ValueLimit;
 	pub(crate) type CollectionIdOf<T> = <<T as Config>::NftHandler as NftHandler<
 		AccountIdOf<T>,
 		AvatarIdOf<T>,
+		KeyLimitOf<T>,
+		ValueLimitOf<T>,
 		Avatar,
 	>>::CollectionId;
 
@@ -120,7 +124,21 @@ pub mod pallet {
 
 		type Randomness: Randomness<Self::Hash, Self::BlockNumber>;
 
-		type NftHandler: NftHandler<Self::AccountId, Self::Hash, Avatar>;
+		/// The maximum length of an attribute key.
+		#[pallet::constant]
+		type KeyLimit: Get<u32>;
+
+		/// The maximum length of an attribute value.
+		#[pallet::constant]
+		type ValueLimit: Get<u32>;
+
+		type NftHandler: NftHandler<
+			Self::AccountId,
+			Self::Hash,
+			Self::KeyLimit,
+			Self::ValueLimit,
+			Avatar,
+		>;
 
 		type WeightInfo: WeightInfo;
 	}

--- a/pallets/ajuna-awesome-avatars/src/mock.rs
+++ b/pallets/ajuna-awesome-avatars/src/mock.rs
@@ -116,8 +116,6 @@ parameter_types! {
 	pub const CollectionDeposit: MockBalance = 1;
 	pub const ItemDeposit: MockBalance = 1;
 	pub const StringLimit: u32 = 128;
-	pub const KeyLimit: u32 = 32;
-	pub static MockValueLimit: u32 = 200;
 	pub const MetadataDepositBase: MockBalance = 1;
 	pub const AttributeDepositBase: MockBalance = 1;
 	pub const DepositPerByte: MockBalance = 1;
@@ -147,6 +145,18 @@ impl<CollectionId: From<u16>, ItemId: From<[u8; 32]>>
 	}
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, MaxEncodedLen, TypeInfo)]
+pub struct ParameterGet<const N: u32>;
+
+impl<const N: u32> Get<u32> for ParameterGet<N> {
+	fn get() -> u32 {
+		N
+	}
+}
+
+pub type KeyLimit = ParameterGet<32>;
+pub type ValueLimit = ParameterGet<64>;
+
 impl pallet_nfts::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type CollectionId = MockCollectionId;
@@ -162,7 +172,7 @@ impl pallet_nfts::Config for Test {
 	type DepositPerByte = DepositPerByte;
 	type StringLimit = StringLimit;
 	type KeyLimit = KeyLimit;
-	type ValueLimit = MockValueLimit;
+	type ValueLimit = ValueLimit;
 	type ApprovalsLimit = ApprovalsLimit;
 	type ItemAttributesApprovalsLimit = ItemAttributesApprovalsLimit;
 	type MaxTips = MaxTips;
@@ -186,6 +196,8 @@ impl pallet_ajuna_awesome_avatars::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type Randomness = Randomness;
+	type KeyLimit = KeyLimit;
+	type ValueLimit = ValueLimit;
 	type NftHandler = NftTransfer;
 	type WeightInfo = ();
 }
@@ -200,6 +212,8 @@ impl pallet_ajuna_nft_transfer::Config for Test {
 	type CollectionId = MockCollectionId;
 	type ItemId = H256;
 	type ItemConfig = pallet_nfts::ItemConfig;
+	type KeyLimit = KeyLimit;
+	type ValueLimit = ValueLimit;
 	type NftHelper = Nft;
 }
 
@@ -211,7 +225,6 @@ pub struct ExtBuilder {
 	balances: Vec<(MockAccountId, MockBalance)>,
 	free_mints: Vec<(MockAccountId, MintCount)>,
 	create_nft_collection: bool,
-	value_limit: u32,
 }
 
 impl Default for ExtBuilder {
@@ -224,7 +237,6 @@ impl Default for ExtBuilder {
 			balances: Default::default(),
 			free_mints: Default::default(),
 			create_nft_collection: Default::default(),
-			value_limit: MockValueLimit::get(),
 		}
 	}
 }
@@ -258,14 +270,8 @@ impl ExtBuilder {
 		self.create_nft_collection = create_nft_collection;
 		self
 	}
-	pub fn value_limit(mut self, value_limit: u32) -> Self {
-		self.value_limit = value_limit;
-		self
-	}
-
 	pub fn build(self) -> sp_io::TestExternalities {
 		MOCK_EXISTENTIAL_DEPOSIT.with(|v| *v.borrow_mut() = self.existential_deposit);
-		MOCK_VALUE_LIMIT.with(|v| *v.borrow_mut() = self.value_limit);
 		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 		pallet_balances::GenesisConfig::<Test> { balances: self.balances }
 			.assimilate_storage(&mut t)

--- a/pallets/ajuna-awesome-avatars/src/tests.rs
+++ b/pallets/ajuna-awesome-avatars/src/tests.rs
@@ -3256,7 +3256,7 @@ mod nft_transfer {
 					<Nft as Inspect<MockAccountId>>::system_attribute(
 						&CollectionId::<Test>::get().unwrap(),
 						&avatar_id,
-						&<Avatar as NftConvertible<KeyLimit, ValueLimit>>::ITEM_CODE,
+						<Avatar as NftConvertible<KeyLimit, ValueLimit>>::ITEM_CODE,
 					)
 					.unwrap(),
 					avatar.encode(),

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/nft.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/nft.rs
@@ -25,7 +25,7 @@ where
 	VL: Get<u32>,
 {
 	const ITEM_CODE: &'static [u8] = b"AVATAR";
-	const IPFS_URL_CODE: &'static [u8] = b"AVATAR_IPFS";
+	const IPFS_URL_CODE: &'static [u8] = b"IPFS_URL";
 
 	fn get_attribute_codes() -> Vec<NFTAttribute<KL>> {
 		vec![

--- a/pallets/ajuna-awesome-avatars/src/types/avatar/nft.rs
+++ b/pallets/ajuna-awesome-avatars/src/types/avatar/nft.rs
@@ -14,32 +14,51 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::types::{Avatar, ByteConvertible, Force, RarityTier};
-use codec::Encode;
-use pallet_ajuna_nft_transfer::traits::{AttributeCode, NftConvertible};
+use crate::types::Avatar;
+use frame_support::{traits::Get, BoundedVec};
+use pallet_ajuna_nft_transfer::traits::{NFTAttribute, NftConvertible};
 use sp_std::prelude::*;
 
-pub const DNA: AttributeCode = 10;
-pub const SOUL_POINTS: AttributeCode = 11;
-pub const RARITY: AttributeCode = 12;
-pub const FORCE: AttributeCode = 13;
-pub const SEASON_ID: AttributeCode = 14;
+impl<KL, VL> NftConvertible<KL, VL> for Avatar
+where
+	KL: Get<u32>,
+	VL: Get<u32>,
+{
+	const ITEM_CODE: &'static [u8] = b"AVATAR";
+	const IPFS_URL_CODE: &'static [u8] = b"AVATAR_IPFS";
 
-impl NftConvertible for Avatar {
-	const ITEM_CODE: AttributeCode = 0;
-	const IPFS_URL_CODE: AttributeCode = 1;
-
-	fn get_attribute_codes() -> Vec<AttributeCode> {
-		vec![DNA, SOUL_POINTS, RARITY, FORCE, SEASON_ID]
+	fn get_attribute_codes() -> Vec<NFTAttribute<KL>> {
+		vec![
+			BoundedVec::try_from(b"DNA".to_vec()).unwrap(),
+			BoundedVec::try_from(b"SOUL_POINTS".to_vec()).unwrap(),
+			BoundedVec::try_from(b"RARITY".to_vec()).unwrap(),
+			BoundedVec::try_from(b"FORCE".to_vec()).unwrap(),
+			BoundedVec::try_from(b"SEASON_ID".to_vec()).unwrap(),
+		]
 	}
 
-	fn get_encoded_attributes(&self) -> Vec<(AttributeCode, Vec<u8>)> {
+	fn get_encoded_attributes(&self) -> Vec<(NFTAttribute<KL>, NFTAttribute<VL>)> {
 		vec![
-			(DNA, self.dna.clone().encode()),
-			(SOUL_POINTS, self.souls.encode()),
-			(RARITY, RarityTier::from_byte(self.rarity()).encode()),
-			(FORCE, Force::from_byte(self.force()).encode()),
-			(SEASON_ID, self.season_id.encode()),
+			(
+				BoundedVec::try_from(b"DNA".to_vec()).unwrap(),
+				BoundedVec::try_from(self.dna.clone().to_vec()).unwrap(),
+			),
+			(
+				BoundedVec::try_from(b"SOUL_POINTS".to_vec()).unwrap(),
+				BoundedVec::try_from(self.souls.to_le_bytes().to_vec()).unwrap(),
+			),
+			(
+				BoundedVec::try_from(b"RARITY".to_vec()).unwrap(),
+				BoundedVec::try_from(self.rarity().to_le_bytes().to_vec()).unwrap(),
+			),
+			(
+				BoundedVec::try_from(b"FORCE".to_vec()).unwrap(),
+				BoundedVec::try_from(self.force().to_le_bytes().to_vec()).unwrap(),
+			),
+			(
+				BoundedVec::try_from(b"SEASON_ID".to_vec()).unwrap(),
+				BoundedVec::try_from(self.season_id.to_le_bytes().to_vec()).unwrap(),
+			),
 		]
 	}
 }

--- a/pallets/ajuna-nft-staking/benchmarking/src/mock.rs
+++ b/pallets/ajuna-nft-staking/benchmarking/src/mock.rs
@@ -142,8 +142,8 @@ impl<const N: u32> Get<u32> for ParameterGet<N> {
 	}
 }
 
-pub type KeyLimit = ParameterGet<8>;
-pub type ValueLimit = ParameterGet<32>;
+pub type KeyLimit = ParameterGet<32>;
+pub type ValueLimit = ParameterGet<64>;
 
 impl pallet_nfts::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/pallets/ajuna-nft-staking/src/tests/mock.rs
+++ b/pallets/ajuna-nft-staking/src/tests/mock.rs
@@ -154,8 +154,8 @@ impl<const N: u32> Get<u32> for ParameterGet<N> {
 	}
 }
 
-pub type KeyLimit = ParameterGet<8>;
-pub type ValueLimit = ParameterGet<32>;
+pub type KeyLimit = ParameterGet<32>;
+pub type ValueLimit = ParameterGet<64>;
 
 impl pallet_nfts::Config for Test {
 	type RuntimeEvent = RuntimeEvent;

--- a/pallets/ajuna-nft-transfer/src/lib.rs
+++ b/pallets/ajuna-nft-transfer/src/lib.rs
@@ -156,12 +156,7 @@ pub mod pallet {
 						attribute_code.as_slice() != Item::ITEM_CODE,
 						Error::<T>::DuplicateItemCode
 					);
-					T::NftHelper::set_attribute(
-						&collection_id,
-						&item_id,
-						&attribute_code,
-						&attribute,
-					)
+					T::NftHelper::set_attribute(&collection_id, &item_id, attribute_code, attribute)
 				})?;
 
 			NftStatuses::<T>::insert(collection_id, item_id, NftStatus::Stored);

--- a/pallets/ajuna-nft-transfer/src/lib.rs
+++ b/pallets/ajuna-nft-transfer/src/lib.rs
@@ -68,6 +68,14 @@ pub mod pallet {
 		/// Type that holds the specific configurations for an item.
 		type ItemConfig: Default + MaxEncodedLen + TypeInfo;
 
+		/// The maximum length of an attribute key.
+		#[pallet::constant]
+		type KeyLimit: Get<u32>;
+
+		/// The maximum length of an attribute value.
+		#[pallet::constant]
+		type ValueLimit: Get<u32>;
+
 		/// An NFT helper for the management of collections and items.
 		type NftHelper: Inspect<Self::AccountId, CollectionId = Self::CollectionId, ItemId = Self::ItemId>
 			+ Mutate<Self::AccountId, Self::ItemConfig>;
@@ -112,7 +120,9 @@ pub mod pallet {
 		}
 	}
 
-	impl<T: Config, Item: NftConvertible> NftHandler<T::AccountId, T::ItemId, Item> for Pallet<T> {
+	impl<T: Config, Item: NftConvertible<T::KeyLimit, T::ValueLimit>>
+		NftHandler<T::AccountId, T::ItemId, T::KeyLimit, T::ValueLimit, Item> for Pallet<T>
+	{
 		type CollectionId = T::CollectionId;
 
 		fn store_as_nft(
@@ -124,21 +134,29 @@ pub mod pallet {
 		) -> DispatchResult {
 			let config = T::ItemConfig::default();
 			T::NftHelper::mint_into(&collection_id, &item_id, &owner, &config, false)?;
-			T::NftHelper::set_typed_attribute(&collection_id, &item_id, &Item::ITEM_CODE, &item)?;
-
-			ensure!(!ipfs_url.is_empty(), Error::<T>::EmptyIpfsUrl);
-			T::NftHelper::set_typed_attribute(
+			T::NftHelper::set_attribute(
 				&collection_id,
 				&item_id,
-				&Item::IPFS_URL_CODE,
-				&ipfs_url,
+				Item::ITEM_CODE,
+				item.encode().as_slice(),
+			)?;
+
+			ensure!(!ipfs_url.is_empty(), Error::<T>::EmptyIpfsUrl);
+			T::NftHelper::set_attribute(
+				&collection_id,
+				&item_id,
+				Item::IPFS_URL_CODE,
+				ipfs_url.as_slice(),
 			)?;
 
 			item.get_encoded_attributes()
 				.iter()
 				.try_for_each(|(attribute_code, attribute)| {
-					ensure!(attribute_code != &Item::ITEM_CODE, Error::<T>::DuplicateItemCode);
-					T::NftHelper::set_typed_attribute(
+					ensure!(
+						attribute_code.as_slice() != Item::ITEM_CODE,
+						Error::<T>::DuplicateItemCode
+					);
+					T::NftHelper::set_attribute(
 						&collection_id,
 						&item_id,
 						&attribute_code,
@@ -162,14 +180,13 @@ pub mod pallet {
 				Error::<T>::NftOutsideOfChain
 			);
 
-			let item =
-				T::NftHelper::system_attribute(&collection_id, &item_id, &Item::ITEM_CODE.encode())
-					.ok_or(Error::<T>::UnknownItem)?;
+			let item = T::NftHelper::system_attribute(&collection_id, &item_id, Item::ITEM_CODE)
+				.ok_or(Error::<T>::UnknownItem)?;
 
-			T::NftHelper::clear_typed_attribute(&collection_id, &item_id, &Item::ITEM_CODE)?;
-			T::NftHelper::clear_typed_attribute(&collection_id, &item_id, &Item::IPFS_URL_CODE)?;
+			T::NftHelper::clear_attribute(&collection_id, &item_id, Item::ITEM_CODE)?;
+			T::NftHelper::clear_attribute(&collection_id, &item_id, Item::IPFS_URL_CODE)?;
 			for attribute_key in Item::get_attribute_codes() {
-				T::NftHelper::clear_typed_attribute(&collection_id, &item_id, &attribute_key)?;
+				T::NftHelper::clear_attribute(&collection_id, &item_id, &attribute_key)?;
 			}
 
 			NftStatuses::<T>::remove(collection_id, item_id);

--- a/pallets/ajuna-nft-transfer/src/mock.rs
+++ b/pallets/ajuna-nft-transfer/src/mock.rs
@@ -15,7 +15,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{self as pallet_ajuna_nft_transfer};
+use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
+	dispatch::TypeInfo,
 	parameter_types,
 	traits::{AsEnsureOriginWithArg, ConstU16, ConstU64},
 	PalletId,
@@ -27,7 +29,7 @@ use frame_system::{
 use pallet_nfts::{PalletFeature, PalletFeatures};
 use sp_runtime::{
 	testing::{Header, TestSignature, H256},
-	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
+	traits::{BlakeTwo256, Get, IdentifyAccount, IdentityLookup, Verify},
 	BuildStorage,
 };
 
@@ -102,12 +104,22 @@ impl pallet_balances::Config for Test {
 	type MaxFreezes = ();
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, MaxEncodedLen, TypeInfo)]
+pub struct ParameterGet<const N: u32>;
+
+impl<const N: u32> Get<u32> for ParameterGet<N> {
+	fn get() -> u32 {
+		N
+	}
+}
+
+pub type KeyLimit = ParameterGet<32>;
+pub type ValueLimit = ParameterGet<64>;
+
 parameter_types! {
 	pub const CollectionDeposit: MockBalance = 999;
 	pub const ItemDeposit: MockBalance = 333;
 	pub const StringLimit: u32 = 128;
-	pub const KeyLimit: u32 = 32;
-	pub const ValueLimit: u32 = 64;
 	pub const MetadataDepositBase: MockBalance = 1;
 	pub const AttributeDepositBase: MockBalance = 1;
 	pub const DepositPerByte: MockBalance = 1;
@@ -179,6 +191,8 @@ impl pallet_ajuna_nft_transfer::Config for Test {
 	type CollectionId = MockCollectionId;
 	type ItemId = H256;
 	type ItemConfig = pallet_nfts::ItemConfig;
+	type KeyLimit = KeyLimit;
+	type ValueLimit = ValueLimit;
 	type NftHelper = Nft;
 }
 

--- a/pallets/ajuna-nft-transfer/src/tests.rs
+++ b/pallets/ajuna-nft-transfer/src/tests.rs
@@ -93,7 +93,7 @@ mod store_as_nft {
 					Some(item.encode())
 				);
 				assert_eq!(
-					Nft::system_attribute(&collection_id, &item_id, &MockItem::IPFS_URL_CODE),
+					Nft::system_attribute(&collection_id, &item_id, MockItem::IPFS_URL_CODE),
 					Some(url)
 				);
 				for (attribute_code, encoded_attributes) in item.get_encoded_attributes() {

--- a/pallets/ajuna-nft-transfer/src/tests.rs
+++ b/pallets/ajuna-nft-transfer/src/tests.rs
@@ -20,7 +20,7 @@ use frame_support::{
 	assert_err, assert_noop, assert_ok,
 	traits::tokens::nonfungibles_v2::{Create, Inspect},
 };
-use sp_runtime::testing::H256;
+use sp_runtime::{bounded_vec, testing::H256, BoundedVec};
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
 struct MockItem {
@@ -35,19 +35,19 @@ impl Default for MockItem {
 	}
 }
 
-impl NftConvertible for MockItem {
-	const ITEM_CODE: AttributeCode = 1;
-	const IPFS_URL_CODE: AttributeCode = 2;
+impl NftConvertible<KeyLimit, ValueLimit> for MockItem {
+	const ITEM_CODE: &'static [u8] = &[1];
+	const IPFS_URL_CODE: &'static [u8] = &[2];
 
-	fn get_attribute_codes() -> Vec<AttributeCode> {
-		vec![111, 222, 333]
+	fn get_attribute_codes() -> Vec<NFTAttribute<KeyLimit>> {
+		vec![bounded_vec![111], bounded_vec![222], bounded_vec![240]]
 	}
 
-	fn get_encoded_attributes(&self) -> Vec<(AttributeCode, Vec<u8>)> {
+	fn get_encoded_attributes(&self) -> Vec<(NFTAttribute<KeyLimit>, NFTAttribute<ValueLimit>)> {
 		vec![
-			(111, self.field_1.encode()),
-			(222, self.field_2.encode()),
-			(333, self.field_3.encode()),
+			(bounded_vec![111], BoundedVec::try_from(self.field_1.clone()).unwrap()),
+			(bounded_vec![222], BoundedVec::try_from(self.field_2.to_le_bytes().to_vec()).unwrap()),
+			(bounded_vec![240], BoundedVec::try_from(vec![self.field_3 as u8]).unwrap()),
 		]
 	}
 }
@@ -66,6 +66,7 @@ fn create_collection(organizer: MockAccountId) -> MockCollectionId {
 
 mod store_as_nft {
 	use super::*;
+	use sp_runtime::traits::Get;
 
 	#[test]
 	fn can_store_item_successfully() {
@@ -88,21 +89,17 @@ mod store_as_nft {
 				assert_eq!(Nft::collection_owner(collection_id), Some(ALICE));
 				assert_eq!(Nft::owner(collection_id, item_id), Some(BOB));
 				assert_eq!(
-					Nft::system_attribute(&collection_id, &item_id, &MockItem::ITEM_CODE.encode()),
+					Nft::system_attribute(&collection_id, &item_id, MockItem::ITEM_CODE),
 					Some(item.encode())
 				);
 				assert_eq!(
-					Nft::system_attribute(
-						&collection_id,
-						&item_id,
-						&MockItem::IPFS_URL_CODE.encode()
-					),
-					Some(url.encode())
+					Nft::system_attribute(&collection_id, &item_id, &MockItem::IPFS_URL_CODE),
+					Some(url)
 				);
 				for (attribute_code, encoded_attributes) in item.get_encoded_attributes() {
 					assert_eq!(
-						Nft::system_attribute(&collection_id, &item_id, &attribute_code.encode()),
-						Some(encoded_attributes.encode())
+						Nft::system_attribute(&collection_id, &item_id, &attribute_code),
+						Some(encoded_attributes.to_vec())
 					);
 				}
 				assert_eq!(

--- a/pallets/ajuna-nft-transfer/src/traits.rs
+++ b/pallets/ajuna-nft-transfer/src/traits.rs
@@ -3,31 +3,31 @@ use frame_support::{
 	dispatch::{DispatchError, DispatchResult},
 	Parameter,
 };
-use sp_runtime::traits::AtLeast32BitUnsigned;
+use sp_runtime::{traits::AtLeast32BitUnsigned, BoundedVec};
 use sp_std::vec::Vec;
 
 /// Type used to differentiate attribute codes for each item.
-pub type AttributeCode = u16;
+pub type NFTAttribute<N> = BoundedVec<u8, N>;
 
 /// Type to denote an IPFS URL.
 pub type IpfsUrl = Vec<u8>;
 
 /// Marker trait for items that can be converted back and forth into an NFT representation.
-pub trait NftConvertible: Codec {
+pub trait NftConvertible<KL, VL>: Codec {
 	/// Numeric key used to identify this item as an NFT attribute.
-	const ITEM_CODE: AttributeCode;
+	const ITEM_CODE: &'static [u8];
 	/// Numeric key used to identify this item's IPFS URL as an NFT attribute.
-	const IPFS_URL_CODE: AttributeCode;
+	const IPFS_URL_CODE: &'static [u8];
 
 	/// Returns the list of attribute codes associated with this type.
-	fn get_attribute_codes() -> Vec<AttributeCode>;
+	fn get_attribute_codes() -> Vec<NFTAttribute<KL>>;
 
 	/// Returns the list of pairs of attribute code and its encoded attribute.
-	fn get_encoded_attributes(&self) -> Vec<(AttributeCode, Vec<u8>)>;
+	fn get_encoded_attributes(&self) -> Vec<(NFTAttribute<KL>, NFTAttribute<VL>)>;
 }
 
 /// Trait to define the transformation and bridging of NFT items.
-pub trait NftHandler<Account, ItemId, Item: NftConvertible> {
+pub trait NftHandler<Account, ItemId, KL, VL, Item: NftConvertible<KL, VL>> {
 	type CollectionId: AtLeast32BitUnsigned + Codec + Parameter + MaxEncodedLen;
 
 	/// Consumes the given `item` and its associated identifiers, and stores it as an NFT

--- a/runtime/solo/src/lib.rs
+++ b/runtime/solo/src/lib.rs
@@ -529,6 +529,8 @@ impl pallet_ajuna_awesome_avatars::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type Randomness = Randomness;
+	type KeyLimit = KeyLimit;
+	type ValueLimit = ValueLimit;
 	type NftHandler = NftTransfer;
 	type WeightInfo = ();
 }
@@ -599,8 +601,8 @@ impl<const N: u32> Get<u32> for ParameterGet<N> {
 	}
 }
 
-pub type KeyLimit = ParameterGet<8>;
-pub type ValueLimit = ParameterGet<32>;
+pub type KeyLimit = ParameterGet<32>;
+pub type ValueLimit = ParameterGet<64>;
 
 impl pallet_nfts::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
@@ -641,6 +643,8 @@ impl pallet_ajuna_nft_transfer::Config for Runtime {
 	type CollectionId = CollectionId;
 	type ItemId = Hash;
 	type ItemConfig = pallet_nfts::ItemConfig;
+	type KeyLimit = KeyLimit;
+	type ValueLimit = ValueLimit;
 	type NftHelper = Nft;
 }
 


### PR DESCRIPTION
## Description

This PR aims at changing the typing of the NFT attribute in the `NFTConvertible` interface exposed in the `pallet-ajuna-nft-transfer`. Many supporting changes have been applied in order for it to work as expected.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [x] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
