### PR TITLE
[ABO-197] Add orml-vesting to the RelayChain block for Ajuna Network

### DIFF
--- a/runtime/ajuna/src/lib.rs
+++ b/runtime/ajuna/src/lib.rs
@@ -457,14 +457,16 @@ parameter_types! {
 	pub const MinVestedTransfer: Balance = 100 * MICRO_AJUN;
 }
 
+type RelayChainBlockData = cumulus_pallet_parachain_system::RelaychainDataProvider<Runtime>;
+
 impl orml_vesting::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type MinVestedTransfer = MinVestedTransfer;
 	type VestedTransferOrigin = EnsureSigned<AccountId>;
-	type MaxVestingSchedules = frame_support::traits::ConstU32<100>;
-	type BlockNumberProvider = System;
 	type WeightInfo = ();
+	type MaxVestingSchedules = frame_support::traits::ConstU32<100>;
+	type BlockNumberProvider = RelayChainBlockData;
 }
 
 parameter_types! {


### PR DESCRIPTION
## Description

This PR adjusts the `BlockNumberProvider` for the Ajuna runtime so that it uses the relay chain block number instead of the parachain block number for the vesting calculations.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
