### PR TITLE
[ABO-217][Erdstall] Error Description for not owned NFT

### DIFF
--- a/pallets/ajuna-wildcard/src/tests/ext/deposit.rs
+++ b/pallets/ajuna-wildcard/src/tests/ext/deposit.rs
@@ -54,7 +54,7 @@ mod fungible_native {
 	}
 
 	#[test]
-	fn test_token_error_invalid_input() {
+	fn test_token_error_invalid_padding() {
 		ExtBuilder::default().build().execute_with(|| {
 			let asset_deposit = AssetDeposit {
 				origin: CHAIN_ID,
@@ -65,7 +65,7 @@ mod fungible_native {
 
 			assert_noop!(
 				Wildcard::deposit(RuntimeOrigin::signed(ALICE), asset_deposit),
-				Error::<Test>::InvalidInput
+				Error::<Test>::InvalidNativeFungiblePadding
 			);
 		});
 	}
@@ -242,7 +242,7 @@ mod fungible_foreign {
 	}
 
 	#[test]
-	fn test_error_invalid_input() {
+	fn test_error_invalid_padding() {
 		ExtBuilder::default().build().execute_with(|| {
 			let asset_deposit = AssetDeposit {
 				origin: FOREIGN_CHAIN_ID,
@@ -253,7 +253,7 @@ mod fungible_foreign {
 
 			assert_noop!(
 				Wildcard::deposit(RuntimeOrigin::signed(ALICE), asset_deposit),
-				Error::<Test>::InvalidInput
+				Error::<Test>::InvalidNativeFungiblePadding
 			);
 		});
 	}
@@ -345,7 +345,7 @@ mod non_fungible {
 
 			assert_noop!(
 				Wildcard::deposit(RuntimeOrigin::signed(ALICE), asset_deposit),
-				Error::<Test>::InvalidInput
+				Error::<Test>::ReserveNonFungibleWithoutOwner
 			);
 
 			let (primary_id, secondary_id) = generate_native_non_fungible_wide_id(3, 1);
@@ -359,7 +359,7 @@ mod non_fungible {
 
 			assert_noop!(
 				Wildcard::deposit(RuntimeOrigin::signed(ALICE), asset_deposit),
-				Error::<Test>::InvalidInput
+				Error::<Test>::InvalidNativeFungiblePadding
 			);
 		});
 	}
@@ -484,7 +484,7 @@ mod non_fungible {
 
 			assert_noop!(
 				Wildcard::deposit(RuntimeOrigin::signed(ALICE), asset_deposit),
-				Error::<Test>::InvalidInput
+				Error::<Test>::ReserveNonFungibleWithoutOwner
 			);
 
 			let collection_id = create_collection(&ALICE);
@@ -505,7 +505,7 @@ mod non_fungible {
 
 			assert_noop!(
 				Wildcard::deposit(RuntimeOrigin::signed(ALICE), asset_deposit),
-				Error::<Test>::InvalidInput
+				Error::<Test>::ReserveNonFungibleWithoutOwner
 			);
 		});
 	}
@@ -568,7 +568,7 @@ mod non_fungible {
 
 			assert_noop!(
 				Wildcard::deposit(RuntimeOrigin::signed(ALICE), asset_deposit),
-				Error::<Test>::InvalidInput
+				Error::<Test>::ReserveNonFungibleWithoutOwner
 			);
 		});
 	}

--- a/pallets/ajuna-wildcard/src/tests/ext/withdraw.rs
+++ b/pallets/ajuna-wildcard/src/tests/ext/withdraw.rs
@@ -183,7 +183,7 @@ mod fungible_native {
 
 				assert_noop!(
 					Wildcard::withdraw(RuntimeOrigin::signed(ALICE), proof_err, signature),
-					Error::<Test>::InvalidInput
+					Error::<Test>::NativeAssetMappingNotFound
 				);
 
 				let invalid_signature = sp_core::sr25519::Signature([34; 64]);
@@ -306,7 +306,7 @@ mod fungible_native {
 
 			assert_noop!(
 				Wildcard::withdraw(RuntimeOrigin::signed(ALICE), proof_err, signature),
-				Error::<Test>::InvalidInput
+				Error::<Test>::NativeAssetMappingNotFound
 			);
 		});
 	}
@@ -422,7 +422,7 @@ mod fungible_foreign {
 
 			assert_noop!(
 				Wildcard::withdraw(RuntimeOrigin::signed(ALICE), proof_err, signature),
-				Error::<Test>::InvalidInput
+				Error::<Test>::NativeAssetMappingNotFound
 			);
 
 			let proof = BalanceProof {
@@ -526,7 +526,7 @@ mod non_fungible {
 
 			assert_noop!(
 				Wildcard::withdraw(RuntimeOrigin::signed(ALICE), proof_err, signature),
-				Error::<Test>::InvalidInput
+				Error::<Test>::NativeAssetMappingNotFound
 			);
 
 			let proof = BalanceProof::using_deposit(&deposit, now, ALICE, true, 0);


### PR DESCRIPTION
## Description

* Removes the `InvalidInput` and `UnknownDeposit` error enums for more descriptive variants.
* Adds documentation message to all error variants.

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [x] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [x] Tests for the changes have been added
- [x] Necessary documentation is added (if appropriate)
- [x] Formatted with `cargo fmt --all`
- [x] Linted with `cargo clippy --all-features --all-targets`
- [x] Tested with `cargo test --workspace --all-features --all-targets`
