### PR TITLE
[ChainSpec] Add `bad_blocks` extension

### DIFF
--- a/node/service/src/chain_spec/ajuna.rs
+++ b/node/service/src/chain_spec/ajuna.rs
@@ -71,7 +71,7 @@ pub fn development_config() -> ChainSpec {
 		Some("ajuna-dev"),
 		None,
 		Some(properties),
-		Extensions { relay_chain: "rococo-local".into(), para_id: PARA_ID },
+		Extensions { relay_chain: "rococo-local".into(), para_id: PARA_ID, bad_blocks: None },
 	)
 }
 
@@ -119,7 +119,7 @@ pub fn local_testnet_config() -> ChainSpec {
 		Some("ajuna-local"),
 		None,
 		Some(properties),
-		Extensions { relay_chain: "rococo-local".into(), para_id: PARA_ID },
+		Extensions { relay_chain: "rococo-local".into(), para_id: PARA_ID, bad_blocks: None },
 	)
 }
 

--- a/node/service/src/chain_spec/bajun.rs
+++ b/node/service/src/chain_spec/bajun.rs
@@ -71,7 +71,7 @@ pub fn development_config() -> ChainSpec {
 		Some("bajun-dev"),
 		None,
 		Some(properties),
-		Extensions { relay_chain: "rococo-local".into(), para_id: PARA_ID },
+		Extensions { relay_chain: "rococo-local".into(), para_id: PARA_ID, bad_blocks: None },
 	)
 }
 
@@ -119,7 +119,7 @@ pub fn local_testnet_config() -> ChainSpec {
 		Some("bajun-local"),
 		None,
 		Some(properties),
-		Extensions { relay_chain: "rococo-local".into(), para_id: PARA_ID },
+		Extensions { relay_chain: "rococo-local".into(), para_id: PARA_ID, bad_blocks: None },
 	)
 }
 

--- a/node/service/src/chain_spec/mod.rs
+++ b/node/service/src/chain_spec/mod.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use ajuna_primitives::{AccountId, AccountPublic};
-use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
+use sc_chain_spec::ChainSpecExtension;
 use serde::{Deserialize, Serialize};
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::IdentifyAccount;
@@ -52,13 +52,15 @@ where
 }
 
 /// The extensions for the [`ChainSpec`].
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ChainSpecGroup, ChainSpecExtension)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ChainSpecExtension)]
 #[serde(deny_unknown_fields)]
 pub struct Extensions {
 	/// The relay chain of the Parachain.
 	pub relay_chain: String,
 	/// The id of the Parachain.
 	pub para_id: u32,
+	/// Know bad block hashes
+	pub bad_blocks: sc_client_api::BadBlocks<ajuna_primitives::Block>,
 }
 
 impl Extensions {


### PR DESCRIPTION
## Description

Adds the option to specify `bad_blocks` extension to the runtime's chain-spec file.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [x] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [ ] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
