### PR TITLE
Add CI job for checking missing migrations and fix the missing `PolkadotXcm` migration for ajuna

### DIFF
--- a/.github/workflows/check-migration.yml
+++ b/.github/workflows/check-migration.yml
@@ -1,0 +1,74 @@
+name: Check Migrations
+
+on:
+  push:
+    branches: ["develop"]
+  pull_request:
+    branches: ["develop"]
+  workflow_dispatch:
+
+# Cancel a currently running workflow from the same PR, branch or tag when a new workflow is
+# triggered (ref https://stackoverflow.com/a/72408109)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  runtime-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      runtime: ${{ steps.runtime.outputs.runtime }}
+    name: Extract tasks from matrix
+    steps:
+      - uses: actions/checkout@v2
+      - id: runtime
+        run: |
+          # Filter out runtimes that don't have a URI
+          TASKS=$(jq '[.[] | select(.uri != null)]' .github/workflows/runtimes-matrix.json)
+          SKIPPED_TASKS=$(jq '[.[] | select(.uri == null)]' .github/workflows/runtimes-matrix.json)
+          echo --- Running the following tasks ---
+          echo $TASKS
+          echo --- Skipping the following tasks due to not having a uri field ---
+          echo $SKIPPED_TASKS
+          # Strip whitespace from Tasks now that we've logged it
+          TASKS=$(echo $TASKS | jq -c .)
+          echo "runtime=$TASKS" >> $GITHUB_OUTPUT
+
+  check-migrations:
+    needs: [runtime-matrix]
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runtime: ${{ fromJSON(needs.runtime-matrix.outputs.runtime) }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Download try-runtime-cli
+        run: |
+          curl -sL https://github.com/paritytech/try-runtime-cli/releases/download/v0.5.2/try-runtime-x86_64-unknown-linux-musl -o try-runtime
+          chmod +x ./try-runtime
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: "3.6.1"
+
+      - name: Add wasm32-unknown-unknown target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Build ${{ matrix.runtime.name }}
+        run: |
+          cargo build --release -p ${{ matrix.runtime.package }} --features try-runtime -q --locked
+
+      - name: Check migrations
+        run: |
+          PACKAGE_NAME=${{ matrix.runtime.package }}
+          RUNTIME_BLOB_NAME=$(echo $PACKAGE_NAME | sed 's/-/_/g').compact.compressed.wasm
+          RUNTIME_BLOB_PATH=./target/release/wbuild/$PACKAGE_NAME/$RUNTIME_BLOB_NAME
+
+          ./try-runtime \
+            --runtime $RUNTIME_BLOB_PATH \
+            on-runtime-upgrade --checks=pre-and-post \
+            live --uri ${{ matrix.runtime.uri }}

--- a/.github/workflows/check-migration.yml
+++ b/.github/workflows/check-migration.yml
@@ -20,7 +20,7 @@ jobs:
       runtime: ${{ steps.runtime.outputs.runtime }}
     name: Extract tasks from matrix
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: runtime
         run: |
           # Filter out runtimes that don't have a URI
@@ -63,6 +63,7 @@ jobs:
           cargo build --release -p ${{ matrix.runtime.package }} --features try-runtime -q --locked
 
       - name: Check migrations
+        # Todo: enable spec-version-check dynamically if we are releasing
         run: |
           PACKAGE_NAME=${{ matrix.runtime.package }}
           RUNTIME_BLOB_NAME=$(echo $PACKAGE_NAME | sed 's/-/_/g').compact.compressed.wasm
@@ -71,4 +72,5 @@ jobs:
           ./try-runtime \
             --runtime $RUNTIME_BLOB_PATH \
             on-runtime-upgrade --checks=pre-and-post \
+            --disable-spec-version-check --disable-idempotency-checks \
             live --uri ${{ matrix.runtime.uri }}

--- a/.github/workflows/check-migration.yml
+++ b/.github/workflows/check-migration.yml
@@ -2,9 +2,9 @@ name: Check Migrations
 
 on:
   push:
-    branches: ["develop"]
+    branches: ["develop", "ajuna-stable" ]
   pull_request:
-    branches: ["develop"]
+    branches: ["develop", "ajuna-stable"]
   workflow_dispatch:
 
 # Cancel a currently running workflow from the same PR, branch or tag when a new workflow is

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - develop
+      - ajuna-stable
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -14,6 +15,7 @@ on:
   push:
     branches:
       - develop
+      - ajuna-stable
 
 # Ensures only one build is run per branch, unless pushing to develop
 concurrency:

--- a/.github/workflows/runtimes-matrix.json
+++ b/.github/workflows/runtimes-matrix.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "bajun",
+    "package": "bajun-runtime",
+    "path": "runtime/bajun-runtime",
+    "uri": "wss://rpc-parachain.bajun.network:433"
+  }
+]

--- a/.github/workflows/runtimes-matrix.json
+++ b/.github/workflows/runtimes-matrix.json
@@ -1,8 +1,8 @@
 [
   {
-    "name": "bajun",
-    "package": "bajun-runtime",
-    "path": "runtime/bajun-runtime",
-    "uri": "wss://rpc-parachain.bajun.network:433"
+    "name": "ajuna",
+    "package": "ajuna-runtime",
+    "path": "runtime/ajuna-runtime",
+    "uri": "wss://rpc-parachain.ajuna.network:443"
   }
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,6 @@ dependencies = [
  "sp-runtime",
  "sp-timestamp",
  "substrate-build-script-utils",
- "try-runtime-cli",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -64,3 +64,19 @@ A game platform [parachain](https://wiki.polkadot.network/docs/learn-parachains)
   # parachain with rococo-local relay chain
   docker-compose -f docker/parachain.yml up
   ```
+
+
+## Check state migrations
+
+```bash
+curl -sL https://github.com/paritytech/try-runtime-cli/releases/download/v0.5.2/try-runtime-x86_64-unknown-linux-musl -o try-runtime
+chmod +x ./try-runtime
+
+# check state migrations with state fetched from the remote chain.
+../bin/try-runtime \
+  --runtime ./target/release/wbuild/ajuna-solo-runtime/ajuna_solo_runtime.wasm \
+  on-runtime-upgrade --checks=pre-and-post \
+  live --uri wss://rpc-parachain.bajun.network:443
+```
+
+This is also executed in the check-migration.yml CI.

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -44,8 +44,6 @@ sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polk
 sc-tracing   = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", optional = true }
 sp-io        = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", optional = true }
 
-try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", optional = true }
-
 # Polkadot
 polkadot-cli        = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.42", optional = true }
 polkadot-parachain  = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.42", optional = true }
@@ -84,11 +82,10 @@ runtime-benchmarks = [
     "polkadot-cli?/runtime-benchmarks",
 ]
 
-cli         = [ "try-runtime-cli" ]
+cli         = [ ]
 try-runtime = [
     "ajuna-service/try-runtime",
     "polkadot-cli?/try-runtime",
     "sc-executor",
     "sp-io",
-    "try-runtime-cli/try-runtime"
 ]

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -81,8 +81,14 @@ rococo-native   = [ "polkadot-cli/rococo-native" ]
 
 runtime-benchmarks = [
     "ajuna-service/runtime-benchmarks",
-    "polkadot-cli/runtime-benchmarks",
+    "polkadot-cli?/runtime-benchmarks",
 ]
 
 cli         = [ "try-runtime-cli" ]
-try-runtime = [ "try-runtime-cli/try-runtime", "sc-executor", "sp-io" ]
+try-runtime = [
+    "ajuna-service/try-runtime",
+    "polkadot-cli?/try-runtime",
+    "sc-executor",
+    "sp-io",
+    "try-runtime-cli/try-runtime"
+]

--- a/node/cli/src/para/cli.rs
+++ b/node/cli/src/para/cli.rs
@@ -52,12 +52,9 @@ pub enum Subcommand {
 	#[clap(subcommand)]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 
-	/// Try some testing command against a specified runtime state.
-	#[cfg(feature = "try-runtime")]
-	TryRuntime(try_runtime_cli::TryRuntimeCmd),
-
-	/// Errors since the binary was not build with `--features try-runtime`.
-	#[cfg(not(feature = "try-runtime"))]
+	/// Try-runtime has migrated to a standalone
+	/// [CLI](<https://github.com/paritytech/try-runtime-cli>). The subcommand exists as a stub and
+	/// deprecation notice. It will be removed entirely some time after Janurary 2024.
 	TryRuntime,
 }
 

--- a/node/cli/src/para/command.rs
+++ b/node/cli/src/para/command.rs
@@ -308,48 +308,7 @@ pub fn run() -> Result<()> {
 				_ => Err("Benchmarking sub-command unsupported".into()),
 			}
 		},
-		#[cfg(feature = "try-runtime")]
-		Some(Subcommand::TryRuntime(cmd)) => {
-			use sc_executor::{sp_wasm_interface::ExtendedHostFunctions, NativeExecutionDispatch};
-			use try_runtime_cli::block_building_info::timestamp_with_aura_info;
-
-			let runner = cli.create_runner(cmd)?;
-			type HostFunctionsOf<E> = ExtendedHostFunctions<
-				sp_io::SubstrateHostFunctions,
-				<E as NativeExecutionDispatch>::ExtendHostFunctions,
-			>;
-
-			// grab the task manager.
-			let registry = &runner.config().prometheus_config.as_ref().map(|cfg| &cfg.registry);
-			let task_manager =
-				sc_service::TaskManager::new(runner.config().tokio_handle.clone(), *registry)
-					.map_err(|e| format!("Error: {:?}", e))?;
-
-			#[cfg(feature = "ajuna")]
-			if cfg!(feature = "ajuna") {
-				return runner.async_run(|_| {
-					Ok((
-						cmd.run::<AjunaBlock, HostFunctionsOf<AjunaRuntimeExecutor>, _>(Some(
-							timestamp_with_aura_info::<AjunaBlock>(6000),
-						)),
-						task_manager,
-					))
-				})
-			}
-			#[cfg(feature = "bajun")]
-			runner.async_run(|_| {
-				Ok((
-					cmd.run::<BajunBlock, HostFunctionsOf<BajunRuntimeExecutor>, _>(Some(
-						timestamp_with_aura_info::<BajunBlock>(6000),
-					)),
-					task_manager,
-				))
-			})
-		},
-		#[cfg(not(feature = "try-runtime"))]
-		Some(Subcommand::TryRuntime) => Err("Try-runtime was not enabled when building the node. \
-			You can enable it with `--features try-runtime`."
-			.into()),
+		Some(Subcommand::TryRuntime) => Err("The `try-runtime` subcommand has been migrated to a standalone CLI (https://github.com/paritytech/try-runtime-cli). It is no longer being maintained here and will be removed entirely some time after January 2024. Please remove this subcommand from your runtime and use the standalone CLI.".into()),
 		None => {
 			let runner = cli.create_runner(&cli.run.normalize())?;
 			let collator_options = cli.run.collator_options();

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -118,7 +118,6 @@ runtime-benchmarks = [
 ]
 
 try-runtime = [
-    "ajuna-solo-runtime?/try-runtime",
     "bajun-runtime?/try-runtime",
 	"polkadot-service?/try-runtime",
     "sp-runtime/try-runtime"

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -112,11 +112,14 @@ polkadot-native = [ "polkadot-service/polkadot-native" ]
 rococo-native   = [ "polkadot-service/rococo-native" ]
 
 runtime-benchmarks = [
-    "ajuna-solo-runtime/runtime-benchmarks",
-    "bajun-runtime/runtime-benchmarks",
-    "ajuna-runtime/runtime-benchmarks",
+    "ajuna-solo-runtime?/runtime-benchmarks",
+    "bajun-runtime?/runtime-benchmarks",
+    "ajuna-runtime?/runtime-benchmarks",
 ]
 
 try-runtime = [
-    "bajun-runtime/try-runtime",
+    "ajuna-solo-runtime?/try-runtime",
+    "bajun-runtime?/try-runtime",
+	"polkadot-service?/try-runtime",
+    "sp-runtime/try-runtime"
 ]

--- a/runtime/ajuna/src/lib.rs
+++ b/runtime/ajuna/src/lib.rs
@@ -114,7 +114,10 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	Migrations,
 >;
+
+type Migrations = (pallet_xcm::migration::v1::MigrateToV1<Runtime>,);
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
 /// node's balance type.

--- a/runtime/solo/Cargo.toml
+++ b/runtime/solo/Cargo.toml
@@ -135,27 +135,3 @@ std = [
     "pallet-ajuna-nft-staking/std",
     "pallet-ajuna-nft-transfer/std",
 ]
-
-try-runtime = [
-    "frame-executive/try-runtime",
-    "frame-system/try-runtime",
-    "orml-vesting/try-runtime",
-    "pallet-aura/try-runtime",
-    "pallet-balances/try-runtime",
-    "pallet-collective/try-runtime",
-    "pallet-identity/try-runtime",
-    "pallet-membership/try-runtime",
-    "pallet-multisig/try-runtime",
-    "pallet-nfts/try-runtime",
-    "pallet-preimage/try-runtime",
-    "pallet-proxy/try-runtime",
-    "pallet-insecure-randomness-collective-flip/try-runtime",
-    "pallet-scheduler/try-runtime",
-    "pallet-sudo/try-runtime",
-    "pallet-timestamp/try-runtime",
-    "pallet-transaction-payment/try-runtime",
-    "pallet-treasury/try-runtime",
-    "pallet-utility/try-runtime",
-    "pallet-ajuna-awesome-avatars/try-runtime",
-    "pallet-ajuna-nft-transfer/try-runtime",
-]

--- a/runtime/solo/Cargo.toml
+++ b/runtime/solo/Cargo.toml
@@ -135,3 +135,29 @@ std = [
     "pallet-ajuna-nft-staking/std",
     "pallet-ajuna-nft-transfer/std",
 ]
+
+try-runtime = [
+    "frame-executive/try-runtime",
+    "frame-system/try-runtime",
+    "orml-vesting/try-runtime",
+    "pallet-aura/try-runtime",
+    "pallet-balances/try-runtime",
+    "pallet-collective/try-runtime",
+    "pallet-identity/try-runtime",
+    "pallet-membership/try-runtime",
+    "pallet-multisig/try-runtime",
+    "pallet-nfts/try-runtime",
+    "pallet-preimage/try-runtime",
+    "pallet-proxy/try-runtime",
+    "pallet-insecure-randomness-collective-flip/try-runtime",
+    "pallet-scheduler/try-runtime",
+    "pallet-sudo/try-runtime",
+    "pallet-timestamp/try-runtime",
+    "pallet-transaction-payment/try-runtime",
+    "pallet-treasury/try-runtime",
+    "pallet-utility/try-runtime",
+    "pallet-ajuna-awesome-avatars/try-runtime",
+    "pallet-ajuna-nft-transfer/try-runtime",
+]
+
+experimental = [ "pallet-aura/experimental" ]

--- a/runtime/solo/Cargo.toml
+++ b/runtime/solo/Cargo.toml
@@ -159,5 +159,3 @@ try-runtime = [
     "pallet-ajuna-awesome-avatars/try-runtime",
     "pallet-ajuna-nft-transfer/try-runtime",
 ]
-
-experimental = [ "pallet-aura/experimental" ]


### PR DESCRIPTION
There is only one tiny migration and we therefore use almost no weight, so the migration should run through without any issues. Try-runtime output on my machine:

```console
[2024-02-12T13:05:16Z INFO  try_runtime_core::commands::on_runtime_upgrade] 🔬 TryRuntime_on_runtime_upgrade succeeded! Running it again without checks for weight measurements.


[2024-02-12T13:05:16Z INFO  try_runtime_core::commands::on_runtime_upgrade] -------------------------------------------------------------------
[2024-02-12T13:05:16Z INFO  pallet_xcm::migration::v1] v1 applied successfully
[2024-02-12T13:05:16Z INFO  runtime::frame-support] ⚠️ ParachainSystem declares internal migrations (which *might* execute). On-chain `StorageVersion(2)` vs current storage version `StorageVersion(2)`
[2024-02-12T13:05:16Z INFO  runtime::frame-support] ⚠️ XcmpQueue declares internal migrations (which *might* execute). On-chain `StorageVersion(3)` vs current storage version `StorageVersion(2)`
[2024-02-12T13:05:16Z INFO  runtime::frame-support] ⚠️ PolkadotXcm declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`
[2024-02-12T13:05:16Z INFO  runtime::frame-support] ⚠️ DmpQueue declares internal migrations (which *might* execute). On-chain `StorageVersion(2)` vs current storage version `StorageVersion(1)`
[2024-02-12T13:05:16Z INFO  try_runtime_core::commands::on_runtime_upgrade] ℹ Skipping idempotency check
[2024-02-12T13:05:16Z INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 1.0 KB. For parachains, it's your responsibility to verify that a PoV of this size fits within any relaychain constraints.
[2024-02-12T13:05:16Z INFO  try-runtime::cli] Consumed ref_time: 0.000325s (0.06% of max 0.5s)
[2024-02-12T13:05:16Z INFO  try-runtime::cli] ✅ No weight safety issues detected. Please note this does not guarantee a successful runtime upgrade. Always test your runtime upgrade with recent state, and ensure that the weight usage of your migrations will not drastically differ between testing and actual on-chain execution.

```