### PR TITLE
[ABO-219] Adjust call filter

### DIFF
--- a/runtime/bajun/src/lib.rs
+++ b/runtime/bajun/src/lib.rs
@@ -78,7 +78,7 @@ use staging_xcm_executor::XcmExecutor;
 use ajuna_primitives::{
 	AccountId, AccountPublic, Balance, BlockNumber, CollectionId, Hash, Header, Nonce, Signature,
 };
-use pallet_nfts::Call as NftsCall;
+use pallet_nfts::{AttributeNamespace, Call as NftsCall};
 
 /// The address format for describing accounts.
 pub type Address = MultiAddress<AccountId, ()>;
@@ -258,7 +258,15 @@ parameter_types! {
 pub struct BaseCallFilter;
 impl Contains<RuntimeCall> for BaseCallFilter {
 	fn contains(call: &RuntimeCall) -> bool {
-		!matches!(call, RuntimeCall::Nft(NftsCall::set_attribute { .. }))
+		match call {
+			RuntimeCall::Nft(NftsCall::set_attribute { namespace, .. })
+				if namespace == &AttributeNamespace::CollectionOwner =>
+				true,
+			RuntimeCall::Nft(NftsCall::set_attribute { namespace, .. })
+				if namespace != &AttributeNamespace::CollectionOwner =>
+				false,
+			_ => true,
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

* Adjusts call filter for bajun runtime so that the `pallet_nfts::set_attribute` extrinsic can be called if the namespace parameters is set to `CollectionOwner`

## Type of changes

- [ ] `build`: Changes that affect the build system or external dependencies (eg, Cargo, Docker)
- [ ] `ci`: Changes to CI configuration
- [ ] `docs`: Changes to documentation only
- [ ] `feat`: Changes to add a new feature
- [ ] `fix`: Changes to fix a bug
- [x] `refactor`: Changes that do not alter functionality
- [ ] `style`: Changes to format the code
- [ ] `test`: Changes to add missing tests or correct existing tests

## Checklist

- [ ] Tests for the changes have been added
- [ ] Necessary documentation is added (if appropriate)
- [ ] Formatted with `cargo fmt --all`
- [ ] Linted with `cargo clippy --all-features --all-targets`
- [ ] Tested with `cargo test --workspace --all-features --all-targets`
