### PR TITLE
Add governance config for solo node.

### DIFF
--- a/node/service/src/chain_spec/solo.rs
+++ b/node/service/src/chain_spec/solo.rs
@@ -17,7 +17,7 @@
 use crate::chain_spec::{chain_spec_properties, get_well_known_accounts};
 use ajuna_primitives::Balance;
 use ajuna_solo_runtime::{
-	currency::AJUNS, AssetsConfig, AuraConfig, BalancesConfig, CouncilConfig, GrandpaConfig,
+	currency::AJUNS, AssetsConfig, AuraConfig, BalancesConfig, CouncilConfig, TechnicalCommitteeConfig, GrandpaConfig,
 	RuntimeGenesisConfig, SudoConfig, SystemConfig, VestingConfig, WASM_BINARY,
 };
 use sc_service::ChainType;
@@ -71,6 +71,7 @@ struct Config {
 	grandpa: GrandpaConfig,
 	sudo: SudoConfig,
 	council: CouncilConfig,
+	technical_committee: TechnicalCommitteeConfig,
 	balances: BalancesConfig,
 	assets: AssetsConfig,
 	vesting: VestingConfig,
@@ -95,6 +96,10 @@ fn development_config_genesis() -> RuntimeGenesisConfig {
 		grandpa: GrandpaConfig { authorities: grandpa_authorities, ..Default::default() },
 		sudo: SudoConfig { key: Some(accounts.alice.clone()) },
 		council: CouncilConfig {
+			members: vec![accounts.bob.clone(), accounts.charlie.clone(), accounts.dave.clone()],
+			phantom: Default::default(),
+		},
+		technical_committee: TechnicalCommitteeConfig {
 			members: vec![accounts.bob.clone(), accounts.charlie.clone(), accounts.dave.clone()],
 			phantom: Default::default(),
 		},
@@ -161,6 +166,7 @@ fn testnet_config_genesis() -> RuntimeGenesisConfig {
 		},
 		sudo: SudoConfig { key: Some(accounts.alice.clone()) },
 		council: CouncilConfig::default(),
+		technical_committee: TechnicalCommitteeConfig::default(),
 		balances: BalancesConfig {
 			balances: vec![
 				(accounts.alice, INITIAL_BALANCE),
@@ -187,20 +193,20 @@ fn compose_genesis_config(config: Config) -> RuntimeGenesisConfig {
 	let wasm_binary = WASM_BINARY.expect(
 		"Development wasm binary is not available. Please rebuild with SKIP_WASM_BUILD disabled.",
 	);
-	let Config { aura, grandpa, sudo, council, balances, assets, vesting } = config;
+	let Config { aura, grandpa, sudo, council, technical_committee, balances, assets, vesting } = config;
 	RuntimeGenesisConfig {
 		// overridden config
 		aura,
 		grandpa,
 		sudo,
 		council,
+		technical_committee,
 		balances,
 		assets,
 		vesting,
 		// default config
 		system: SystemConfig { code: wasm_binary.to_vec(), ..Default::default() },
 		transaction_payment: Default::default(),
-		council_membership: Default::default(),
 		treasury: Default::default(),
 		democracy: Default::default(),
 		awesome_avatars: Default::default(),

--- a/node/service/src/chain_spec/solo.rs
+++ b/node/service/src/chain_spec/solo.rs
@@ -107,7 +107,7 @@ fn development_config_genesis() -> RuntimeGenesisConfig {
 			phantom: Default::default(),
 		},
 		technical_committee: TechnicalCommitteeConfig {
-			members: vec![accounts.bob.clone(), accounts.charlie.clone(), accounts.dave.clone()],
+			members: vec![accounts.alice.clone(), accounts.bob.clone(), accounts.charlie.clone()],
 			phantom: Default::default(),
 		},
 		balances: BalancesConfig {

--- a/node/service/src/chain_spec/solo.rs
+++ b/node/service/src/chain_spec/solo.rs
@@ -17,8 +17,9 @@
 use crate::chain_spec::{chain_spec_properties, get_well_known_accounts};
 use ajuna_primitives::Balance;
 use ajuna_solo_runtime::{
-	currency::AJUNS, AssetsConfig, AuraConfig, BalancesConfig, CouncilConfig, TechnicalCommitteeConfig, GrandpaConfig,
-	RuntimeGenesisConfig, SudoConfig, SystemConfig, VestingConfig, WASM_BINARY,
+	currency::AJUNS, AssetsConfig, AuraConfig, BalancesConfig, CouncilConfig, GrandpaConfig,
+	RuntimeGenesisConfig, SudoConfig, SystemConfig, TechnicalCommitteeConfig, VestingConfig,
+	WASM_BINARY,
 };
 use sc_service::ChainType;
 
@@ -96,7 +97,13 @@ fn development_config_genesis() -> RuntimeGenesisConfig {
 		grandpa: GrandpaConfig { authorities: grandpa_authorities, ..Default::default() },
 		sudo: SudoConfig { key: Some(accounts.alice.clone()) },
 		council: CouncilConfig {
-			members: vec![accounts.bob.clone(), accounts.charlie.clone(), accounts.dave.clone()],
+			members: vec![
+				accounts.alice.clone(),
+				accounts.bob.clone(),
+				accounts.charlie.clone(),
+				accounts.dave.clone(),
+				accounts.eve.clone(),
+			],
 			phantom: Default::default(),
 		},
 		technical_committee: TechnicalCommitteeConfig {
@@ -193,7 +200,8 @@ fn compose_genesis_config(config: Config) -> RuntimeGenesisConfig {
 	let wasm_binary = WASM_BINARY.expect(
 		"Development wasm binary is not available. Please rebuild with SKIP_WASM_BUILD disabled.",
 	);
-	let Config { aura, grandpa, sudo, council, technical_committee, balances, assets, vesting } = config;
+	let Config { aura, grandpa, sudo, council, technical_committee, balances, assets, vesting } =
+		config;
 	RuntimeGenesisConfig {
 		// overridden config
 		aura,

--- a/runtime/solo/src/gov.rs
+++ b/runtime/solo/src/gov.rs
@@ -80,7 +80,7 @@ impl pallet_collective::Config<CouncilCollective> for Runtime {
 	type MotionDuration = CouncilMotionDuration;
 	type MaxProposals = ConstU32<100>;
 	type MaxMembers = ConstU32<100>;
-	type DefaultVote = pallet_collective::PrimeDefaultVote;
+	type DefaultVote = pallet_collective::MoreThanMajorityThenPrimeDefaultVote;
 	type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
 	type SetMembersOrigin = EnsureRootOrMoreThanHalfCouncil;
 	type MaxProposalWeight = MaxProposalWeight;

--- a/runtime/solo/src/gov.rs
+++ b/runtime/solo/src/gov.rs
@@ -53,6 +53,8 @@ impl<
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn try_successful_origin() -> Result<O, ()> {
+		use parity_scale_codec::Decode;
+		use sp_runtime::traits::TrailingZeroInput;
 		let zero_account_id =
 			<AccountIdFor<T>>::decode(&mut TrailingZeroInput::zeroes()).map_err(|_| ())?;
 		Ok(O::from(RawOrigin::Signed(zero_account_id)))

--- a/runtime/solo/src/gov.rs
+++ b/runtime/solo/src/gov.rs
@@ -1,0 +1,119 @@
+use crate::{BlockWeights, OriginCaller, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, DAYS};
+use ajuna_primitives::{AccountId, Balance, BlockNumber};
+use frame_support::{
+	parameter_types,
+	traits::{ConstBool, ConstU32, EitherOfDiverse},
+	weights::Weight,
+};
+use frame_system::{EnsureRoot, EnsureSigned};
+use pallet_collective::{EnsureProportionAtLeast, EnsureProportionMoreThan};
+use sp_runtime::Perbill;
+
+pub type EnsureRootOrMoreThanHalfCouncil = EitherOfDiverse<
+	EnsureRoot<AccountId>,
+	EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
+>;
+
+pub type EnsureRootOrMoreThanHalfTechnicalCommittee = EitherOfDiverse<
+	EnsureRoot<AccountId>,
+	EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 2>,
+>;
+
+pub type EnsureRootOrAllTechnicalCommittee = EitherOfDiverse<
+	EnsureRoot<AccountId>,
+	EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 1>,
+>;
+
+/// Council collective instance declaration.
+///
+/// The council primarily serves to optimize and balance the inclusive referendum system,
+/// by being allowed to propose external democracy proposals, which can be fast tracked and
+/// bypass the one active referendum at a time rule.
+///
+/// It also control the treasury.
+type CouncilCollective = pallet_collective::Instance1;
+
+parameter_types! {
+	pub CouncilMotionDuration: BlockNumber = 3 * DAYS;
+	pub MaxProposalWeight: Weight = Perbill::from_percent(50) * BlockWeights::get().max_block;
+}
+
+impl pallet_collective::Config<CouncilCollective> for Runtime {
+	type RuntimeOrigin = RuntimeOrigin;
+	type Proposal = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type MotionDuration = CouncilMotionDuration;
+	type MaxProposals = ConstU32<100>;
+	type MaxMembers = ConstU32<100>;
+	type DefaultVote = pallet_collective::PrimeDefaultVote;
+	type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
+	type SetMembersOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type MaxProposalWeight = MaxProposalWeight;
+}
+
+/// The technical committee primarily serves to safeguard against malicious referenda,
+/// and fast track critical referenda.
+pub type TechnicalCommitteeInstance = pallet_collective::Instance2;
+
+parameter_types! {
+	pub const TechnicalMotionDuration: BlockNumber = 3 * DAYS;
+}
+
+impl pallet_collective::Config<TechnicalCommitteeInstance> for Runtime {
+	type RuntimeOrigin = RuntimeOrigin;
+	type Proposal = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	// The maximum amount of time (in blocks) for technical committee members to vote on motions.
+	// Motions may end in fewer blocks if enough votes are cast to determine the result.
+	type MotionDuration = TechnicalMotionDuration;
+	type MaxProposals = ConstU32<100>;
+	type MaxMembers = ConstU32<100>;
+	type DefaultVote = pallet_collective::MoreThanMajorityThenPrimeDefaultVote;
+	type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
+	type SetMembersOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type MaxProposalWeight = MaxProposalWeight;
+}
+
+parameter_types! {
+	pub const ThirtyDays: BlockNumber = 30 * DAYS;
+	pub const TwentyEightDays: BlockNumber = 28 * DAYS;
+	pub const ThreeDays: BlockNumber = 3 * DAYS;
+	pub const MinimumDeposit: Balance = 1;
+	pub EnactmentPeriod: BlockNumber = 7 * DAYS;
+}
+
+impl pallet_democracy::Config for Runtime {
+	type WeightInfo = pallet_democracy::weights::SubstrateWeight<Runtime>;
+	type RuntimeEvent = RuntimeEvent;
+	type Scheduler = pallet_scheduler::Pallet<Runtime>;
+	type Preimages = pallet_preimage::Pallet<Runtime>;
+	type Currency = pallet_balances::Pallet<Runtime>;
+	type EnactmentPeriod = EnactmentPeriod;
+	type LaunchPeriod = TwentyEightDays;
+	type VotingPeriod = TwentyEightDays;
+	type VoteLockingPeriod = EnactmentPeriod;
+	type MinimumDeposit = MinimumDeposit;
+	type InstantAllowed = ConstBool<true>;
+	type FastTrackVotingPeriod = ThreeDays;
+	type CooloffPeriod = TwentyEightDays;
+	type MaxVotes = ConstU32<100>;
+	type MaxProposals = ConstU32<100>;
+	type MaxDeposits = ConstU32<100>;
+	type MaxBlacklisted = ConstU32<100>;
+	type ExternalOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type ExternalMajorityOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type ExternalDefaultOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type SubmitOrigin = EnsureSigned<AccountId>;
+	type FastTrackOrigin = EnsureRootOrMoreThanHalfTechnicalCommittee;
+	type InstantOrigin = EnsureRootOrMoreThanHalfTechnicalCommittee;
+	// To cancel a proposal that has passed.
+	type CancellationOrigin = EnsureRoot<AccountId>;
+	type BlacklistOrigin = EnsureRootOrMoreThanHalfCouncil;
+	// To cancel a proposal before it has passed, and slash its backers.
+	type CancelProposalOrigin = EnsureRootOrAllTechnicalCommittee;
+	// Any single technical committee member may veto a coming council proposal, however they can
+	// only do it once and it lasts only for the cooloff period.
+	type VetoOrigin = pallet_collective::EnsureMember<AccountId, TechnicalCommitteeInstance>;
+	type PalletsOrigin = OriginCaller;
+	type Slash = pallet_treasury::Pallet<Runtime>;
+}

--- a/runtime/solo/src/gov.rs
+++ b/runtime/solo/src/gov.rs
@@ -6,7 +6,7 @@ use frame_support::{
 	weights::Weight,
 };
 use frame_system::{EnsureRoot, EnsureSigned};
-use pallet_collective::{EnsureProportionAtLeast, EnsureProportionMoreThan};
+use pallet_collective::{EnsureMember, EnsureProportionAtLeast, EnsureProportionMoreThan};
 use sp_runtime::Perbill;
 
 pub type EnsureRootOrMoreThanHalfCouncil = EitherOfDiverse<
@@ -103,7 +103,9 @@ impl pallet_democracy::Config for Runtime {
 	type ExternalOrigin = EnsureRootOrMoreThanHalfCouncil;
 	type ExternalMajorityOrigin = EnsureRootOrMoreThanHalfCouncil;
 	type ExternalDefaultOrigin = EnsureRootOrMoreThanHalfCouncil;
-	type SubmitOrigin = EnsureSigned<AccountId>;
+	// Initially, we want that only the council can submit proposals to
+	// prevent malicious proposals.
+	type SubmitOrigin = EnsureMember<AccountId, CouncilCollective>;
 	type FastTrackOrigin = EnsureRootOrMoreThanHalfTechnicalCommittee;
 	type InstantOrigin = EnsureRootOrMoreThanHalfTechnicalCommittee;
 	// To cancel a proposal that has passed.
@@ -113,7 +115,7 @@ impl pallet_democracy::Config for Runtime {
 	type CancelProposalOrigin = EnsureRootOrAllTechnicalCommittee;
 	// Any single technical committee member may veto a coming council proposal, however they can
 	// only do it once and it lasts only for the cooloff period.
-	type VetoOrigin = pallet_collective::EnsureMember<AccountId, TechnicalCommitteeInstance>;
+	type VetoOrigin = EnsureMember<AccountId, TechnicalCommitteeInstance>;
 	type PalletsOrigin = OriginCaller;
 	type Slash = pallet_treasury::Pallet<Runtime>;
 }

--- a/runtime/solo/src/gov.rs
+++ b/runtime/solo/src/gov.rs
@@ -1,4 +1,6 @@
-use crate::{BlockWeights, OriginCaller, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, DAYS};
+use crate::{
+	BlockWeights, OriginCaller, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, AJUNS, DAYS,
+};
 use ajuna_primitives::{AccountId, Balance, BlockNumber};
 use frame_support::{
 	dispatch::RawOrigin,
@@ -108,11 +110,11 @@ impl pallet_collective::Config<TechnicalCommitteeInstance> for Runtime {
 }
 
 parameter_types! {
-	pub const ThirtyDays: BlockNumber = 30 * DAYS;
-	pub const TwentyEightDays: BlockNumber = 28 * DAYS;
 	pub const ThreeDays: BlockNumber = 3 * DAYS;
-	pub const MinimumDeposit: Balance = 1;
+	pub const TwentyEightDays: BlockNumber = 28 * DAYS;
+	pub const ThirtyDays: BlockNumber = 30 * DAYS;
 	pub EnactmentPeriod: BlockNumber = 7 * DAYS;
+	pub const MinimumDeposit: Balance = 1 * AJUNS;
 }
 
 impl pallet_democracy::Config for Runtime {

--- a/runtime/solo/src/gov.rs
+++ b/runtime/solo/src/gov.rs
@@ -45,8 +45,7 @@ impl<
 	type Success = AccountIdFor<T>;
 	fn try_origin(o: O) -> Result<Self::Success, O> {
 		o.into().and_then(|o| match o {
-			RawOrigin::Signed(a) if pallet_collective::Pallet::<T, I>::is_member(&a) =>
-				Ok(a.into()),
+			RawOrigin::Signed(a) if pallet_collective::Pallet::<T, I>::is_member(&a) => Ok(a),
 			r => Err(O::from(r)),
 		})
 	}
@@ -114,7 +113,7 @@ parameter_types! {
 	pub const TwentyEightDays: BlockNumber = 28 * DAYS;
 	pub const ThirtyDays: BlockNumber = 30 * DAYS;
 	pub EnactmentPeriod: BlockNumber = 7 * DAYS;
-	pub const MinimumDeposit: Balance = 1 * AJUNS;
+	pub const MinimumDeposit: Balance = AJUNS;
 }
 
 impl pallet_democracy::Config for Runtime {

--- a/runtime/solo/src/gov.rs
+++ b/runtime/solo/src/gov.rs
@@ -65,7 +65,7 @@ impl<
 /// by being allowed to propose external democracy proposals, which can be fast tracked and
 /// bypass the one active referendum at a time rule.
 ///
-/// It also control the treasury.
+/// It also controls the treasury.
 type CouncilCollective = pallet_collective::Instance1;
 
 parameter_types! {
@@ -98,8 +98,6 @@ impl pallet_collective::Config<TechnicalCommitteeInstance> for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 	type Proposal = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
-	// The maximum amount of time (in blocks) for technical committee members to vote on motions.
-	// Motions may end in fewer blocks if enough votes are cast to determine the result.
 	type MotionDuration = TechnicalMotionDuration;
 	type MaxProposals = ConstU32<100>;
 	type MaxMembers = ConstU32<100>;

--- a/runtime/solo/src/gov.rs
+++ b/runtime/solo/src/gov.rs
@@ -5,7 +5,7 @@ use frame_support::{
 	traits::{ConstBool, ConstU32, EitherOfDiverse},
 	weights::Weight,
 };
-use frame_system::{EnsureRoot, EnsureSigned};
+use frame_system::EnsureRoot;
 use pallet_collective::{EnsureMember, EnsureProportionAtLeast, EnsureProportionMoreThan};
 use sp_runtime::Perbill;
 

--- a/runtime/solo/src/lib.rs
+++ b/runtime/solo/src/lib.rs
@@ -84,9 +84,9 @@ impl_opaque_keys! {
 }
 
 parameter_types! {
-	pub const TwoWeeks: BlockNumber = 14 * DAYS;
-	pub const OneWeek: BlockNumber = 7 * DAYS;
 	pub const OneDay: BlockNumber = DAYS;
+	pub const OneWeek: BlockNumber = 7 * DAYS;
+	pub const TwoWeeks: BlockNumber = 14 * DAYS;
 }
 
 // To learn more about runtime versioning and what each of the following value means:
@@ -641,7 +641,6 @@ construct_runtime!(
 		Council: pallet_collective::<Instance1> = 9,
 		// pub type TechnicalCommitteeInstance = pallet_collective::Instance2;
 		TechnicalCommittee: pallet_collective::<Instance2> = 10,
-		// CouncilMembership: pallet_membership::<Instance2> = 10,
 		Treasury: pallet_treasury = 11,
 		Democracy: pallet_democracy = 12,
 		Sudo: pallet_sudo = 13,

--- a/runtime/solo/src/types.rs
+++ b/runtime/solo/src/types.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pub mod governance {
-	use crate::CouncilCollective;
+	use crate::{CouncilCollective, TechnicalCommitteeInstance};
 	use ajuna_primitives::AccountId;
 	use frame_support::traits::EitherOfDiverse;
 	use frame_system::EnsureRoot;
@@ -25,16 +25,16 @@ pub mod governance {
 		EnsureRoot<AccountId>,
 		EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
 	>;
-	pub(crate) type EnsureRootOrAtLeastTwoThirdsCouncil = EitherOfDiverse<
+
+	pub type EnsureRootOrMoreThanHalfTechnicalCommittee = EitherOfDiverse<
 		EnsureRoot<AccountId>,
-		EnsureProportionAtLeast<AccountId, CouncilCollective, 2, 3>,
+		EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 2>,
 	>;
 
-	pub(crate) type EnsureAtLeastHalfCouncil =
-		EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 2>;
-	pub(crate) type EnsureAtLeastThreeFourthsCouncil =
-		EnsureProportionAtLeast<AccountId, CouncilCollective, 3, 4>;
-	pub(crate) type EnsureAllCouncil = EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 1>;
+	pub type EnsureRootOrAllTechnicalCommittee = EitherOfDiverse<
+		EnsureRoot<AccountId>,
+		EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 1>,
+	>;
 }
 
 pub mod proxy {

--- a/runtime/solo/src/types.rs
+++ b/runtime/solo/src/types.rs
@@ -14,29 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub mod governance {
-	use crate::{CouncilCollective, TechnicalCommitteeInstance};
-	use ajuna_primitives::AccountId;
-	use frame_support::traits::EitherOfDiverse;
-	use frame_system::EnsureRoot;
-	use pallet_collective::{EnsureProportionAtLeast, EnsureProportionMoreThan};
-
-	pub(crate) type EnsureRootOrMoreThanHalfCouncil = EitherOfDiverse<
-		EnsureRoot<AccountId>,
-		EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
-	>;
-
-	pub type EnsureRootOrMoreThanHalfTechnicalCommittee = EitherOfDiverse<
-		EnsureRoot<AccountId>,
-		EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 2>,
-	>;
-
-	pub type EnsureRootOrAllTechnicalCommittee = EitherOfDiverse<
-		EnsureRoot<AccountId>,
-		EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 1>,
-	>;
-}
-
 pub mod proxy {
 	use frame_support::{
 		pallet_prelude::MaxEncodedLen, traits::InstanceFilter, RuntimeDebugNoBound,


### PR DESCRIPTION
Add Governance config to solo-node.

I think most of the things are self-explanatory. I have removed the membership pallet for managing our collective instances, because I thought that it introduces many more configurations with little benefit, which might be the most controversial decision. However, we decided the same at Integritee and we never regretted.

## Tests 
- [x] Only council can propose, all other accounts get a bad origin error.
- [x] External council motion works
- [x] Fast track works
- [x] execution of a root proposal works

These are the critical tests in my opinion. These are the crucial things that need to work to guarantee, we can still execute root stuff, and if needed execute it fast with fast track. All other things that can go wrong with governance are minor config things, and could still be fixed.